### PR TITLE
Updating data beam/trigger gate filter to handle TriggerV3 fragments 

### DIFF
--- a/sbndaq-artdaq/ArtModules/ICARUS/ICARUSGateFilter_module.cc
+++ b/sbndaq-artdaq/ArtModules/ICARUS/ICARUSGateFilter_module.cc
@@ -112,7 +112,7 @@ bool icarus::ICARUSGateFilter::filter(art::Event & evt)
   }
   
   else if(!raw_data.isValid()) {
-    TLOG(TLVL_WARN) << "Run " << evt.run() << ", subrun " << evt.subRun() << ", event " << eventNumber << " has zero ICARUSTriggerV3 Fragments in module, checking for ICARUSTriggerV2 fragments ";
+    TLOG(TLVL_DEBUG) << "Run " << evt.run() << ", subrun " << evt.subRun() << ", event " << eventNumber << " has zero ICARUSTriggerV3 Fragments in module, checking for ICARUSTriggerV2 fragments!";
   }
     
   evt.getByLabel(raw_data_label_, "ICARUSTriggerV2", raw_data);
@@ -126,7 +126,7 @@ bool icarus::ICARUSGateFilter::filter(art::Event & evt)
   }
 
   else if(!raw_data.isValid()) {
-    TLOG(TLVL_WARN) << "Run " << evt.run() << ", subrun " << evt.subRun() << ", event " << eventNumber << " has zero ICARUSTriggerV2 Fragments in module ";
+    TLOG(TLVL_WARN) << "Run " << evt.run() << ", subrun " << evt.subRun() << ", event " << eventNumber << " has zero ICARUSTriggerV2 or ICARUSTriggerV3 Fragments in module, not separating by beam type!";
   }
 
   


### PR DESCRIPTION
### Description

Updates to data stream filtering in order to filter events per beam/trigger type into the correct files with the updated trigger fragment. This preserves backwards compatibility by introducing a template class to take in the two different trigger fragment types V2 and V3 with the default being V3 and a warning is thrown if it cannot find either fragment type in the event. A debug message is there saying it is trying to find V2 if it cannot find V3. Apologies for the very short notice, but my understanding is this should go in for Run2, which I just found out at a different meeting very recently starts this weekend so we can use the updated trigger fragment definition. 

### Related Repository Branches

None

### Testing details
Tested with full ICARUS data, Run9151 and filtering appears successful with what I understand was operational at the time.
