### PR TITLE
Fix SequenceIDs warning when counter naturally overflows

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -33,7 +33,6 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   debugLevel(0),
   runSyncMode(0),
   outputSignalMode(0),
-  eventCounterWarning(0),
   memoryAlmostFull(0),
   analogMode(0),
   testPattern(0),
@@ -62,7 +61,6 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   debugLevel           = ps.get<int>("debugLevel");
   postPercent          = ps.get<int>("postPercent");
   irqWaitTime          = ps.get<int>("irqWaitTime");
-  eventCounterWarning  = ps.get<int>("eventCounterWarning");
   memoryAlmostFull     = ps.get<int>("memoryAlmostFull");
   readoutMode          = ps.get<int>("readoutMode");
   analogMode           = ps.get<int>("analogMode");
@@ -139,7 +137,6 @@ std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
   os << "  AcqMode               " << e.acqMode << " " 
      << sbndaq::CAENDecoder::AcquisitionMode((CAEN_DGTZ_AcqMode_t)e.acqMode) << std::endl;
   os << "  DebugLevel            " << e.debugLevel << std::endl;
-  os << "  EventCounterWarning   " << e.eventCounterWarning << std::endl;
   os << "  MemoryAlmostFull      " << e.memoryAlmostFull << std::endl;
   os << "  ReadoutMode           " << e.readoutMode << " " 
      << sbndaq::CAENDecoder::EnaDisMode((CAEN_DGTZ_EnaDis_t)e.readoutMode) << std::endl;

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
@@ -48,7 +48,6 @@ class CAENConfiguration
     int  debugLevel;
     int  runSyncMode;
     int  outputSignalMode;
-    int  eventCounterWarning;
     int  memoryAlmostFull;
     int  readoutMode;
     int  analogMode;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -238,8 +238,9 @@ namespace sbndaq
     bool     fOK;
     bool     fail_GetNext;
     uint32_t fEvCounter; // set to zero at the beginning
+    uint32_t fOverflowCounter; //count overflows of fEvCounter
     uint32_t last_rcvd_rwcounter;
-    uint32_t last_sent_rwcounter;
+    uint32_t last_sent_seqid;
     const uint32_t max_rwcounter = 0xFFFFFF; //24-bit
     uint32_t last_sent_ts;
     uint32_t total_data_size;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -240,6 +240,7 @@ namespace sbndaq
     uint32_t fEvCounter; // set to zero at the beginning
     uint32_t last_rcvd_rwcounter;
     uint32_t last_sent_rwcounter;
+    const uint32_t max_rwcounter = 0xFFFFFF; //24-bit
     uint32_t last_sent_ts;
     uint32_t total_data_size;
     //uint32_t event_size;	

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1739,7 +1739,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 
     if( readoutwindow_event_counter < last_sent_rwcounter && last_sent_rwcounter < max_rwcounter )
       {
-	TLOG(TLVL_ERROR) << "SequnceIDs processed out of order!! "
+	TLOG(TLVL_ERROR) << "SequenceIDs processed out of order!! "
 			 << readoutwindow_event_counter << " < " << last_sent_rwcounter << TLOG_ENDL;
       }
     if( last_sent_ts > ts_frag)

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1540,7 +1540,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 
     //check trigger counter gaps
     auto readoutwindow_trigger_counter_gap= uint32_t{header->eventCounter} - last_rcvd_rwcounter;
