### PR TITLE
Feature/caenintenable

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -19,8 +19,6 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   boardId(0),
   recordLength(0),
   postPercent(0),
-  maxEventsPerTransfer(0),
-  eventsPerInterrupt(0),
   irqWaitTime(0),
   allowTriggerOverlap(true),
   usePedestals(0),
@@ -29,7 +27,6 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   ioLevel(0),
   nChannels(0),
   triggerPolarity(0),
-  interruptLevel(0),
   extTrgMode(0),
   swTrgMode(0),
   acqMode(0),
@@ -45,7 +42,6 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   enableReadout        = ps.get<int>("enableReadout");
   boardId              = ps.get<int>("boardId");
   recordLength         = ps.get<int>("recordLength");
-  maxEventsPerTransfer = ps.get<int>("maxEventsPerTransfer");
   runSyncMode          = ps.get<int>("runSyncMode");
   outputSignalMode     = ps.get<int>("outputSignalMode");
   allowTriggerOverlap  = ps.get<bool>("allowTriggerOverlap");
@@ -61,14 +57,12 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   triggerPulseWidth    = ps.get<uint8_t>("triggerPulseWidth");
   debugLevel           = ps.get<int>("debugLevel");
   postPercent          = ps.get<int>("postPercent");
-  eventsPerInterrupt   = ps.get<int>("eventsPerInterrupt");
   irqWaitTime          = ps.get<int>("irqWaitTime");
   eventCounterWarning  = ps.get<int>("eventCounterWarning");
   memoryAlmostFull     = ps.get<int>("memoryAlmostFull");
   readoutMode          = ps.get<int>("readoutMode");
   analogMode           = ps.get<int>("analogMode");
   testPattern          = ps.get<int>("testPattern");
-  interruptLevel       = ps.get<int>("InterruptLevel");
 
   char tag[1024];
   channelEnableMask = 0;
@@ -121,10 +115,8 @@ std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
   os << "  DacValue              " << e.dacValue << std::endl;
   os << "  DynamicRange          " << e.dynamicRange << std::endl;
   os << "  nChannels             " << e.nChannels << std::endl;
-  os << "  MaxEventsPerTransfer  " << e.maxEventsPerTransfer << std::endl;
   os << "  PostPercent           " << e.postPercent << "%" << std::endl;
   os << "  IrqWaitTime           " << e.irqWaitTime << std::endl;
-  os << "  EventsPerInterrupt    " << e.eventsPerInterrupt << std::endl;
   os << "  IOLevel (NIM or TTL)  " << e.ioLevel << " " 
      << sbndaq::CAENDecoder::IOLevel((CAEN_DGTZ_IOLevel_t)e.ioLevel) << std::endl;
   os << "  TriggerPolarity       " << e.triggerPolarity << " " 
@@ -144,7 +136,6 @@ std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
      << sbndaq::CAENDecoder::EnaDisMode((CAEN_DGTZ_EnaDis_t)e.readoutMode) << std::endl;
   os << "  AnalogMode            " << e.analogMode << std::endl;
   os << "  TestPattern           " << e.testPattern << std::endl;
-  os << "  InterruptLevel        " << e.interruptLevel << std::endl;
   os << "  BoardId               " << e.boardId << 
       "  EnableReadout " << e.enableReadout << std::endl;
   if ( e.enableReadout )

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
@@ -30,7 +30,6 @@ class CAENConfiguration
     int  boardId;
     int  recordLength;
     int  postPercent;
-    int  maxEventsPerTransfer;
     int  eventsPerInterrupt;
     int  irqWaitTime;
     bool allowTriggerOverlap;
@@ -42,7 +41,6 @@ class CAENConfiguration
     int  triggerPolarity;
     uint16_t triggerThresholds[MAX_CHANNELS];
     uint8_t   triggerPulseWidth;
