### PR TITLE
Add error message for CAENV1730 temperature >65 deg Celsius

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -43,7 +43,7 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
 {
   link                 = ps.get<int>("link");
   enableReadout        = ps.get<int>("enableReadout");
-  boardId              = ps.get<int>("boardId");
+  boardId              = ps.get<int>("board_id");
   recordLength         = ps.get<int>("recordLength");
   runSyncMode          = ps.get<int>("runSyncMode");
   outputSignalMode     = ps.get<int>("outputSignalMode");

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1281,6 +1281,8 @@ void sbndaq::CAENV1730Readout::stop()
   TLOG_ARB(TSTOP,TRACE_NAME) << "stop() done." << TLOG_ENDL;
 }
 
+// This function is called internally by the art framework and should not be called in the boardreader itself
+// The two relevant fcl parameters are: "poll_hardware_status" (true/false) and "hardware_poll_interval_us" (period in us)
 bool sbndaq::CAENV1730Readout::checkHWStatus_(){
 
   for(size_t ch=0; ch<CAENConfiguration::MAX_CHANNELS; ++ch){
@@ -1304,6 +1306,11 @@ bool sbndaq::CAENV1730Readout::checkHWStatus_(){
     metricMan->sendMetric(tempStream.str(), int(ch_temps[ch]), "C", 1,
 			  artdaq::MetricMode::Average);
 
+    if( ch_temps[ch] > 65 ){ // digitizers shut down at 70 celsius
+      TLOG(TLVL_ERROR) << "CAENV1730 BoardID " << fBoardID << " : "
+                       << "Temperature above 65 degrees Celsius for channel " << ch
+		       << TLOG_ENDL;
+    }
 
     ReadChannelBusyStatus(fHandle,ch,ch_status[ch]);
     TLOG_ARB(TTEMP,TRACE_NAME) << statStream.str()


### PR DESCRIPTION
### Description
Two items:

- This PR adds an error message to be printed in the log file if any channel of CAENV1730 goes over 65 degrees Celsius. These temperatures are usually monitored via Grafana. However, if the board reaches 70 degrees Celsius, it shuts its ADCs off and the temperature drops back again thus clearing the error in Grafana. Adding this error message in the log makes identifying these temperature problems easier.

- This PR fixes the definition of the PMT board ID currently used in the board reader for log messages and Grafana metric streams. The board reader now uses the `board_id` parameter, which is already [used internally by artdaq](https://github.com/art-daq/artdaq/blob/263fc0a133e64023bf830aa951f961359eb814a4/artdaq/Generators/CommandableFragmentGenerator.hh#L101-L102), instead of `boardId`. The latter can therefore be removed in the fcl files.

### Testing details
- May not require ad-hoc testing given the nature of the changes (`board_id` is already in use, therefore correcly read)
