### PR TITLE
EventAna Bugfixing

### DIFF
--- a/sbndaq-artdaq/ArtModules/Common/EventAna_module.cc
+++ b/sbndaq-artdaq/ArtModules/Common/EventAna_module.cc
@@ -456,9 +456,8 @@ void sbndaq::EventAna::analyze(const art::Event& evt)
 {
   fRun = evt.run();
   fEvent = evt.event();
-  if (fverbose)   std::cout << "Run " << fRun << " event " << fEvent << std::endl;
-  std::cout << "\n" <<std::endl;
-  std::cout << "Run " << fRun << " event " << fEvent << std::endl;
+  if (fverbose)
+    std::cout << "\n\nRun " << fRun << " event " << fEvent << std::endl;
 
   /************************************************************************************************/
   // need to clear tree variables at the beginning of the event
@@ -483,7 +482,7 @@ void sbndaq::EventAna::analyze(const art::Event& evt)
   feb_hit_number.clear()          ;    timestamp.clear()               ;    last_accepted_timestamp.clear() ; 
   lost_hits.clear()               ;   run_start_time.clear();   this_poll_start.clear();   this_poll_end.clear();
   last_poll_start.clear();   last_poll_end.clear();    system_clock_deviation.clear();    feb_hits_in_poll.clear();
-  feb_hits_in_fragment.clear();
+  feb_hits_in_fragment.clear(); sequence_id.clear();
   /************************************************************************************************/
 
   // Reset PTB variables


### PR DESCRIPTION
Simple bugfix. The sequence ID vector in `EventAna_module.cc` is not being cleared between events, this is increasing runtime & file size by orders of magnitude (and is exponentially worse over long runs).

While I was at it I've hidden the only remaining print statement that wasn't already shielded by a verbose flag.