### PR TITLE
Feature/kalra tpc ntb implementation

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/CMakeLists.txt
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(nevishwutils)
 include_directories ( $ENV{WINDRIVER_INC} )
 
 SET_SOURCE_FILES_PROPERTIES(NevisTPC2StreamNUandSNXMIT_generator.cc PROPERTIES COMPILE_FLAGS -Wno-error=unused-function)
+SET_SOURCE_FILES_PROPERTIES(NevisTBStream_generator.cc PROPERTIES COMPILE_FLAGS -Wno-error=unused-function)
 SET_SOURCE_FILES_PROPERTIES(NevisTPCNUXMIT_generator.cc PROPERTIES COMPILE_FLAGS -Wno-error=unused-function)
 SET_SOURCE_FILES_PROPERTIES(NevisTPCCALIB_generator.cc PROPERTIES COMPILE_FLAGS -Wno-error=unused-function)
 
@@ -15,13 +16,28 @@ cet_make_library(
     sbndaq-artdaq_nevishwutils
 )
 
+cet_make_library(
+  LIBRARY_NAME
+    sbndaq-artdaq_NevisTBGeneratorBase
+  SOURCE
+    NevisTB_generatorBase.cc
+   LIBRARIES
+    ${LIBRARY_CORE_LIB_LIST}
+    sbndaq-artdaq_nevishwutils
+)
+
+
+
 list(APPEND BUILD_PLUGIN_CORE_LIB_LIST sbndaq-artdaq_NevisTPCGeneratorBase)
+
 
 basic_plugin(NevisTPCData "generator" LIBRARIES REG ${BUILD_PLUGIN_CORE_LIB_LIST})
 basic_plugin(NevisTPC2StreamNUandSNXMIT "generator" LIBRARIES REG ${BUILD_PLUGIN_CORE_LIB_LIST})
+basic_plugin(NevisTBStream "generator" LIBRARIES REG ${BUILD_PLUGIN_CORE_LIB_LIST} sbndaq-artdaq_NevisTBGeneratorBase)
 basic_plugin(NevisTPCNUXMIT "generator" LIBRARIES REG ${BUILD_PLUGIN_CORE_LIB_LIST})
 basic_plugin(NevisTPCCALIB "generator" LIBRARIES REG ${BUILD_PLUGIN_CORE_LIB_LIST})
 basic_plugin(NevisTPCFile "generator" LIBRARIES REG ${BUILD_PLUGIN_CORE_LIB_LIST})
