### PR TITLE
add a mutex around the timestamp map

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <mutex>
 
 namespace sbndaq
 {
@@ -292,6 +293,7 @@ namespace sbndaq
     std::unique_ptr<uint16_t[]> fBuffer;
 
     std::unordered_map<uint32_t,artdaq::Fragment::timestamp_t> fTimestampMap;
+    mutable std::mutex fTimestampMapMutex;
 
     //internals in getting the data
     boost::posix_time::ptime fTimePollEnd,fTimePollBegin;


### PR DESCRIPTION
running in the production area now. Tested via run 6973 in icarus.