-    if( readoutwindow_trigger_counter_gap > 1u ){
+    if( readoutwindow_trigger_counter_gap > 1u && last_rcvd_rwcounter < max_rwcounter ){
       TLOG (TLVL_DEBUG) << "(FragID=" << fFragmentID << ")"
 			<< "Missing triggers; previous trigger sequenceID / gap  = " << last_rcvd_rwcounter << " / "
 			<< readoutwindow_trigger_counter_gap <<", freeBlockCount=" <<fPoolBuffer.freeBlockCount() 
@@ -1729,7 +1729,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 
     
     if( readoutwindow_event_counter_gap > 1u ){
-      if ( last_sent_rwcounter > 0 )
+      if ( last_sent_rwcounter > 0 && last_sent_rwcounter < max_rwcounter )
       {
 	TLOG (TLVL_DEBUG) << "Missing data; previous fragment sequenceID / gap  = " << last_sent_rwcounter << " / "
                         << readoutwindow_event_counter_gap;
@@ -1737,7 +1737,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
       }
     }
 
-    if( readoutwindow_event_counter < last_sent_rwcounter )
+    if( readoutwindow_event_counter < last_sent_rwcounter && last_sent_rwcounter < max_rwcounter )
       {
 	TLOG(TLVL_ERROR) << "SequnceIDs processed out of order!! "
 			 << readoutwindow_event_counter << " < " << last_sent_rwcounter << TLOG_ENDL;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -611,19 +611,6 @@ void sbndaq::CAENV1730Readout::Write_ADC_CalParams_V1730(int handle, int ch, uin
 
 // Animesh add ends
 
-// GVS: commented old ConfigureSelfTriggerMode()
-/* void sbndaq::CAENV1730Readout::ConfigureSelfTriggerMode()
-{
-  CAEN_DGTZ_ErrorCode retcod = CAEN_DGTZ_Success;
-  uint32_t data,readBack;
-
-  retcod = CAEN_DGTZ_SetChannelSelfTrigger(fHandle,
-					   (CAEN_DGTZ_TriggerMode_t)fSelfTriggerMode,
-					   fSelfTriggerMask);
-  sbndaq::CAENDecoder::checkError(retcod,"SetSelfTriggerMask",fBoardID);
-}
-*/
-
 // GVS: new ConfigureSelfTriggerMode() function
  void sbndaq::CAENV1730Readout::ConfigureSelfTriggerMode()
 {
@@ -1032,20 +1019,8 @@ void sbndaq::CAENV1730Readout::ConfigureTrigger()
   }
 
   // for ICARUS
-  if(fModeLVDS!=0){
-/*
-    TLOG_ARB(TCONFIG,TRACE_NAME) << "Set global trigger pulse width to " << fCAEN.triggerPulseWidth << TLOG_ENDL;
-    retcode = CAEN_DGTZ_WriteRegister(fHandle,TRG_OUT_WIDTH,fCAEN.triggerPulseWidth);
-    sbndaq::CAENDecoder::checkError(retcode,"SetGlobalTriggerPulseWidth",fBoardID);
-    // Readback must be channel by channel (see reg doc)
-    for ( uint32_t ch=0; ch<CAENConfiguration::MAX_CHANNELS; ch++)
-      {
-	uint32_t address = TRG_OUT_WIDTH_CH | ( ch << 8 );  
-	retcode = CAEN_DGTZ_ReadRegister(fHandle,address,&readback);
-	CheckReadback("SetGlobalTriggerPulseWidth",fBoardID,fCAEN.triggerPulseWidth,readback);
-      }*/    
-    ConfigureLVDS();
-  }
+  if(fModeLVDS!=0){ ConfigureLVDS();  }
+
   ConfigureSelfTriggerMode();
 
   TLOG_ARB(TCONFIG,TRACE_NAME) << "SetTriggerMode" << fCAEN.extTrgMode << TLOG_ENDL;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -37,7 +37,7 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   loadConfiguration(ps);
   
   last_rcvd_rwcounter=0x0;
-  last_sent_rwcounter=0x1;
+  last_sent_seqid=0x1;
   last_sent_ts=0;
   CAEN_DGTZ_ErrorCode retcode;
 
@@ -1158,7 +1158,7 @@ void sbndaq::CAENV1730Readout::start()
   
   ConfigureDataBuffer();
   total_data_size = 0;
-  last_sent_rwcounter = 0;
+  last_sent_seqid = 0;
   
   if((CAEN_DGTZ_AcqMode_t)(fCAEN.acqMode)==CAEN_DGTZ_AcqMode_t::CAEN_DGTZ_SW_CONTROLLED)
     {
@@ -1169,6 +1169,7 @@ void sbndaq::CAENV1730Readout::start()
     }
   
   fEvCounter=0;
+  fOverflowCounter=0;
   CAEN_DGTZ_ErrorCode retcod;
 
   // Animesh add ADC registers here
@@ -1418,7 +1419,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     auto block =  fPoolBuffer.takeFreeBlock();
     if(!block) {
       TLOG(TLVL_ERROR) << "(FragID=" << fFragmentID << ")"
-		       << "PoolBuffer is empty; last received trigger sequenceID=" <<last_rcvd_rwcounter;
+		       << "PoolBuffer is empty; last received trigger eventCounter=" <<last_rcvd_rwcounter;
       TLOG(TLVL_ERROR) << "(FragID=" << fFragmentID << ")"
 		       << "PoolBuffer status: freeBlockCount=" << fPoolBuffer.freeBlockCount()
                        << "(FragID=" << fFragmentID << ")"
@@ -1538,11 +1539,12 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 		   << ": Timestamp for event " << header->eventCounter << " = " << fTS;
 
 
-    //check trigger counter gaps
+    //check trigger event counter gaps: this is a 24-bit counter in the CAEN board
+    //if the run is long, it can overflow --> do not throw errors in that case
     auto readoutwindow_trigger_counter_gap= uint32_t{header->eventCounter} - last_rcvd_rwcounter;
     if( readoutwindow_trigger_counter_gap > 1u && last_rcvd_rwcounter < max_rwcounter ){
       TLOG (TLVL_DEBUG) << "(FragID=" << fFragmentID << ")"
-			<< "Missing triggers; previous trigger sequenceID / gap  = " << last_rcvd_rwcounter << " / "
+			<< "Missing triggers; previous trigger eventCounter / gap  = " << last_rcvd_rwcounter << " / "
 			<< readoutwindow_trigger_counter_gap <<", freeBlockCount=" <<fPoolBuffer.freeBlockCount() 
 			<< ", activeBlockCount=" <<fPoolBuffer.activeBlockCount() << ", fullyDrainedCount=" << fPoolBuffer.fullyDrainedCount();
     }    
@@ -1578,17 +1580,17 @@ bool sbndaq::CAENV1730Readout::getNext_(artdaq::FragmentPtrs & fragments){
 bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & fragments){
   TLOG(TGETNEXT) << "Begin of readSingleWindowFragments()" ;
 
-	static auto start= std::chrono::steady_clock::now();
+  static auto start= std::chrono::steady_clock::now();
 
- 	std::chrono::duration<double> delta = std::chrono::steady_clock::now()-start;
+  std::chrono::duration<double> delta = std::chrono::steady_clock::now()-start;
 
   if (delta.count() >0.005*fGetNextFragmentBunchSize) {
      metricMan->sendMetric("Laggy getNext",1,"count",1,artdaq::MetricMode::Accumulate);
-     TLOG (TLVL_DEBUG) << "Time spent outside of getNext_() " << delta.count()*1000 << " ms. Last seen fragment sequenceID=" << last_sent_rwcounter;
+     TLOG (TLVL_DEBUG) << "Time spent outside of getNext_() " << delta.count()*1000 << " ms. Last seen fragment sequenceID=" << last_sent_seqid;
    }
 
   if(fPoolBuffer.activeBlockCount() == 0){
-    TLOG(TGETNEXT) << "PoolBuffer has no data.  Laast last seen fragment sequenceID=" <<last_sent_rwcounter
+    TLOG(TGETNEXT) << "PoolBuffer has no data.  Laast last seen fragment sequenceID=" << last_sent_seqid
                    << "; Sleep for " << fGetNextSleep << " us and return.";
     ::usleep(fGetNextSleep);
     start= std::chrono::steady_clock::now();
@@ -1610,19 +1612,22 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
   while(fPoolBuffer.activeBlockCount()){
 
     start= std::chrono::steady_clock::now();
-//    TLOG(21) << "b4 FragmentBytes";
     auto fragment_uptr=artdaq::Fragment::FragmentBytes(fragment_datasize_bytes,fEvCounter,fFragmentID,sbndaq::detail::FragmentType::CAENV1730,metadata);
 
 
     using sbndaq::PoolBuffer;
     PoolBuffer::DataRange<decltype(artdaq::Fragment())> range{fragment_uptr->dataBegin(),fragment_uptr->dataEnd()};
 
-//	TLOG(21) << "b4 fPoolBuffer.read(range)";
     if(!fPoolBuffer.read(range)) break;
 
     const auto header = reinterpret_cast<CAENV1730EventHeader const *>(fragment_uptr->dataBeginBytes());
+   
+    // get eventCounter, which is the key to get the correct timestamp from the map
+    // for longer runs it can overflow (24 bit) --> play safe and don't use it as sequence id
+    // build sequence id keeping track of overflows (avoids repeated seqIDs in the same run)
     const auto readoutwindow_event_counter = uint32_t {header->eventCounter};
-    fragment_uptr->setSequenceID(readoutwindow_event_counter);
+    uint64_t readoutwindow_sequence_id = uint64_t{readoutwindow_event_counter + fOverflowCounter*(max_rwcounter+1u)};
+    fragment_uptr->setSequenceID(readoutwindow_sequence_id);
 
     size_t ts_count;
     {
@@ -1632,7 +1637,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
     int ts_loop=0;
 
     while(ts_loop<3 && ts_count==0){
-      TLOG(TLVL_WARNING) << " TIMESTAMP FOR SEQID " << readoutwindow_event_counter << " not found in fTimestampMap!"
+      TLOG(TLVL_WARNING) << " TIMESTAMP FOR SEQID " << readoutwindow_sequence_id << " EVCOUNTER " << readoutwindow_event_counter << " not found in fTimestampMap!"
 			 << " Will sleep for 200 ms and try again. Times tried = " << ts_loop;
       ::usleep(200000);
       ts_loop++;
@@ -1667,7 +1672,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
       fTimestampMap.erase(readoutwindow_event_counter);
     }
     else{
-      TLOG(TLVL_ERROR) << " TIMESTAMP FOR SEQID " << readoutwindow_event_counter << " not found in fTimestampMap!"
+      TLOG(TLVL_ERROR) << " TIMESTAMP FOR SEQID " << readoutwindow_sequence_id << " EVCOUNTER " << readoutwindow_event_counter << " not found in fTimestampMap!"
 		       << " Will generate new one now...";
 
       if(fUseTimeTagForTimeStamp){
@@ -1722,25 +1727,26 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 
     fragment_uptr->setTimestamp( ts_frag );
 
-    auto readoutwindow_event_counter_gap= readoutwindow_event_counter - last_sent_rwcounter;
+    // check for possible gaps in the sequence IDs: compare current one with last sent
+    // throw errors if gap > 1 or order is not correct
+    auto readoutwindow_sequence_id_gap= readoutwindow_sequence_id - last_sent_seqid;
 
-    TLOG(TMAKEFRAG)<<"Created fragment " << fFragmentID << " for event " << readoutwindow_event_counter
+    TLOG(TMAKEFRAG)<<"Created fragment " << fFragmentID << " sequenceID " << readoutwindow_sequence_id << " for event " << readoutwindow_event_counter
                    << " triggerTimeTag " << header->triggerTimeTag << " ts=" << ts_frag;
-
     
-    if( readoutwindow_event_counter_gap > 1u ){
-      if ( last_sent_rwcounter > 0 && last_sent_rwcounter < max_rwcounter )
+    if( readoutwindow_sequence_id_gap > 1u ){
+      if ( last_sent_seqid > 0 )
       {
-	TLOG (TLVL_DEBUG) << "Missing data; previous fragment sequenceID / gap  = " << last_sent_rwcounter << " / "
-                        << readoutwindow_event_counter_gap;
-	metricMan->sendMetric("Missing Fragments", uint64_t{readoutwindow_event_counter_gap}, "frags", 1, artdaq::MetricMode::Accumulate);
+	TLOG (TLVL_DEBUG) << "Missing data; previous fragment sequenceID / gap  = " << last_sent_seqid << " / "
+                        << readoutwindow_sequence_id_gap;
+	metricMan->sendMetric("Missing Fragments", uint64_t{readoutwindow_sequence_id_gap}, "frags", 1, artdaq::MetricMode::Accumulate);
       }
     }
 
-    if( readoutwindow_event_counter < last_sent_rwcounter && last_sent_rwcounter < max_rwcounter )
+    if( readoutwindow_sequence_id < last_sent_seqid )
       {
 	TLOG(TLVL_ERROR) << "SequenceIDs processed out of order!! "
-			 << readoutwindow_event_counter << " < " << last_sent_rwcounter << TLOG_ENDL;
+			 << readoutwindow_sequence_id << " < " << last_sent_seqid << TLOG_ENDL;
       }
     if( last_sent_ts > ts_frag)
       {
@@ -1750,9 +1756,13 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 
     fragments.emplace_back(nullptr);
     std::swap(fragments.back(),fragment_uptr);
-    
+   
+    // keep track of CAEN event counter overflows
+    // this is important to avoid repeating sequenceIDs
+    if( readoutwindow_event_counter == max_rwcounter ) fOverflowCounter++;
     fEvCounter++;
-    last_sent_rwcounter = readoutwindow_event_counter;
+
+    last_sent_seqid = readoutwindow_sequence_id;
     last_sent_ts = ts_frag;
     delta = std::chrono::steady_clock::now()-start;
 
@@ -1761,7 +1771,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 
     if (delta.count() >0.0005 ) {
       metricMan->sendMetric("Laggy Fragments",1,"frags",1,artdaq::MetricMode::Maximum);
-      TLOG (TLVL_DEBUG+1) << "Creating a fragment with setSequenceID=" << last_sent_rwcounter <<  " took " << delta.count()*1000 << " ms";
+      TLOG (TLVL_DEBUG+1) << "Creating a fragment with setSequenceID=" << last_sent_seqid <<  " took " << delta.count()*1000 << " ms";
 //TRACE_CNTL("modeM", 0);
     }
   }


### PR DESCRIPTION
### Description

This PR fixes the appearance of the following errors when the `eventCounter` of the CAEN board naturally overflows. This happens simultaneously for all East/West boards roughly every 40 hours (given our rate of trigger primitives). Example of the errors:

```
%MSG-d CAENV1730Readout:  InRunMap::Running 03-Apr-2023 11:46:55 CDT  Sequence ID 110458 CAENV1730Readout_generator.cc:1707
(FragID=8192)Missing triggers; previous trigger sequenceID / gap  = 16777215 / 4278190081, freeBlockCount=3080, activeBlockCount=0, fullyDrainedCount=0
%MSG
%MSG-d CAENV1730Readout:  InRunMap::Running 03-Apr-2023 11:46:55 CDT  Sequence ID 110458 CAENV1730Readout_generator.cc:2065
Missing data; previous fragment sequenceID / gap  = 16777215 / 4278190081
%MSG
%MSG-e CAENV1730Readout:  InRunMap::Running 03-Apr-2023 11:46:55 CDT  Sequence ID 110458 CAENV1730Readout_generator.cc:2073
SequnceIDs processed out of order!! 0 < 16777215
%MSG
```

- `eventCounter` is an unsigned 24-bit integer, so its max value is `16777215`. Then it goes back to `0` and an error (`SequnceIDs processed out of order!! 0 < 16777215`) is sent out. Despite being harmless because data and timestamps are correct, this has recently caused confusion and led to a precautionary run stop (run 9725) for fear of bad data being taken.
I think what I added should avoid this happening, but it may not be a very elegant solution... so suggestions are welcome!

- In addition, `auto readoutwindow_event_counter_gap= readoutwindow_event_counter - last_sent_rwcounter` [here](https://github.com/SBNSoftware/sbndaq-artdaq/blob/9cfde9f1b6534704d3e0b0bf8aa3ee4433615032/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc#L1760) should also be a 24-bit unsigned int, but in the trace printout we get  `4278190081` so something is being treated as a uint_32: any suggestions on how to sanitize this?

Asking reviews (and ideas for the second issue) to PMT-related people: @wesketchum @gvittis @PetrilloAtWork 

### Testing details
- Still needs testing: however, given the current rate of trigger primitives, it requires >40 hours of consecutive data taking so I'm not sure how we can plan such a test.

### UPDATE:
- It was suggested to further sanitize the situation in order to avoid the same sequence ID to be used by multiple fragments in the same run. This was happening because the `readoutwindow_event_counter` was directly used as sequence ID of the corresponding fragment.
- Additional details on how this PR tries to overcome this are given [HERE](https://github.com/SBNSoftware/sbndaq-artdaq/pull/98#issuecomment-1513776317)