### PR TITLE
Sending stop command to LabVIEW application

### DIFF
--- a/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV3.hh
+++ b/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV3.hh
@@ -62,6 +62,7 @@ namespace sbndaq
     void configure_socket(int, struct sockaddr_in&);
     
     //int send_TTLK_INIT(int, int);
+    int send_stop(int, int);
     int initialization(int, int);
     void send_TRIG_VETO();
     void send_TRIG_ALLW();

--- a/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV3_generator.cc
+++ b/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV3_generator.cc
@@ -809,7 +809,6 @@ int sbndaq::ICARUSTriggerV3::initialization(int retries, int sleep_time_ms)
 
 int sbndaq::ICARUSTriggerV3::send_stop(int retries, int sleep_time_ms)
 {   
-   // while(retries>-1){
     char cmd[7];
     sprintf(cmd,"%s","STOP  ");
     
@@ -820,22 +819,10 @@ int sbndaq::ICARUSTriggerV3::send_stop(int retries, int sleep_time_ms)
     TLOG(TLVL_INFO) << "sent:: COMMAND " << cmd << "  to " << ip_config_.c_str() << ":" << configport_ << "\n";
     //int size_bytes = poll_with_timeout(configsocket_,ip_config_, si_config_, sleep_time_ms);
     //
-    int doThis = 0;
-    if (doThis == 1) {
-    int size_bytes = poll_with_timeout(datafd_,ip_config_, si_config_, sleep_time_ms);
-    if(size_bytes>0){
-      buffer[size_bytes+1] = {'\0'};
-      readTCP(datafd_,ip_config_,si_config_,size_bytes,buffer);
-      TLOG(TLVL_INFO) << "STOP  step - received:: " << buffer;
-      return 0;
-    }
-    }
-    
+
     retries--;
-   //}
  
-  //return -1;
-  return 0;
+     return 0;
  
 }
 

--- a/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV3_generator.cc
+++ b/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV3_generator.cc
@@ -99,6 +99,7 @@ sbndaq::ICARUSTriggerV3::ICARUSTriggerV3(fhicl::ParameterSet const& ps)
     {
       TLOG(TLVL_INFO) << "Moving to accept function" << "\n";
       datafd_ = accept(configsocket_, (struct sockaddr *) &si_config_, &configlen);
+      TLOG(TLVL_INFO) << "After datafd_ accept(configsocket_...." << "\n";
     }
   else
     {
@@ -654,7 +655,7 @@ void sbndaq::ICARUSTriggerV3::start()
 
   }
   //send_TRIG_ALLW();
-  close(datafd_);
+  //////////////close(datafd_); ///////////// DO NOT CLOSE this soecket ??? we'll use if for STOP command
   socklen_t datalen = sizeof((struct sockaddr_in&) si_data_);
   bind(datasocket_, (struct sockaddr *) &si_data_, datalen);                     
   if(listen(datasocket_, 1) >= 0)            
@@ -668,8 +669,21 @@ void sbndaq::ICARUSTriggerV3::start()
     abort();
   }                                                                            
 }
+
+
 void sbndaq::ICARUSTriggerV3::stop()
 {
+  if(send_stop(n_init_retries_,n_init_timeout_ms_) < 0) //comment out for fake trigger tests
+  {  
+     TLOG(TLVL_ERROR) << "Was not able to STOP LabVIEW: closing socket  " << "\n";
+     close(datafd_); ///////////// DO NOT CLOSE this soecket ??? we'll use if for STOP command
+     abort();
+  
+  }
+  else {
+     TLOG(TLVL_ERROR) << " STOPPED LabVIEW; closing socket  " << "\n";
+     close(datafd_); ///////////// DO NOT CLOSE this soecket ??? we'll use if for STOP command
+  }
   //send_TRIG_VETO();
 }
 void sbndaq::ICARUSTriggerV3::pause()
@@ -775,7 +789,7 @@ int sbndaq::ICARUSTriggerV3::initialization(int retries, int sleep_time_ms)
     //sendto(configsocket_,&cmd,16, 0, (struct sockaddr *) &si_config_, sizeof(si_config_));
     int sendcode = send(datafd_,&cmd,16, 0); //datafd
     TLOG(TLVL_INFO) << "retcode from send call is: " << sendcode;
-    TLOG(TLVL_DEBUG) << "sent!:: COMMAND " << cmd << "to " << ip_config_.c_str() << ":" << configport_ << "\n";
+    TLOG(TLVL_DEBUG) << "sent:: COMMAND " << cmd << "to " << ip_config_.c_str() << ":" << configport_ << "\n";
     //int size_bytes = poll_with_timeout(configsocket_,ip_config_, si_config_, sleep_time_ms);
     int size_bytes = poll_with_timeout(datafd_,ip_config_, si_config_, sleep_time_ms);  
     if(size_bytes>0){
@@ -791,6 +805,44 @@ int sbndaq::ICARUSTriggerV3::initialization(int retries, int sleep_time_ms)
   return -1;
   
 }
+
+
+int sbndaq::ICARUSTriggerV3::send_stop(int retries, int sleep_time_ms)
+{   
+   // while(retries>-1){
+    char cmd[7];
+    sprintf(cmd,"%s","STOP  ");
+    
+    TLOG(TLVL_INFO) << "to send:: COMMAND " << cmd << "  to " << ip_config_.c_str() << ":" << configport_ << "\n";
+    //sendto(configsocket_,&cmd,16, 0, (struct sockaddr *) &si_config_, sizeof(si_config_));
+    int sendcode = send(datafd_,&cmd,7, 0); //datafd
+    TLOG(TLVL_INFO) << "retcode from send call is: " << sendcode;
+    TLOG(TLVL_INFO) << "sent:: COMMAND " << cmd << "  to " << ip_config_.c_str() << ":" << configport_ << "\n";
+    //int size_bytes = poll_with_timeout(configsocket_,ip_config_, si_config_, sleep_time_ms);
+    //
+    int doThis = 0;
+    if (doThis == 1) {
+    int size_bytes = poll_with_timeout(datafd_,ip_config_, si_config_, sleep_time_ms);
+    if(size_bytes>0){
+      buffer[size_bytes+1] = {'\0'};
+      readTCP(datafd_,ip_config_,si_config_,size_bytes,buffer);
+      TLOG(TLVL_INFO) << "STOP  step - received:: " << buffer;
+      return 0;
+    }
+    }
+    
+    retries--;
+   //}
+ 
+  //return -1;
+  return 0;
+ 
+}
+
+
+
+
+
 
 void sbndaq::ICARUSTriggerV3::configure_socket(int socket, struct sockaddr_in& si)
 {


### PR DESCRIPTION
### Description

This code will send the stop command to the LabVIEW application via a TCP/IP socket already opened

### Testing details
_ NEEDS a new version of LabVIEW project (that listens and acts upon receiving the STOP command)
- tested at SBN-FD 
- run numbers: 9782-9786, 9788, 9798-9806

