### PR TITLE
Revert "Upgrade caen libs"

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -21,9 +21,9 @@ fcldir      -
 product               version      optional
 artdaq                v3_11_02
 sbndaq_artdaq_core    v1_01_00
-caencomm              v1_5_0
-caenvme               v3_3_0
-caendigitizer         v2_17_0
+caencomm              v1_2a
+caenvme               v2_50
+caendigitizer         v2_12_0
 pqxx                  v6_2_5d     s110
 pqxx                  v6_2_5e     s112
 epics                 v7_0_6_1


### PR DESCRIPTION
Reverts SBNSoftware/sbndaq-artdaq#58
Upgrade does not work properly at Icarus and further testing / investigation is needed.