-    int  interruptLevel;
     int  extTrgMode;
     int  swTrgMode;
     int  selfTrgMode;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -125,9 +125,7 @@ namespace sbndaq
     //fhicl parameters
     int fVerbosity;
     int fBoardChainNumber;
-    uint8_t  fInterruptLevel;
-    uint16_t fInterruptEventNumber;
-    uint32_t fInterruptStatusID;
+    uint8_t  fInterruptEnable;
     uint32_t fGetNextSleep;
     uint32_t fGetNextFragmentBunchSize;
     bool     fSWTrigger;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -99,12 +99,12 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
 
 void sbndaq::CAENV1730Readout::configureInterrupts() 
 {
-  CAEN_DGTZ_EnaDis_t  state,stateOut;
-  uint8_t             interruptLevel,interruptLevelOut;
+  CAEN_DGTZ_EnaDis_t  state __attribute((unused)),stateOut __attribute((unused));
+  uint8_t             interruptLevel __attribute((unused)),interruptLevelOut __attribute((unused));
   uint32_t            statusId __attribute__((unused)),statusIdOut __attribute__((unused));
  //uint32_t            statusIdOut;
-  uint16_t            eventNumber,eventNumberOut;
-  CAEN_DGTZ_IRQMode_t mode,modeOut;
+  uint16_t            eventNumber  __attribute__((unused)) ,eventNumberOut __attribute__((unused));
+  CAEN_DGTZ_IRQMode_t mode __attribute__((unused)),modeOut __attribute__((unused));
 
   fInterruptLevel =1; //FIXME:GAL remove this line
 
@@ -128,6 +128,7 @@ void sbndaq::CAENV1730Readout::configureInterrupts()
   CAENDecoder::checkError(retcode,"GetInterruptConfig",fBoardID);
   TLOG(TLVL_INFO) << "CAEN_DGTZ_ReadRegister reg=0xef00 value=" <<  std::bitset<32>(readback) ;
 
+  // Why is GetInterruptConfig called here?
   retcode = CAEN_DGTZ_GetInterruptConfig(fHandle, &stateOut, &interruptLevelOut, &statusIdOut, &eventNumberOut, &modeOut);
   CAENDecoder::checkError(retcode,"GetInterruptConfig",fBoardID);
 
@@ -158,7 +159,7 @@ void sbndaq::CAENV1730Readout::configureInterrupts()
                                         eventNumber,
                                         mode);
   CAENDecoder::checkError(retcode,"SetInterruptConfig",fBoardID);
-	*/
+
   retcode = CAEN_DGTZ_ReadRegister(fHandle,READOUT_CONTROL,&readback);
   CAENDecoder::checkError(retcode,"GetInterruptConfig",fBoardID);
   TLOG(TLVL_INFO) << "CAEN_DGTZ_ReadRegiste reg=READOUT_CONTROL value=" <<  std::bitset<32>(readback) ;
@@ -184,7 +185,7 @@ void sbndaq::CAENV1730Readout::configureInterrupts()
       << "Interrupt State was not setup properly, mode write/read="
       << int32_t { mode }<< "/"<<int32_t { modeOut };
   }
-
+	*/
 }
 
 void sbndaq::CAENV1730Readout::loadConfiguration(fhicl::ParameterSet const& ps)

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -864,13 +864,7 @@ bool sbndaq::CAENV1730Readout::GetData() {
 
   // read the data from the buffer of the card
   // this_data_size is the size of the acq window
-  if(fInterruptEnable > 0){
-  }
-  else {
-   return readSingleWindowDataBlock();
-  }
-
-  return true;
+  return readSingleWindowDataBlock();
 }// CAENV1730Readout::GetData()
 
 bool sbndaq::CAENV1730Readout::readSingleWindowDataBlock() {


### PR DESCRIPTION
Actually enable call to SetInterruptConfiguration; remove a few interrupt related parameters that the user must never change; leave the write to READOUT_CONTROL in place

Test at D0 run 2456

Tested at D0 run 2485, enabling readout with interruptEnable is set