### PR TITLE
Uncomment analog monitor output and change from (broken) GetAnalogMon…

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1172,11 +1172,14 @@ void sbndaq::CAENV1730Readout::ConfigureAcquisition()
   retcode = CAEN_DGTZ_GetAcquisitionMode(fHandle,(CAEN_DGTZ_AcqMode_t*)&readback);
   CheckReadback("SetAcquisitionMode",fBoardID,fCAEN.acqMode,readback);
 
-  //TLOG_ARB(TCONFIG,TRACE_NAME) << "SetAnalogMonOutputMode " << (CAEN_DGTZ_AnalogMonitorOutputMode_t)(fCAEN.analogMode) << TLOG_ENDL;
-  //retcode = CAEN_DGTZ_SetAnalogMonOutput(fHandle,(CAEN_DGTZ_AnalogMonitorOutputMode_t)(fCAEN.analogMode));
-  //sbndaq::CAENDecoder::checkError(retcode,"SetAnalogMonOutputMode",fBoardID);
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetAnalogMonOutputMode " << (CAEN_DGTZ_AnalogMonitorOutputMode_t)(fCAEN.analogMode) << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SetAnalogMonOutput(fHandle,(CAEN_DGTZ_AnalogMonitorOutputMode_t)(fCAEN.analogMode));
+  sbndaq::CAENDecoder::checkError(retcode,"SetAnalogMonOutputMode",fBoardID);
+  
+  // GetAnalogMonOutput function does not work for V1730s, use register access instead
   //retcode = CAEN_DGTZ_GetAnalogMonOutput(fHandle,(CAEN_DGTZ_AnalogMonitorOutputMode_t*)&readback);
-  //CheckReadback("SetAnalogMonOutputMode",fBoardID,fCAEN.analogMode,readback);
+  retcode = CAEN_DGTZ_ReadRegister(fHandle,CAEN_DGTZ_MON_MODE_ADD,&readback);
+  CheckReadback("SetAnalogMonOutputMode",fBoardID,fCAEN.analogMode,readback);
 
   TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureAcquisition() done." << TLOG_ENDL;
 }


### PR DESCRIPTION
…Output function to register access

### Description

Uncomment analog monitor output and change from (broken) GetAnalogMonOutput function to register access. SBND needs this output to be turned on so it can be put into the PTB.

### Related Repository Branches

List related branches from other repos here (links to PRs even better!), if not linked above.

### Testing details
- *Where it was tested*: SBN-ND
- *Run number associated with test*: 2121
- Other information: tested with CRT## running with the PTB. This code is also shared with Icarus but as far as I know has not been tested by them yet.
