### PR TITLE
New max temperature fhicl parameter for CAENV1730 + fhicl clean-up

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -13,7 +13,6 @@
 // Constructor
 sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   link(0),
-  firstBoardId(0),
   nBoards(0),
   enableReadout(0),
   boardId(0),
@@ -21,8 +20,6 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   postPercent(0),
   irqWaitTime(0),
   allowTriggerOverlap(true),
-  usePedestals(0),
-  dacValue(0),
   dynamicRange(0),
   ioLevel(0),
   nChannels(0),
@@ -32,8 +29,6 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   acqMode(0),
   debugLevel(0),
   runSyncMode(0),
-  outputSignalMode(0),
-  memoryAlmostFull(0),
   analogMode(0),
   testPattern(0),
   //ovthValue(0),
@@ -47,10 +42,7 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   boardId              = ps.get<int>("board_id");
   recordLength         = ps.get<int>("recordLength");
   runSyncMode          = ps.get<int>("runSyncMode");
-  outputSignalMode     = ps.get<int>("outputSignalMode");
   allowTriggerOverlap  = ps.get<bool>("allowTriggerOverlap");
-  usePedestals         = ps.get<bool>("usePedestals");
-  dacValue             = ps.get<int>("dacValue");
   dynamicRange         = ps.get<int>("dynamicRange");
   ioLevel              = ps.get<int>("ioLevel");
   nChannels            = ps.get<int>("nChannels");
@@ -62,7 +54,6 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   debugLevel           = ps.get<int>("debugLevel");
   postPercent          = ps.get<int>("postPercent");
   irqWaitTime          = ps.get<int>("irqWaitTime");
-  memoryAlmostFull     = ps.get<int>("memoryAlmostFull");
   readoutMode          = ps.get<int>("readoutMode");
   analogMode           = ps.get<int>("analogMode");
   testPattern          = ps.get<int>("testPattern");
@@ -119,8 +110,6 @@ std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
   os << "  EnableReadout         " << e.enableReadout << std::endl;
   os << "  RecordLength          " << e.recordLength << std::endl;
   os << "  AllowTriggerOverlap   " << e.allowTriggerOverlap << std::endl;
-  os << "  UsePedestals          " << e.usePedestals << std::endl;
-  os << "  DacValue              " << e.dacValue << std::endl;
   os << "  DynamicRange          " << e.dynamicRange << std::endl;
   os << "  nChannels             " << e.nChannels << std::endl;
   os << "  PostPercent           " << e.postPercent << "%" << std::endl;
@@ -139,7 +128,6 @@ std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
   os << "  AcqMode               " << e.acqMode << " " 
      << sbndaq::CAENDecoder::AcquisitionMode((CAEN_DGTZ_AcqMode_t)e.acqMode) << std::endl;
   os << "  DebugLevel            " << e.debugLevel << std::endl;
-  os << "  MemoryAlmostFull      " << e.memoryAlmostFull << std::endl;
   os << "  ReadoutMode           " << e.readoutMode << " " 
      << sbndaq::CAENDecoder::EnaDisMode((CAEN_DGTZ_EnaDis_t)e.readoutMode) << std::endl;
   os << "  AnalogMode            " << e.analogMode << std::endl;

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -39,7 +39,8 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   //ovthValue(0),
   triggerLogic(0),
   majorityLevel(0),
-  majorityCoincidenceWindow(0)
+  majorityCoincidenceWindow(0),
+  maxTemp(0)
 {
   link                 = ps.get<int>("link");
   enableReadout        = ps.get<int>("enableReadout");
@@ -69,6 +70,7 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   triggerLogic         = ps.get<int>("triggerLogic");  
   majorityLevel        = ps.get<int>("majorityLevel"); 
   majorityCoincidenceWindow = ps.get<int>("majorityCoincidenceWindow"); 
+  maxTemp              = ps.get<int>("maxTempCelsius");
 
   char tag[1024];
   channelEnableMask = 0;
@@ -146,6 +148,7 @@ std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
   os << "  TriggerLogic          " << e.triggerLogic << std::endl;
   os << "  MajorityLevel         " << e.majorityLevel << std::endl;
   os << "  MajorityCoincidenceWindow " << e.majorityCoincidenceWindow << std::endl;
+  os << "  MaxTempCelsius        " << e.maxTemp << std::endl;
   os << "  BoardId               " << e.boardId << 
       "  EnableReadout " << e.enableReadout << std::endl;
   if ( e.enableReadout )

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -61,7 +61,7 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
   triggerLogic         = ps.get<int>("triggerLogic");  
   majorityLevel        = ps.get<int>("majorityLevel"); 
   majorityCoincidenceWindow = ps.get<int>("majorityCoincidenceWindow"); 
-  maxTemp              = ps.get<int>("maxTempCelsius");
+  maxTemp              = ps.get<uint32_t>("maxTempCelsius");
 
   char tag[1024];
   channelEnableMask = 0;

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
@@ -63,6 +63,7 @@ class CAENConfiguration
     int  triggerLogic;  
     int  majorityLevel; 
     int  majorityCoincidenceWindow;
+    uint32_t  maxTemp;
 
     void print(std::ostream & os = std::cout);
 };

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
@@ -24,7 +24,6 @@ class CAENConfiguration
   CAENConfiguration(fhicl::ParameterSet const & ps);
 
     int  link;
-    int  firstBoardId;
     int  nBoards;
     int  enableReadout;
     int  boardId;
@@ -33,8 +32,6 @@ class CAENConfiguration
     int  eventsPerInterrupt;
     int  irqWaitTime;
     bool allowTriggerOverlap;
-    bool usePedestals;
-    int  dacValue;
     int  dynamicRange;
     int  ioLevel;
     int  nChannels;
@@ -47,8 +44,6 @@ class CAENConfiguration
     int  acqMode;
     int  debugLevel;
     int  runSyncMode;
-    int  outputSignalMode;
-    int  memoryAlmostFull;
     int  readoutMode;
     int  analogMode;
     int  testPattern;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1306,9 +1306,9 @@ bool sbndaq::CAENV1730Readout::checkHWStatus_(){
     metricMan->sendMetric(tempStream.str(), int(ch_temps[ch]), "C", 1,
 			  artdaq::MetricMode::Average);
 
-    if( ch_temps[ch] > 65 ){ // digitizers shut down at 70 celsius
+    if( ch_temps[ch] > fCAEN.maxTemp ){ // V1730(S) shuts down at 70(85) celsius
       TLOG(TLVL_ERROR) << "CAENV1730 BoardID " << fBoardID << " : "
-                       << "Temperature above 65 degrees Celsius for channel " << ch
+                       << "Temperature above " << fCAEN.maxTemp << " degrees Celsius for channel " << ch
 		       << TLOG_ENDL;
     }
 


### PR DESCRIPTION
### Description

Two items:

1. Following @wbadgett 's comment on #100 , I added a fhicl parameter called `maxTempCelsius` to set the limit at which error messages are sent out. This should allow to customize the behavior between V1730 and V1730S.

2. I've taken the opportunity to remove several fcl parameters in `CAENConfiguration`, which were either not read or read but not used anywhere. The list of parameters that can now be removed from `pmt_standard.fcl` is: 
   - firstBoardId
   - usePedestals 
   - dacValue
   - outputSignalMode 
   - memoryAlmostFull
   - boardId (since #100 )
   - eventCounterWarning (since #98 )

### Testing details
- Breaking change: configurations now require `maxTempCelsius` in `pmt_standard.fcl` to work.