+
 
 install_source()
 install_headers()

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTBStream.hh
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTBStream.hh
@@ -1,0 +1,65 @@
+#ifndef _sbndaq_readout_Generators_NevisTBStream_generator
+#define _sbndaq_readout_Generators_NevisTBStream_generator
+
+/**                                                                                                                                                                        
+ * Nevis TB data generator                                                                                                                                                 
+ *                                                                                                                                                                         
+ * Author: D.Kalra  <dkalra@nevis.columbia.edu>, 2023/05/01                                                                                                                
+ */
+
+#include "sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.hh"
+#include "sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/ControllerModule.h"
+#include "sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.h"
+#include "sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/XMITReader.h"
+#include <fstream> // temp                                                                                                                                                 
+
+namespace sbndaq {
+
+  class NevisTBStream : public sbndaq::NevisTB_generatorBase {
+  public:
+    explicit NevisTBStream(fhicl::ParameterSet const& _p) :
+      NevisTB_generatorBase(_p),
+      fntbreader( new nevistpc::NevisTBStreamReader("ntb_reader",_p))
+      //      fControllerModule( new nevistpc::ControllerModule(_p) ),
+      //fNUXMITReader( new nevistpc::XMITReader("nu_xmit_reader", _p) ),
+      //fSNXMITReader( new nevistpc::XMITReader("sn_xmit_reader", _p) )
+    {
+      ConfigureNTBStart();
+    }
+    virtual ~NevisTBStream() {}
+  private:
+    void ConfigureNTBStart();
+    void ConfigureNTBStop();
+
+     size_t GetNevisTBData();
+
+    /*  bool GetNTBData(); //! Get NTB stream data                                                                                                                  
+    share::WorkerThreadUPtr GetNTBData_thread_;
+    */
+    std::unique_ptr<uint16_t[]> NTBDMABuffer_;
+    CircularBuffer_t NTBCircularBuffer_;
+    //bool WriteNTBData(); //! Write NTB stream data                                                                                                              
+    // share::WorkerThreadUPtr WriteNTBData_thread_;
+    uint16_t* NTBBuffer_;
+   
+
+    //    nevistpc::ControllerModuleSPtr fControllerModule;
+    //nevistpc::XMITReaderSPtr fNUXMITReader;
+    //nevistpc::XMITReaderSPtr fSNXMITReader;
+    //nevistpc::CrateSPtr fCrate;
+
+    nevistpc::NevisTBStreamReaderSPtr fntbreader;
+
+    uint32_t fNTBChunkSize;
+    bool fDumpNTBBinary; //!< Write binary file before the artdaq back-end                                                                                                 
+    std::string fDumpNTBBinaryDir; //!< Directory for binary file dump                                                                                                     
+    std::ofstream binFileNTB;
+    char binFileNameNevisTB[80];
+
+  };
+
+}  // namespace sbndaq                                                                                                                                                     
+
+#endif // _sbndaq_readout_Generators_NevisTBStream_generator                                                                                                               
+
+

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTBStream.hh
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTBStream.hh
@@ -20,9 +20,6 @@ namespace sbndaq {
     explicit NevisTBStream(fhicl::ParameterSet const& _p) :
       NevisTB_generatorBase(_p),
       fntbreader( new nevistpc::NevisTBStreamReader("ntb_reader",_p))
-      //      fControllerModule( new nevistpc::ControllerModule(_p) ),
-      //fNUXMITReader( new nevistpc::XMITReader("nu_xmit_reader", _p) ),
-      //fSNXMITReader( new nevistpc::XMITReader("sn_xmit_reader", _p) )
     {
       ConfigureNTBStart();
     }
@@ -31,23 +28,11 @@ namespace sbndaq {
     void ConfigureNTBStart();
     void ConfigureNTBStop();
 
-     size_t GetNevisTBData();
-
-    /*  bool GetNTBData(); //! Get NTB stream data                                                                                                                  
-    share::WorkerThreadUPtr GetNTBData_thread_;
-    */
+    size_t GetNevisTBData();
     std::unique_ptr<uint16_t[]> NTBDMABuffer_;
     CircularBuffer_t NTBCircularBuffer_;
-    //bool WriteNTBData(); //! Write NTB stream data                                                                                                              
-    // share::WorkerThreadUPtr WriteNTBData_thread_;
     uint16_t* NTBBuffer_;
    
-
-    //    nevistpc::ControllerModuleSPtr fControllerModule;
-    //nevistpc::XMITReaderSPtr fNUXMITReader;
-    //nevistpc::XMITReaderSPtr fSNXMITReader;
-    //nevistpc::CrateSPtr fCrate;
-
     nevistpc::NevisTBStreamReaderSPtr fntbreader;
 
     uint32_t fNTBChunkSize;

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTBStream_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTBStream_generator.cc
@@ -46,41 +46,12 @@ void sbndaq::NevisTBStream::ConfigureNTBStart() {
 
 }
 
-/*
-// Set up worker GetNTBData thread.                                                                                                                           
-            
-share::ThreadFunctor GetNTBData_functor = std::bind( &NevisTBStream::GetNTBData, this );
-auto GetNTBData_worker_functor = share::WorkerThreadFunctorUPtr( new share::WorkerThreadFunctor( GetNTBData_functor, "GetNTBDataWorkerThread" ) );
-auto GetNTBData_worker = share::WorkerThread::createWorkerThread( GetNTBData_worker_functor );
-GetNTBData_thread_.swap(GetNTBData_worker);
-if(fDumpNTBBinary){
-  GetNTBData_thread_->start();
-  TLOG(TLVL_INFO) << "Started GetNTBData thread" << TLOG_ENDL;
- }
-
-
-// Set up worker WriteSNData thread.                                                                                                                                     
-share::ThreadFunctor WriteNTBData_functor = std::bind( &NevisTBStream::WriteNTBData, this );
-auto WriteNTBData_worker_functor = share::WorkerThreadFunctorUPtr( new share::WorkerThreadFunctor( WriteNTBData_functor, "WriteNTBDataWorkerThread" ) );
-auto WriteNTBData_worker = share::WorkerThread::createWorkerThread( WriteNTBData_worker_functor );
-WriteNTBData_thread_.swap(WriteNTBData_worker);
-if( fDumpNTBBinary ){
-  WriteNTBData_thread_->start();
-  TLOG(TLVL_INFO) << "Started WriteNTBData thread" << TLOG_ENDL;
- }
-
-*/
-
 void sbndaq::NevisTBStream::ConfigureNTBStop() {
 
   if( fDumpNTBBinary ){
     TLOG(TLVL_INFO)<< "Closig raw binary file " << binFileNameNevisTB;
     binFileNTB.close();
-    //GetNTBData_thread_->stop();
-    //WriteNTBData_thread_->stop();
   }
-
-  //  delete[] NTBBuffer_;
 
 
   TLOG(TLVL_INFO)<< "Successful " << __func__ ;
@@ -88,50 +59,15 @@ void sbndaq::NevisTBStream::ConfigureNTBStop() {
 }
 
 size_t sbndaq::NevisTBStream::GetNevisTBData() {
-
-  //  std::streamsize bytesRead = fCrate->getNevisTBStreamReader()->readsome(reinterpret_cast<char*>(&DMABufferNTB_[0]), fNTBChunkSize);
   TLOG(TLVL_INFO)<< "GetNevisTBData";
 
   std::streamsize bytesRead = fntbreader->readsome(reinterpret_cast<char*>(&DMABufferNTB_[0]), fNTBChunkSize);  
-  TLOG(TLVL_INFO)<< "NTB bytes:" << bytesRead;
-  //  if(bytesRead>0){
 
-    binFileNTB.write( (char*)(&DMABufferNTB_[0]), bytesRead); //fNTBChunkSize );  
-
-  // size_t n_words = bytesRead/sizeof(uint16_t); 
-  //size_t new_buffer_size = NTBCircularBuffer_.Insert(n_words, NTBDMABuffer_);
-  //if( NTBCircularBuffer_.buffer.size() < fNTBChunkSize ) return false;
-  //std::copy(NTBCircularBuffer_.buffer.begin(), NTBCircularBuffer_.buffer.begin() + fNTBChunkSize, NTBBuffer_); 
-
-  //binFileNTB.write((char*)NTBBuffer_, fNTBChunkSize );                                                                                                     
+  binFileNTB.write( (char*)(&DMABufferNTB_[0]), bytesRead); //fNTBChunkSize );                         
   binFileNTB.flush();
-  //}                                                                                                                                        
-  return bytesRead;
+ return bytesRead;
 
 }
 
-/*
-bool sbndaq::NevisTBStream::GetNTBData() {
-  std::streamsize bytesRead = fCrate->getNevisTBStreamReader()->readsome(reinterpret_cast<char*>(&NTBDMABuffer_[0]), fNTBChunkSize);
-  size_t n_words = bytesRead/sizeof(uint16_t);
-  size_t new_buffer_size = NTBCircularBuffer_.Insert(n_words, NTBDMABuffer_);
-
-  TLOG(TGETDATA)<< "Successfully inserted " << n_words << " . SN Buffer occupancy now " << new_buffer_size;
-  return true;
-}
-
-bool sbndaq::NevisTBStream::WriteNTBData() {
-  if( NTBCircularBuffer_.buffer.size() < fNTBChunkSize ) return false;
-
-  std::copy(NTBCircularBuffer_.buffer.begin(), NTBCircularBuffer_.buffer.begin() + fNTBChunkSize, NTBBuffer_);
-
-  binFileNTB.write((char*)NTBBuffer_, fNTBChunkSize );
-  binFileNTB.flush();
-  size_t new_buffer_size = NTBCircularBuffer_.Erase(fNTBChunkSize);
-  TLOG(TFILLFRAG)<< "Successfully erased " << fNTBChunkSize << " . NTB Buffer occupancy now " << new_buffer_size;
-
-  return true;
-}
-*/
 
 DEFINE_ARTDAQ_COMMANDABLE_GENERATOR(sbndaq::NevisTBStream)

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTBStream_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTBStream_generator.cc
@@ -1,0 +1,137 @@
+#define TRACE_NAME "NevisTBStreamGenerator"
+
+#include "artdaq/DAQdata/Globals.hh"
+#include "artdaq/Generators/GeneratorMacros.hh"
+#include "sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTBStream.hh"
+
+
+#include <chrono>
+#include <ctime>
+
+void sbndaq::NevisTBStream::ConfigureNTBStart() {
+  TLOG(TLVL_INFO) << "ConfigureStart NTB";
+
+  fNTBChunkSize = ps_.get<int>("NTBChunkSize", 96);
+
+  fDumpNTBBinary = ps_.get<bool>("DumpNTBBinary", false);
+  fDumpNTBBinaryDir = ps_.get<std::string>("DumpNTBBinaryDir", ".");
+
+ 
+
+  NTBDMABuffer_.reset(new uint16_t[fNTBChunkSize]);
+  NTBCircularBuffer_ = CircularBuffer(1e9/sizeof(uint16_t)); // to do: define in fcl                                             
+                                           
+  NTBCircularBuffer_.Init();
+  NTBBuffer_ = new uint16_t[fNTBChunkSize];
+ 
+  if( fDumpNTBBinary ){
+    // Get timestamp for binary file name                                                                                                                                  
+    time_t t = time(0);
+    struct tm ltm = *localtime( &t );
+
+    sprintf(binFileNameNevisTB, "%s/sbndrawbin_run%06i_%4i.%02i.%02i-%02i.%02i.%02i_NevisTB.dat",
+            fDumpNTBBinaryDir.c_str(), sbndaq::NevisTB_generatorBase::run_number(),
+            ltm.tm_year + 1900, ltm.tm_mon + 1, ltm.tm_mday, ltm.tm_hour, ltm.tm_min, ltm.tm_sec);
+    binFileNTB.open( binFileNameNevisTB, std::ofstream::out | std::ofstream::binary ); // temp                                                                         
+
+    TLOG(TLVL_INFO)<< "Opening raw binary file " << binFileNameNevisTB;
+
+  }
+
+  TLOG(TLVL_INFO) << "Configure NTB PCIe card";
+  fntbreader->configureReader();
+  fntbreader->initializePCIeCard();
+  fntbreader->setupTXModeRegister();
+  TLOG(TLVL_INFO) << "Configured NTB PCIe card";
+
+}
+
+/*
+// Set up worker GetNTBData thread.                                                                                                                           
+            
+share::ThreadFunctor GetNTBData_functor = std::bind( &NevisTBStream::GetNTBData, this );
+auto GetNTBData_worker_functor = share::WorkerThreadFunctorUPtr( new share::WorkerThreadFunctor( GetNTBData_functor, "GetNTBDataWorkerThread" ) );
+auto GetNTBData_worker = share::WorkerThread::createWorkerThread( GetNTBData_worker_functor );
+GetNTBData_thread_.swap(GetNTBData_worker);
+if(fDumpNTBBinary){
+  GetNTBData_thread_->start();
+  TLOG(TLVL_INFO) << "Started GetNTBData thread" << TLOG_ENDL;
+ }
+
+
+// Set up worker WriteSNData thread.                                                                                                                                     
+share::ThreadFunctor WriteNTBData_functor = std::bind( &NevisTBStream::WriteNTBData, this );
+auto WriteNTBData_worker_functor = share::WorkerThreadFunctorUPtr( new share::WorkerThreadFunctor( WriteNTBData_functor, "WriteNTBDataWorkerThread" ) );
+auto WriteNTBData_worker = share::WorkerThread::createWorkerThread( WriteNTBData_worker_functor );
+WriteNTBData_thread_.swap(WriteNTBData_worker);
+if( fDumpNTBBinary ){
+  WriteNTBData_thread_->start();
+  TLOG(TLVL_INFO) << "Started WriteNTBData thread" << TLOG_ENDL;
+ }
+
+*/
+
+void sbndaq::NevisTBStream::ConfigureNTBStop() {
+
+  if( fDumpNTBBinary ){
+    TLOG(TLVL_INFO)<< "Closig raw binary file " << binFileNameNevisTB;
+    binFileNTB.close();
+    //GetNTBData_thread_->stop();
+    //WriteNTBData_thread_->stop();
+  }
+
+  //  delete[] NTBBuffer_;
+
+
+  TLOG(TLVL_INFO)<< "Successful " << __func__ ;
+  mf::LogInfo("NevisTBStream") << "Successful " << __func__;
+}
+
+size_t sbndaq::NevisTBStream::GetNevisTBData() {
+
+  //  std::streamsize bytesRead = fCrate->getNevisTBStreamReader()->readsome(reinterpret_cast<char*>(&DMABufferNTB_[0]), fNTBChunkSize);
+  TLOG(TLVL_INFO)<< "GetNevisTBData";
+
+  std::streamsize bytesRead = fntbreader->readsome(reinterpret_cast<char*>(&DMABufferNTB_[0]), fNTBChunkSize);  
+  TLOG(TLVL_INFO)<< "NTB bytes:" << bytesRead;
+  //  if(bytesRead>0){
+
+    binFileNTB.write( (char*)(&DMABufferNTB_[0]), bytesRead); //fNTBChunkSize );  
+
+  // size_t n_words = bytesRead/sizeof(uint16_t); 
+  //size_t new_buffer_size = NTBCircularBuffer_.Insert(n_words, NTBDMABuffer_);
+  //if( NTBCircularBuffer_.buffer.size() < fNTBChunkSize ) return false;
+  //std::copy(NTBCircularBuffer_.buffer.begin(), NTBCircularBuffer_.buffer.begin() + fNTBChunkSize, NTBBuffer_); 
+
+  //binFileNTB.write((char*)NTBBuffer_, fNTBChunkSize );                                                                                                     
+  binFileNTB.flush();
+  //}                                                                                                                                        
+  return bytesRead;
+
+}
+
+/*
+bool sbndaq::NevisTBStream::GetNTBData() {
+  std::streamsize bytesRead = fCrate->getNevisTBStreamReader()->readsome(reinterpret_cast<char*>(&NTBDMABuffer_[0]), fNTBChunkSize);
+  size_t n_words = bytesRead/sizeof(uint16_t);
+  size_t new_buffer_size = NTBCircularBuffer_.Insert(n_words, NTBDMABuffer_);
+
+  TLOG(TGETDATA)<< "Successfully inserted " << n_words << " . SN Buffer occupancy now " << new_buffer_size;
+  return true;
+}
+
+bool sbndaq::NevisTBStream::WriteNTBData() {
+  if( NTBCircularBuffer_.buffer.size() < fNTBChunkSize ) return false;
+
+  std::copy(NTBCircularBuffer_.buffer.begin(), NTBCircularBuffer_.buffer.begin() + fNTBChunkSize, NTBBuffer_);
+
+  binFileNTB.write((char*)NTBBuffer_, fNTBChunkSize );
+  binFileNTB.flush();
+  size_t new_buffer_size = NTBCircularBuffer_.Erase(fNTBChunkSize);
+  TLOG(TFILLFRAG)<< "Successfully erased " << fNTBChunkSize << " . NTB Buffer occupancy now " << new_buffer_size;
+
+  return true;
+}
+*/
+
+DEFINE_ARTDAQ_COMMANDABLE_GENERATOR(sbndaq::NevisTBStream)

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.cc
@@ -1,0 +1,229 @@
+//
+// sbndaq-artdaq/Generators/SBND/NevisTB_generatorBase.cc (D.Kalra)
+//
+#define TRACE_NAME "NevisTBGenerator"
+#include "artdaq/DAQdata/Globals.hh"
+
+#include "sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.hh"
+#include "sbndaq-artdaq-core/Overlays/FragmentType.hh"
+
+#include <fstream>
+#include <iomanip>
+#include <iterator>
+#include <iostream>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+sbndaq::NevisTB_generatorBase::NevisTB_generatorBase(fhicl::ParameterSet const & ps): CommandableFragmentGenerator(ps), ps_(ps){
+  
+  Initialize();
+}
+
+
+sbndaq::NevisTB_generatorBase::~NevisTB_generatorBase(){
+
+  stopAll();
+}
+
+void sbndaq::NevisTB_generatorBase::Initialize(){
+  CircularBufferSizeBytesNTB_ = ps_.get<uint32_t>("CircularBufferSizeBytesNTB_",1e9);  
+  DMABufferSizeBytesNTB_ = ps_.get<uint32_t>("DMABufferSizeNTB",1e4);                                                                                
+  DMABufferNTB_.reset(new uint16_t[DMABufferSizeBytesNTB_]);       
+  current_subrun_ = 0;
+  events_seen_ = 0;
+  _subrun_event_0 = -1;
+  _this_event = -1;
+
+
+  pseudo_ntbfragment = 1;  
+
+  //Build buffer for NTB        
+  if( CircularBufferSizeBytesNTB_%sizeof(uint16_t)!=0)                                                                                                
+    TRACE(TWARNING,"NevisTB::Initialize() : CircularBufferSizeNTB_ not multiple of size uint16_t. Rounding down.");                                   
+  CircularBufferNTB_ = CircularBuffer(CircularBufferSizeBytesNTB_/sizeof(uint16_t));                                                                  
+  // Initialize our buffer 
+  CircularBufferNTB_.Init();  
+
+  // Set up worker getNTBdata thread. 
+  share::ThreadFunctor ntbfunctor = std::bind(&NevisTB_generatorBase::GetNTBData,this);                                                              
+  auto worker_ntbfunctor = share::WorkerThreadFunctorUPtr(new share::WorkerThreadFunctor(ntbfunctor,"GetNTBDataWorkerThread"));                       
+  auto GetNTBData_worker = share::WorkerThread::createWorkerThread(worker_ntbfunctor);                                                                
+  GetNTBData_thread_.swap(GetNTBData_worker);
+
+}
+
+void sbndaq::NevisTB_generatorBase::start(){
+  GetNTBData_thread_->start();  
+}
+
+void sbndaq::NevisTB_generatorBase::stopAll(){
+  GetNTBData_thread_->stop();   
+}
+
+
+void sbndaq::NevisTB_generatorBase::stop(){
+  ConfigureNTBStop();
+  stopAll();
+}
+
+void sbndaq::NevisTB_generatorBase::stopNoMutex(){
+
+  stopAll();
+}
+
+size_t sbndaq::NevisTB_generatorBase::CircularBuffer::Insert(size_t n_words, std::unique_ptr<uint16_t[]> const& dataptr){
+
+  TRACE(TDEBUG,"Inserting %lu words. Currently %lu/%lu in buffer.",n_words,buffer.size(),buffer.capacity());
+  //don't fill while we wait for available capacity...                                                                                                  
+  while( (buffer.capacity()-buffer.size()) < n_words){ usleep(10); }
+  //obtain the lock                                                                                                                                     
+  std::unique_lock<std::mutex> lock(*(mutexptr));
+  TRACE(TDEBUG,"Obtained circular buffer lock for insert.");
+
+  buffer.insert(buffer.end(),&(dataptr[0]),&(dataptr[n_words]));
+  TRACE(TDEBUG,"Inserted %lu words. Currently have %lu/%lu in buffer.",
+        n_words,buffer.size(),buffer.capacity());
+  return buffer.size();
+}
+
+
+size_t sbndaq::NevisTB_generatorBase::CircularBuffer::Erase(size_t n_words){
+
+  TRACE(TDEBUG,"Erasing %lu words. Currently %lu/%lu in buffer.",
+        n_words,buffer.size(),buffer.capacity());
+
+  std::unique_lock<std::mutex> lock(*(mutexptr));
+  TRACE(TDEBUG,"Obtained circular buffer lock for erase.");
+
+  buffer.erase_begin(n_words);
+  TRACE(TDEBUG,"Erased %lu words. Currently have %lu/%lu in buffer.",
+        n_words,buffer.size(),buffer.capacity());
+
+  return buffer.size();
+}
+
+bool sbndaq::NevisTB_generatorBase::GetNTBData(){                                                                                                     
+                                                                                                                                                        
+  size_t ntb_words = GetNevisTBData()/sizeof(uint16_t);                                                                                                 
+  TLOG(TLVL_INFO)<< "NTB words" << ntb_words;                                                                                                           
+  if(ntb_words==0) return false;                                                                                                                        
+  size_t new_NTBbuffer_size = CircularBufferNTB_.Insert(ntb_words,DMABufferNTB_);                                                                       
+                                                                                                                                                        
+  return true;                                                                                                                                          
+}                                          
+
+
+bool sbndaq::NevisTB_generatorBase::getNext_(artdaq::FragmentPtrs & frags){
+  //this function doesn't run over event by event.                                                                                                      
+  while(true)
+    if(!FillNTBFragment(frags)) break; // and !FillNTBFragment(frags)) break;                                                                              
+
+  return true;
+}
+
+
+bool sbndaq::NevisTB_generatorBase::FillNTBFragment(artdaq::FragmentPtrs &frags, bool clear_buffer[[gnu::unused]]){                                    
+                                                                                                                                                        
+  size_t new_NTBbuffer_size=0;  
+  // Check that we've got at least 4*32 bits of data for NevisTB                                                                                        
+  // We need 4*32bit data because for NTB, the trailer end marker is the fixed one 0xffffffff unlike the TPCs where we have XMIT header that starts with 0xffffffff                                                                                                                                           
+  if(CircularBufferNTB_.buffer.size()*sizeof(uint16_t) < 4*sizeof(uint32_t)){                                                                         
+    TLOG(TLVL_INFO)<< "Size of NTB Circular buffer:" << CircularBufferNTB_.buffer.size();                                                             
+    return false;                                                                                                                                     
+  }            
+
+ //Can we reset event and frame number counter here. For TPC, it is reset during start of header but for NTB, it's tricky because we can only determine event trigger data end marker. Confirm with Gennadiy.         
+  current_ntbevent = -1;        
+  current_ntbframenum = -1;     
+  if( *(reinterpret_cast<uint32_t const*>(&CircularBufferNTB_.buffer[0])) == 0xffffffff ){                                                            
+  TRACE(TFILLFRAG,"FOUND EVENT TRIGGER DATA END MARKER (NTB DATA MARKER)");                                                                           
+   new_NTBbuffer_size = CircularBufferNTB_.Erase(8); //Deleting 8 words. because we read 8 16 bit words when a trigger is issued.                     
+    TRACE(TFILLFRAG,"Successfully erased %d words. Buffer occupancy now %lu",2,new_NTBbuffer_size);                                                   
+    return true;                                                                                                                                      
+  }
+  //Define NevisTB header 
+  auto ntbheader = reinterpret_cast<NevisTrigger_Header const*>(&CircularBufferNTB_.buffer[0]);
+  size_t expected_size = sizeof(NevisTrigger_Header) + sizeof(NevisTrigger_Trailer) + sizeof(NevisTrigger_Data);                                      
+  if(current_ntbevent < 0){                                                                                                                           
+    current_ntbevent = ntbheader->getTriggerNumber();  //this function is defined in NevisTB_dataFormat                                               
+ 
+  }                                                                                                                                                   
+ 
+  else if((uint)current_ntbevent != ntbheader->getTriggerNumber())                                                                                    
+ 
+    {                                                                                                                                                 
+ 
+      char line[132];  
+      sprintf(line,"NTB eventnum out of sync, tanking the run. Current: %d, header: %d",current_ntbevent,ntbheader->getTriggerNumber());                
+      TRACE(TERROR,line);                                                                                                                               
+      throw std::runtime_error(line);                                                                                                                   
+      return false;                                                                                                                                     
+    }                                                                                                                                                   
+                                                                                                                                                        
+  if(current_ntbframenum < 0){                                                                                                                          
+    current_ntbframenum = ntbheader->getFrame();                                                                                                        
+  }                                                                                                                                                     
+                                                                                                                                                        
+  else if((uint)current_ntbframenum != ntbheader->getFrame()){                                                                                          
+    char line[132];    
+    sprintf(line,"NTB framenum out of sync, tanking the run. Current: %d, Header :%d", current_ntbframenum,ntbheader->getFrame());                      
+    TRACE(TERROR,line);                                                                                                                                 
+    throw std::runtime_error(line);                                                                                                                     
+    return false;                                                                                                                                       
+  }                                                                                                                                                     
+                                                                                                                                                        
+                                                                                                                                                        
+  if(CircularBufferNTB_.buffer.size()*sizeof(uint16_t) < expected_size){                                                                                   
+    TRACE(TFILLFRAG,"Not enough NTB data for expected size %lu. Return and try again.",expected_size);                                                  
+    return false;                                                                                                                                       
+  }  
+  // Sweet, now, let's actually fill stuff                                                                                                              
+  _this_event = ntbmetadata_.EventNumber();                                                                                                             
+                                                                                                                                                        
+  // set the subrun event 0 if it has never been set before                                                                                             
+  if (_subrun_event_0 == -1) {                                                                                                                          
+    _subrun_event_0 = _this_event;  
+
+  }
+    struct timespec unixtime;                                                                                                                             
+    clock_gettime(CLOCK_REALTIME, &unixtime);                                                                                                             
+    artdaq::Fragment::timestamp_t unixtime_ns = static_cast<artdaq::Fragment::timestamp_t>(unixtime.tv_sec)*1000000000 +                                  
+    static_cast<artdaq::Fragment::timestamp_t>(unixtime.tv_nsec);                                                                                       
+                                                                                                                                                        
+    ntbmetadata_ = NevisTBFragmentMetadata(ntbheader->getTriggerNumber(),ntbheader->getFrame(), ntbheader->get2MHzSampleNumber());  
+    frags.emplace_back( artdaq::Fragment::FragmentBytes(expected_size,                                                                                    
+							ntbmetadata_.EventNumber(),       // Sequence ID                                                  
+							pseudo_ntbfragment,                                                                               
+							detail::FragmentType::NevisTB,   // Fragment Type                                                 
+							ntbmetadata_,                                                                                     
+							unixtime_ns) );                                                                                   
+                                                                                                                                                        
+    std::copy(CircularBufferNTB_.buffer.begin(),                                                                                                          
+	      CircularBufferNTB_.buffer.begin()+(expected_size/sizeof(uint16_t)),                                                                         
+	      (uint16_t*)(frags.back()->dataBegin()));     
+    new_NTBbuffer_size = CircularBufferNTB_.Erase(expected_size/sizeof(uint16_t));                                                                        
+
+    TRACE(TFILLFRAG,"Successfully erased %lu words. Buffer occupancy now %lu",
+	  expected_size/sizeof(uint16_t),new_NTBbuffer_size);
+
+    // bump the subrun
+    if(EventsPerSubrun_ > 0 && _subrun_event_0 != _this_event && _this_event % EventsPerSubrun_== 0) {
+      TRACE(TFILLFRAG, "Bumping artdaq subrun number from %u to %u. Last subrun spans events %i to %i.", current_subrun_,current_subrun_ + 1, _subrun_event_0, _this_event); 
+      _subrun_event_0 = _this_event;
+      ++current_subrun_;
+      artdaq::FragmentPtr endOfSubrunFrag(new artdaq::Fragment(static_cast<size_t>(ceil(sizeof(my_rank) / static_cast<double>(sizeof(artdaq::Fragment::value_type))))));
+      endOfSubrunFrag->setSystemType(artdaq::Fragment::EndOfSubrunFragmentType);
+      endOfSubrunFrag->setSequenceID(_this_event);
+      *endOfSubrunFrag->dataBegin() = my_rank;
+      frags.emplace_back(std::move(endOfSubrunFrag));
+    }
+
+    ++events_seen_;
+
+    return true;                                                                                                                                          
+                                                                                                                                                          
+  } //End of FillNTBFragment                                                                                                                              
+
+    

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.hh
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.hh
@@ -1,0 +1,109 @@
+//
+// sbndaq-artdaq/Generators/SBND/NevisTB_generatorBase.hh
+//
+
+#ifndef _sbndaq_readout_Generators_NevisTB_generatorBase
+#define _sbndaq_readout_Generators_NevisTB_generatorBase
+
+#include <memory>
+#include <atomic>
+#include <future>
+
+#include <boost/circular_buffer.hpp>
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/fwd.h"
+#include "artdaq-core/Data/Fragment.hh"
+#include "artdaq/Generators/CommandableFragmentGenerator.hh"
+#include "sbndaq-artdaq/Generators/Common/workerThread.hh"
+#include "sbndaq-artdaq-core/Overlays/SBND/NevisTBFragment.hh"
+#include <unistd.h>
+#include <vector>
+
+
+namespace sbndaq
+{
+  class NevisTB_generatorBase: public artdaq::CommandableFragmentGenerator
+  {
+  public:
+    
+    explicit NevisTB_generatorBase(fhicl::ParameterSet const & ps);
+    virtual ~NevisTB_generatorBase();
+    
+  protected:
+    
+    bool getNext_(artdaq::FragmentPtrs & output) override;
+    void start() override;
+    void stop() override;
+    void stopNoMutex() override;
+    void stopAll();
+    void Initialize();
+
+    //These functions MUST be defined by the derived classes
+    virtual void ConfigureNTBStart() = 0; //called in start()
+    virtual void ConfigureNTBStop() = 0;  //called in stop()
+
+    //gets the data. Output is size of data filled. Input is FEM ID. 
+    virtual size_t GetNevisTBData() = 0; 
+    virtual int    GetDataSetup() { return 1; }
+    virtual int    GetDataComplete() { return 1; }
+
+    enum {
+      TERROR    = TLVL_ERROR,
+      TWARNING  = TLVL_WARNING,
+      TINFO     = TLVL_INFO,
+      TDEBUG    = TLVL_DEBUG,
+      TCONFIG=9,
+      TSTART=10,
+      TSTOP=11,
+      TSTATUS=12,
+      TGETNEXT=13,
+      TFILLFRAG=14,
+      TGETDATA=24
+    };
+
+    uint32_t current_subrun_;
+    size_t events_seen_;
+
+    NevisTBFragmentMetadata ntbmetadata_;
+    fhicl::ParameterSet const ps_;
+
+    uint32_t RunNumber_;
+    int32_t EventsPerSubrun_;
+
+    int32_t _this_event;
+    int32_t _subrun_event_0;
+    typedef struct CircularBuffer{
+      boost::circular_buffer<uint16_t> buffer;
+      std::unique_ptr<std::mutex> mutexptr;
+      
+      CircularBuffer(uint32_t capacity): buffer( boost::circular_buffer<uint16_t>(capacity) ),mutexptr(new std::mutex){  Init();}
+      CircularBuffer(){ CircularBuffer(0); }
+      
+      void Init(){
+	buffer.clear();
+	mutexptr->unlock();
+      }
+
+
+      size_t Insert(size_t,std::unique_ptr<uint16_t[]>  const& );
+      size_t Erase(size_t);
+    } CircularBuffer_t;
+    
+    uint32_t DMABufferSizeBytesNTB_;
+    std::unique_ptr<uint16_t[]> DMABufferNTB_;
+    
+    uint32_t CircularBufferSizeBytesNTB_;
+    CircularBuffer_t CircularBufferNTB_;
+    bool GetNTBData();
+    share::WorkerThreadUPtr GetNTBData_thread_;
+
+    virtual bool FillNTBFragment(artdaq::FragmentPtrs &,bool clear_buffer=false);
+    
+    int current_ntbevent, current_ntbframenum; // for checking consistency between FEMs within a run
+    bool desyncCrash;
+    uint64_t pseudo_ntbfragment; 
+
+  };
+}
+
+#endif

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC2StreamNUandSNXMIT.hh
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC2StreamNUandSNXMIT.hh
@@ -27,6 +27,7 @@ namespace sbndaq {
       fNUXMITReader( new nevistpc::XMITReader("nu_xmit_reader", _p) ),
       fSNXMITReader( new nevistpc::XMITReader("sn_xmit_reader", _p) )
     {
+      ConfigureStart();
     }
     virtual ~NevisTPC2StreamNUandSNXMIT() {}
     

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
@@ -45,11 +45,21 @@ void sbndaq::NevisTPC_generatorBase::Initialize(){
   DMABuffer_.reset(new uint16_t[DMABufferSizeBytes_]);
 
   desyncCrash = ps_.get<bool>("desyncCrash",false);
+  current_subrun_ = 0;
+  events_seen_ = 0;
+
+  // intialize event counting                                                                                                       
+  _subrun_event_0 = -1;
+  _this_event = -1;
   
+
   // Build our buffer
   if( CircularBufferSizeBytes_%sizeof(uint16_t)!=0)
     TRACE(TWARNING,"NevisTPC::Initialize() : CircularBufferSize_ not multiple of size uint16_t. Rounding down.");
   CircularBuffer_ = CircularBuffer(CircularBufferSizeBytes_/sizeof(uint16_t));
+ 
+ // Initialize our buffer                                                                                                          
+  CircularBuffer_.Init();
   
   // Set up worker getdata thread.
   share::ThreadFunctor functor = std::bind(&NevisTPC_generatorBase::GetData,this);
@@ -59,18 +69,6 @@ void sbndaq::NevisTPC_generatorBase::Initialize(){
 }
 
 void sbndaq::NevisTPC_generatorBase::start(){
-  
-  current_subrun_ = 0;
-  events_seen_ = 0;
-
-  // intialize event counting
-  _subrun_event_0 = -1;
-  _this_event = -1;
-  
-  ConfigureStart();
-  
-  // Initialize our buffer
-  CircularBuffer_.Init();	
   
   // Magically start getdata thread
   GetData_thread_->start();

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/ControllerModule.cpp
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/ControllerModule.cpp
@@ -154,8 +154,8 @@ namespace nevistpc
   void ControllerModule::setupTXModeRegister()
   {
     nevisPCIeCard->writeAddr32 ( dma_detail::cs_bar, dma_detail::tx_mode_reg, 0xf0000008 );
-    nevisPCIeCard->writeAddr32 ( dma_detail::cs_bar, dma_detail::r2_cs_reg, dma_detail::cs_init );
-    nevisPCIeCard->writeAddr32 ( dma_detail::cs_bar, dma_detail::r2_cs_reg, dma_detail::cs_start+0xffffff );
+    nevisPCIeCard->writeAddr32 ( dma_detail::cs_bar, dma_detail::r1_cs_reg, dma_detail::cs_init );
+    nevisPCIeCard->writeAddr32 ( dma_detail::cs_bar, dma_detail::r1_cs_reg, dma_detail::cs_start+0xffffff );
     TLOG(TLVL_INFO) << "ControllerModule: called " <<  __func__ ;
   }
 

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.cpp
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.cpp
@@ -76,6 +76,10 @@ namespace nevistpc{
     if( name == "SN" ) return _sn_xmit_reader;
     else return NULL;
   }
+
+  //  NevisTBStreamReaderSPtr Crate::getNevisTBStreamReader(){
+  //return _nevistb_reader;//("nevistb_reader");                                                                                          
+  // }
   
   TriggerModuleSPtr Crate::getTriggerModule(){
     return _trigger_module;

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.h
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.h
@@ -6,6 +6,7 @@
 #include "XMITReader.h"
 #include "XMITModule.h"
 #include "TriggerModule.h"
+#include "NevisTBStreamReader.h"
 
 namespace nevistpc{
   
@@ -23,6 +24,7 @@ namespace nevistpc{
     XMITReaderSPtr getXMITReader();
     XMITReaderSPtr getXMITReader(std::string name); // Two-stream overload
     TriggerModuleSPtr getTriggerModule();
+    //    NevisTBStreamReaderSPtr getNevisTBStreamReader();
     
     bool hasTrigger;
     
@@ -45,7 +47,7 @@ namespace nevistpc{
     XMITReaderSPtr					_sn_xmit_reader; // SN stream
     std::vector < NevisTPCFEMSPtr > _fem_modules;
     TriggerModuleSPtr				_trigger_module;
-    
+    //NevisTBStreamReaderSPtr    _nevistb_reader;
   };
   
   typedef std::unique_ptr<Crate> CrateUPtr;

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/NevisTBStreamReader.cpp
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/NevisTBStreamReader.cpp
@@ -1,0 +1,238 @@
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+
+#include "NevisControllerPCIeCard.h"
+#include "NevisTBStreamReader.h"
+#include "TriggerModule.h"
+#include "daqExceptions.h"
+#include "TimeUtils.h"
+#include "StringUtils.h"
+#include "trace.h"
+#define TRACE_NAME "NevisTBStreamReader"
+
+ namespace nevistpc {
+ #define hex(w,d) std::setw(w) << std::setfill('0') << std::hex << d
+
+ NevisTBStreamReader::NevisTBStreamReader ( std::string const& streamName , fhicl::ParameterSet const & ps )
+   : _stream_name {streamName}, _params {ps}
+   // , _triggerCallFunction {doNothing}
+								   //    ,  _reader_synch_object {nullptr}
+								   //    ,  _reader_synch_object(new NevisTBStreamReaderSynchronizationObject)
+     , _trig_data_ctr {0xffffff}
+     , _trig_ctr {0}
+     , _trig_frame {0}
+     , _trig_sample {0}
+     , _trig_sample_remain_16MHz {0}
+     , _trig_sample_remain_64MHz {0}
+				 
+   {
+     //Should happen once.
+     TLOG(TLVL_INFO) << "Calling constructor for NevisTB: " << std::hex << _trig_data_ctr ;
+
+ }
+
+
+   void NevisTBStreamReader::initializePCIeCard()
+   {
+   nevisPCIeCard = std::unique_ptr<NevisControllerPCIeCard>( new NevisControllerPCIeCard(*nevisDeviceInfo) );
+   nevisPCIeCard->deviceOpen();
+   nevisPCIeCard->writeAddr32 ( dma_detail::cs_bar, dma_detail::t2_cs_reg, dma_detail::cs_init );
+   nevisPCIeCard->writeAddr32 ( dma_detail::cs_bar, dma_detail::r2_cs_reg, dma_detail::cs_init );
+   nevisPCIeCard->writeAddr32 ( dma_detail::cs_bar, dma_detail::tx_mode_reg, 0xfff );
+   TLOG(TLVL_INFO) << "NevisTBStreamReader " << _stream_name << ": called " <<  __func__ ;
+ }
+
+   void NevisTBStreamReader::setupTXModeRegister()
+   {
+     nevisPCIeCard->writeAddr32 ( dma_detail::cs_bar, dma_detail::tx_mode_reg, 0xf0000008 );
+     nevisPCIeCard->writeAddr32 ( dma_detail::cs_bar, dma_detail::r2_cs_reg, dma_detail::cs_init );
+     nevisPCIeCard->writeAddr32 ( dma_detail::cs_bar, dma_detail::r2_cs_reg, dma_detail::cs_start+0xffffff );
+
+   }
+
+						/*
+   void NevisTBStreamReader::setReaderSynchronizationObject ( NevisTBStreamReaderSynchronizationObjectSPtr& reader_synch_object )
+   {
+     TLOG_DEBUG(1) << "start - reader_synch_object="<<reader_synch_object.get();
+     assert ( !_reader_synch_object );
+     assert ( reader_synch_object );
+   //     _reader_synch_object = reader_synch_object;
+     TLOG(TLVL_INFO)<< "ReaderSynObject" << _reader_synch_object;
+   //reader_synch_object = std::make_shared<nevistpc::NevisTBStreamReaderSynchronizationObject>();
+   _reader_synch_object = reader_synch_object;   
+
+   }
+						*/
+
+
+
+   void NevisTBStreamReader::configureReader()
+   {
+     try {
+       fhicl::ParameterSet streamconfig;       
+       // NOTE: the name of the block in the fcl file must match
+   //       if( ! _params.get_if_present<fhicl::ParameterSet> ( "trigger_module", streamconfig ) ){
+   if( ! _params.get_if_present<fhicl::ParameterSet> ( "ntb_pciecard", streamconfig ) ){
+ 	TLOG(TLVL_ERROR)<< "TriggerModule: Missing trigger_module configuration block in fcl file" ;
+ 	throw RuntimeErrorException ( std::string("Missing trigger_module configuration block in fcl file") );
+       }
+
+       // Read the parameters identifying the PCIe card
+       nevisDeviceInfo = std::unique_ptr<DeviceInfo>( new DeviceInfo(streamconfig) );
+
+       TLOG(TLVL_INFO)<< "TriggerModule: Configuration read (PCIe card is shared with controller module)" ;
+     } catch ( ... ) {
+       TLOG(TLVL_ERROR)<< "TriggerModule: Failed reading of trigger_module configuration" ;
+       throw RuntimeErrorException ( std::string("Failed reading of trigger_module configuration") );
+     }
+
+     nevisPCIeCard = std::unique_ptr<NevisControllerPCIeCard>( new NevisControllerPCIeCard(*nevisDeviceInfo) );
+     nevisPCIeCard->deviceOpen();
+     TLOG(TLVL_INFO)<< "TriggerModule: called "<< __func__ ;
+  }
+
+
+  std::streamsize NevisTBStreamReader::readsome ( char* buffer, std::streamsize size )
+  {
+
+    TLOG(TLVL_DEBUG_13) << "Readsome for NevisTB is called!!!!!!"; 
+
+    struct timeval t1, t2;
+          
+    if(_do_timing) gettimeofday(&t1,NULL);
+          
+    assert ( buffer != NULL );
+    assert ( size > 0 );
+    //UNUSED(size);
+          
+    std::streamsize readSize = -1;
+    readSize=( size_t ) size;
+
+
+   //setReaderSynchronizationObject(reader_synch_object1);
+   //setReaderSynchronizationObject(reader_synch_object);
+
+   //   TLOG(TLVL_INFO)<< "Reader synch object is: "  << _reader_synch_object ;
+
+   //   if ( _reader_synch_object && !_reader_synch_object->try_lock_TRIGGER())   
+   //   if ( !_reader_synch_object || !_reader_synch_object->try_lock_TRIGGER())
+   //{
+   // TLOG(TLVL_WARN) <<  "\033[93m hello world\033[00m ... "<<_reader_synch_object ;
+   //return 0;
+   // }
+
+   /*
+   if (!_reader_synch_object) {
+      TLOG(TLVL_WARN) << "Ignoring NTB data as the reader object synchronization is null.";
+   //   return 0;
+    }
+    if (!_reader_synch_object->try_lock_TRIGGER()) {
+    TLOG(TLVL_WARN) << "Ignoring NTB data as the reader object synchronization is not in line with hardware.";
+     return 0;
+    }
+   */
+
+    UINT64 trig_data_ctr {0};
+    nevisPCIeCard->readAddr64 ( dma_detail::cs_bar, dma_detail::t2_cs_reg, trig_data_ctr );
+    //extracting a 24-bit value from the upper 32 bits of the read value.
+    trig_data_ctr = (trig_data_ctr>>32) & 0xffffff;
+   //TLOG(TLVL_DEBUG_13)
+   TLOG(TLVL_INFO) << "Nevis TB data (in bytes) reading from transceiver 2" << trig_data_ctr ;
+   //TLOG(TLVL_DEBUG_13) << 
+   TLOG(TLVL_INFO)<< " Hex (Nevis TB data (in bytes) reading from transceiver 2 24-bit value: " << std::hex << trig_data_ctr << " , manually defined " <<  _trig_data_ctr ;  
+
+
+          
+    if( (_trig_data_ctr - trig_data_ctr) < 16 ) {
+   //      if(_reader_synch_object) _reader_synch_object->unlock();
+      TLOG(TLVL_WARN) << "Triggered data is less than 16 bit word, unlocking reader sync object and returning zero"; 
+
+      return 0;
+
+
+    }
+    if(trig_data_ctr<1){
+      TLOG(TLVL_WARN) << "Triggered data is less than 1 bit; zero trigger data";
+      throw RuntimeErrorException ( "Got 0 trigger data!" );
+    }
+
+    UINT64 trig_data0 {0xbad};
+    UINT64 trig_data1 {0xbad};
+    std::vector<uint16_t> trig_data(8,0xbad);
+    nevisPCIeCard->readAddr64 ( dma_detail::t2_tr_bar, 0x0, trig_data0 );
+    trig_data1 = trig_data0;
+    nevisPCIeCard->readAddr64 ( dma_detail::t2_tr_bar, 0x0, trig_data1 );
+          
+    _trig_ctr = (trig_data0 >> 40);
+    _trig_frame = ( ( ( (trig_data0 >> 32) & 0xff )<<16 ) + ( (trig_data0 >> 16) & 0xffff ) );
+    _trig_sample = ( (trig_data0 >> 4) & 0xfff );
+    _trig_sample_remain_16MHz = ( (trig_data0 >> 1) & 0x7 );
+    _trig_sample_remain_64MHz = ( (trig_data1 >> 15) & 0x3 );
+
+    std::ostringstream msg;
+    msg << "[ NEW TRIGGER ]"
+	<< " "
+	<< " Trig: "   << _trig_ctr
+	<< " Frame: "  << _trig_frame
+	<< " Sample: " << _trig_sample
+	<< " Remine (16MHz): " << _trig_sample_remain_16MHz
+	<< " Remine (64MHz): " << _trig_sample_remain_64MHz
+	<< " "
+	<< " Bits: ";
+
+    if((trig_data1>>8) & 0x1) msg << " PC";
+    if((trig_data1>>9) & 0x1) msg << " EXT";
+    if((trig_data1>>12) & 0x1) msg << " Gate1";
+    if((trig_data1>>11) & 0x1) msg << " Gate2";
+    if((trig_data1>>10) & 0x1) msg << " Active";
+    if((trig_data1>>13) & 0x1) msg << " Veto";
+    if((trig_data1>>14) & 0x1) msg << " Calib";
+    if(trig_data1>>32 != 0xffffffff) {
+     std::ostringstream errmsg;
+      errmsg << "Trigger data ctr (local):  " << trig_data_ctr << "\n";
+
+      errmsg << "Trigger data 0: " << trig_data0 << "\n"
+	     << "Trigger data 1: " << trig_data1 << "\n";
+      //      mf::LogError( _stream_name ) << errmsg.str();
+      TLOG(TLVL_WARN) << "Invalid trigger data format" ;
+      throw RuntimeErrorException("Invalid trigger data format!");
+
+    }
+
+    msg << " PMT data: 0x"
+	<< (trig_data1 & 0xff);
+    //  mf::LogDebug ( _stream_name ) << msg.str();
+    TLOG(TLVL_DEBUG) << "PMT triggered data words" << _stream_name << msg.str() ;   
+    trig_data[0] = ((trig_data0      ) & 0xffff); 
+    trig_data[1] = ((trig_data0 >> 16) & 0xffff); 
+    trig_data[2] = ((trig_data0 >> 32) & 0xffff);
+    trig_data[3] = ((trig_data0 >> 48) & 0xffff); 
+    trig_data[4] = ((trig_data1      ) & 0xffff); 
+    trig_data[5] = ((trig_data1 >> 16) & 0xffff); 
+    trig_data[6] = ((trig_data1 >> 32) & 0xffff); 
+    trig_data[7] = ((trig_data1 >> 48) & 0xffff); 
+    _trig_data_ctr -= 16;
+
+    readSize = sizeof(uint16_t)*trig_data.size();
+    TLOG(TLVL_DEBUG_5) << "Nevis TB data in bytes: " << readSize ;
+    memcpy (buffer, (char*)(&trig_data[0]),sizeof(uint16_t)*trig_data.size());
+    //    TLOG(TLVL_DEBUG_6) << "Size of Triggered data t "
+ 
+
+   //    if ( _reader_synch_object ) {
+   // _reader_synch_object->unlock();
+      //_reader_synch_object->finishedDMAingTriggerData();
+   //}
+    if(_do_timing) {
+      gettimeofday(&t2,NULL);
+      //std::cout << "Checkpoint 6: " << utils::diff_time_microseconds(t2,t1) << " us" << std::endl;
+      gettimeofday(&t1,NULL);
+    }
+
+    //return (sizeof(uint16_t)*trig_data.size());
+    return readSize;
+  }
+
+
+} //end nampespace

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/NevisTBStreamReader.h
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/NevisTBStreamReader.h
@@ -1,0 +1,55 @@
+#ifndef _NEVISTPC_NEVISTBSTREAMREADER_H
+#define _NEVISTPC_NEVISTBSTREAMREADER_H 1
+
+#include "NevisControllerPCIeCard.h"
+//#include "NevisPCIeCard.h"
+
+#include "fhiclcpp/ParameterSet.h"
+
+#include <iosfwd>
+#include <string>
+//#include "NevisTBStreamReaderSynchronization.h"
+
+namespace nevistpc{
+
+  void doNothing ( void );
+
+  class NevisTBStreamReader{
+  public:
+
+    explicit NevisTBStreamReader ( std::string const& streamName, fhicl::ParameterSet const & ps);
+    //: _nevistb_reader("nevistb_reader")  {}
+    void configureReader();
+
+    virtual std::streamsize readsome ( char* buffer, std::streamsize requestedSize );
+    //    void setReaderSynchronizationObject ( NevisTBStreamReaderSynchronizationObjectSPtr& mutex );
+
+    void initializePCIeCard();
+
+    void setupTXModeRegister();
+    virtual ~NevisTBStreamReader(){};
+  private:
+    const std::string _stream_name;
+    const fhicl::ParameterSet _params; // FHiCL parameter set
+    std::unique_ptr<DeviceInfo> nevisDeviceInfo;
+    NevisControllerPCIeCardUPtr nevisPCIeCard;
+
+    std::function<void ( void ) > _triggerCallFunction;
+    //NevisTBStreamReaderSynchronizationObjectSPtr _reader_synch_object;
+    //    NevisTBStreamReaderSynchronizationObjectSPtr reader_synch_object1;
+    bool _do_timing;
+    UINT64 _trig_data_ctr;
+    uint32_t _trig_ctr;
+    uint32_t _trig_frame;
+    uint32_t _trig_sample;
+    uint16_t _trig_sample_remain_16MHz;
+    uint16_t _trig_sample_remain_64MHz;
+  };
+
+  typedef std::shared_ptr<NevisTBStreamReader> NevisTBStreamReaderSPtr;
+  //NevisTBStreamReaderSPtr _nevistb_reader;
+
+
+
+}  // end of namespace nevistpc                                                                                                      
+#endif //_NEVISTPC_NEVISTBSTREAMREADER_H                                                                                                      


### PR DESCRIPTION
### Description
Summary of changes in sbndaq-artdaq
(1) Implemented a board reader and a generator base class to read out Nevis Trigger Board (NTB) Data, and added relevant libraries in CMakeLists.txt.
(2) Modified NevisTPC board reader to separate configure and start transition in TPC board reader.
(3) 


### Related Repository Branches
The changes made in sbndaq-artdaq are tested together with the changes made in sbndaq and sbndaq-artdaq-core repositories, the links to which are given below-
https://github.com/SBNSoftware/sbndaq-artdaq/compare/develop...feature/kalra_TPC_NTB_implementation
https://github.com/SBNSoftware/sbndaq/compare/develop...feature/kalra_TPC_NTB_implementation
https://github.com/SBNSoftware/sbndaq-artdaq-core/compare/develop...feature/kalra_TPC_NTB_implementation

### Testing details
The changes are tested running DAQ on sbnd-evb01, partition 9
- *Where it was tested*: (e.g. SBN-FD, SBN-ND, DAB, etc.)
- Run number - 6871 (/scratch/data/daisy/)
