### PR TITLE
Fix ability to specify firmware flag for expected data size

### DIFF
--- a/sbndaq-artdaq/Generators/Common/BernCRTData_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/BernCRTData_generator.cc
@@ -220,7 +220,7 @@ size_t sbndaq::BernCRTData::GetFEBData() {
     
     while(true) {
       //loop over hits received via ethernet and push into circular buffer
-      int numbytes = febdrv.GetData();
+      int numbytes = febdrv.GetData(FirmwareFlag);
       if(numbytes<=0) break;
       
       int datalen = numbytes-18;

--- a/sbndaq-artdaq/Generators/Common/CMakeLists.txt
+++ b/sbndaq-artdaq/Generators/Common/CMakeLists.txt
@@ -98,6 +98,7 @@ cet_make_library(
   SOURCE
     febdrv.cc
   LIBRARIES
+    artdaq_DAQdata
     sbndaq_artdaq_core::sbndaq-artdaq-core_Overlays_Common
     fhiclcpp
     cetlib_except

--- a/sbndaq-artdaq/Generators/Common/febdrv.cc
+++ b/sbndaq-artdaq/Generators/Common/febdrv.cc
@@ -14,6 +14,7 @@
 #include <sys/socket.h>
 #include <net/if.h>
 #include <netinet/ether.h>
+#include "artdaq/DAQdata/Globals.hh"
 
 #include <functional>
 
@@ -517,7 +518,7 @@ void sbndaq::FEBDRV::processSingleHit(int & jj, sbndaq::BernCRTHitV2 & hit, Firm
   //AA: The CAEN manual says all 30 bits of the timestamp are
   //    encoded in Gray Code. This is apparently not true.
   //IK: Two LSBs of the time stamp are indeed coded normal binary, not Gray
-  
+
   uint8_t ls2b0=ts0 & 0x00000003;
   uint8_t ls2b1=ts1 & 0x00000003;
   uint32_t tt0=(ts0 & 0x3fffffff) >> 2;
@@ -542,7 +543,7 @@ void sbndaq::FEBDRV::processSingleHit(int & jj, sbndaq::BernCRTHitV2 & hit, Firm
   if(!NOts1)    hit.flags |= 2;
   if(REFEVTts0) hit.flags |= 4; //bit indicating TS0 reference hit
   if(REFEVTts1) hit.flags |= 8; //bit indicating TS1 reference hit
-  
+
   for(int kk=0; kk<32; kk++) {
     auto adc_ptr = reinterpret_cast<uint16_t*>(&(rpkt).Data[jj]);
     hit.adc[kk] = *adc_ptr;
@@ -558,7 +559,7 @@ void sbndaq::FEBDRV::processSingleHit(int & jj, sbndaq::BernCRTHitV2 & hit, Firm
 
 }
 
-int sbndaq::FEBDRV::GetData() {
+int sbndaq::FEBDRV::GetData(FirmwareVersion firmwareFlag = ICARUS) {
   /**
    * Read another portion of data from FEB
    * Returns number of bytes read, and 0 or -1 if there is no more data
@@ -581,7 +582,7 @@ int sbndaq::FEBDRV::GetData() {
     return -1;
   }
   
-  const int hit_size = 80; //size of data received from FEB
+  const int hit_size = (firmwareFlag == SBND) ? 76 : 80; //size of data received from FEB
   if(numbytes % hit_size != 18) {
     TLOG(TLVL_ERROR)<<"Size of data: "<<(numbytes - 18)<<" received from FEB is not a multiple of "<<std::to_string(hit_size);
   }

--- a/sbndaq-artdaq/Generators/Common/febdrv.hh
+++ b/sbndaq-artdaq/Generators/Common/febdrv.hh
@@ -105,7 +105,7 @@ namespace sbndaq {
     bool sendconfig(uint8_t mac5, uint8_t * bufSCR, uint16_t lenSCR, uint8_t * bufPMR, uint16_t lenPMR);
 
     void processSingleHit(int & jj, sbndaq::BernCRTHitV2& hit, FirmwareVersion firmwareFlag);
-    int GetData();
+    int GetData(FirmwareVersion firmwareFlag);
 
     void pollfeb(uint8_t mac);
     


### PR DESCRIPTION
### Description

Couple of quick updates added while I was working on the CRT firmware. Firstly, this adds the globals header so that TLOG messages are printed to the message viewer / logs. Secondly, the whole point of having the firmware flag is so that we get a message if the size of the data chunks is wrong. This enforces this properly.

### Testing details
Tested at SBN-ND using the CRT Flat. Presentations on the CRT firmware used this setup (e.g. [this one](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=32405)).