### PR TITLE
fix new gcc boost warnings

### DIFF
--- a/sbndaq-artdaq/Generators/Common/GPS/GPSInfo.hh
+++ b/sbndaq-artdaq/Generators/Common/GPS/GPSInfo.hh
@@ -7,6 +7,11 @@
 #ifndef _GPSINFO_HH
 #define _GPSINFO_HH
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS 1
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
+
 #include <cstdlib>
 #include <deque>
 #include <iostream>

--- a/sbndaq-artdaq/Generators/Common/GPS/GPSReceiver.hh
+++ b/sbndaq-artdaq/Generators/Common/GPS/GPSReceiver.hh
@@ -7,6 +7,7 @@
 #ifndef _GPSRECEIVER_HH
 #define _GPSRECEIVER_HH
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS 1
 #include <cstdlib>
 #include <deque>
 #include <iostream>
@@ -18,6 +19,10 @@
 #include <sys/types.h>
 #include <sys/ipc.h>
 #include <sys/msg.h>
+
+#include <boost/bind/bind.hpp>
+
+using namespace boost::placeholders;
 
 using boost::asio::ip::tcp;
 

--- a/sbndaq-artdaq/Generators/Common/GPS/NetworkReceiver.hh
+++ b/sbndaq-artdaq/Generators/Common/GPS/NetworkReceiver.hh
@@ -7,6 +7,10 @@
 #ifndef _NETWORKRECEIVER_HH
 #define _NETWORKRECEIVER_HH
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS 1
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 #include <cstdlib>
 #include <deque>
 #include <iostream>

--- a/sbndaq-artdaq/Generators/Common/SpectraTimeReadout_generator.hh
+++ b/sbndaq-artdaq/Generators/Common/SpectraTimeReadout_generator.hh
@@ -5,6 +5,10 @@
 #ifndef sbndaq_artdaq_Generators_Common_SpectraTimeReadout_generator
 #define sbndaq_artdaq_Generators_Common_SpectraTimeReadout_generator
 
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS 1
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 #include <memory>
 #include <atomic>
 #include <future>
@@ -21,7 +25,6 @@
 #include "sbndaq-artdaq/Generators/Common/GPS/GPSInfo.hh"
 #include <unistd.h>
 #include <vector>
-
 
 namespace sbndaq
 {


### PR DESCRIPTION
Boost bind related warnings have been fixed, tested with runs 2852, 2853, 2854 at D0 on sbnd-daq22
