### PR TITLE
Update CAENV1730Readout_generator.cc

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1058,7 +1058,7 @@ void sbndaq::CAENV1730Readout::ConfigureTrigger()
     if(ch%2==0)
     {
       TLOG_ARB(TCONFIG,TRACE_NAME) << "Set channels " << ch << "/" << ch+1 
-				   << " trigger pulse width to " << fCAEN.triggerPulseWidth << TLOG_ENDL;
+				   << " trigger pulse width to " << (int)(fCAEN.triggerPulseWidth) << TLOG_ENDL;
       retcode = CAEN_DGTZ_WriteRegister(fHandle,0x1070+(ch<<8),fCAEN.triggerPulseWidth);
       sbndaq::CAENDecoder::checkError(retcode,"SetChannelTriggerPulseWidth",fBoardID);
       retcode = CAEN_DGTZ_ReadRegister(fHandle,0x1070+(ch<<8),&readback);


### PR DESCRIPTION
triggerPulseWidth is uint8_t so needs to be casted to int for printing

Suggested very minor change. I have NOT tested it (and not planning to), but perhaps it could be useful for someone making more major updates in V1730 code.