### PR TITLE
fix spec tdc bug

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/fmctdc-lib/fmctdc-lib-math.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/fmctdc-lib/fmctdc-lib-math.cc
@@ -25,7 +25,7 @@ uint64_t fmctdc_ts_approx_ns(struct fmctdc_time *a) {
 
   ns += a->seconds * 1000000000;
   ns += a->coarse * 8;
-  ns += a->frac * 81.03 / 1000; /* FIXME check this because in other func is different */
+  ns += a->frac * 8 / 4096;
   return ns;
 }
 


### PR DESCRIPTION
### Fix SPECTDC Bug

Fixed how the TDCTimestamp calculate the nanosecond resolution: frac * 8 / 4096

### Testing details
- *Where it was tested*: SBN-ND
- *Run number associated with test*: from 3959 to 3968 on sbnd-evb04
- Other information: Tested cable length difference using the timestamp from the spectdc. Able to observed 4ns cable length difference using the new calculation.
