### PR TITLE
Migrate metric reporting levels to allow finer-grained customization …

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCCard.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCCard.cc
@@ -184,8 +184,8 @@ bool TDCCard::start() {
     if (!chan.start()) ++error_count;
 
   if (metricMan) {
-    metricMan->sendMetric(lit::monitor_wr_synced, uint8_t{0}, lit::unit_bool, 1, MetricMode::LastPoint);
-    metricMan->sendMetric(lit::monitor_temperature, float{0}, lit::unit_temperature, 1, MetricMode::Average);
+    metricMan->sendMetric(lit::monitor_wr_synced, uint8_t{0}, lit::unit_bool, 11, MetricMode::LastPoint);
+    metricMan->sendMetric(lit::monitor_temperature, float{0}, lit::unit_temperature, 11, MetricMode::Average);
   }
   TLOG(TLVL_DEBUG_4) << "Started TDC device id=0x" << std::hex << deviceid << ".";
   return 0 == error_count;
@@ -249,8 +249,8 @@ void TDCCard::reportTimeTemp() {
   }
 
   if (metricMan) {
-    metricMan->sendMetric(lit::monitor_wr_synced, uint8_t{status == 0}, lit::unit_bool, 1, MetricMode::LastPoint);
-    metricMan->sendMetric(lit::monitor_temperature, float{temperature}, lit::unit_temperature, 1, MetricMode::Average);
+    metricMan->sendMetric(lit::monitor_wr_synced, uint8_t{status == 0}, lit::unit_bool, 11, MetricMode::LastPoint);
+    metricMan->sendMetric(lit::monitor_temperature, float{temperature}, lit::unit_temperature, 11, MetricMode::Average);
   }
 }
 

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -91,24 +91,24 @@ bool TDCChan::configure() {
 bool TDCChan::start() {
   TLOG(TLVL_DEBUG_4) << "Starting channel=" << int{id} << ".";
   if (metricMan) {
-    metricMan->sendMetric(metric_prefix + lit::tdc_laggy_samples, uint64_t{0}, lit::unit_samples_per_second, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_laggy_samples, uint64_t{0}, lit::unit_samples_per_second, 11,
                           MetricMode::Rate);
-    metricMan->sendMetric(metric_prefix + lit::tdc_sample_time_lag, uint64_t{0}, lit::unit_nanoseconds, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_sample_time_lag, uint64_t{0}, lit::unit_nanoseconds, 11,
                           MetricMode::Average);
-    metricMan->sendMetric(metric_prefix + lit::tdc_sequence_gap, uint64_t{0}, lit::unit_sample_count, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_sequence_gap, uint64_t{0}, lit::unit_sample_count, 11,
                           MetricMode::Accumulate);
-    metricMan->sendMetric(metric_prefix + lit::tdc_sample_rate, uint64_t{0}, lit::unit_samples_per_second, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_sample_rate, uint64_t{0}, lit::unit_samples_per_second, 11,
                           MetricMode::Rate);
-    metricMan->sendMetric(metric_prefix + lit::tdc_bytes_read, uint64_t{0}, lit::unit_bytes, 1, MetricMode::LastPoint);
-    metricMan->sendMetric(metric_prefix + lit::tdc_read_count, uint64_t{0}, lit::unit_sample_count, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_bytes_read, uint64_t{0}, lit::unit_bytes, 11, MetricMode::LastPoint);
+    metricMan->sendMetric(metric_prefix + lit::tdc_read_count, uint64_t{0}, lit::unit_sample_count, 11,
                           MetricMode::LastPoint);
-    metricMan->sendMetric(metric_prefix + lit::tdc_drain_count, uint64_t{0}, lit::unit_sample_count, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_drain_count, uint64_t{0}, lit::unit_sample_count, 11,
                           MetricMode::LastPoint);
-    metricMan->sendMetric(metric_prefix + lit::tdc_missed_count, uint64_t{0}, lit::unit_sample_count, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_missed_count, uint64_t{0}, lit::unit_sample_count, 11,
                           MetricMode::LastPoint);
-    metricMan->sendMetric(metric_prefix + lit::tdc_dropped_count, uint64_t{0}, lit::unit_sample_count, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_dropped_count, uint64_t{0}, lit::unit_sample_count, 11,
                           MetricMode::LastPoint);
-    metricMan->sendMetric(metric_prefix + lit::tdc_last_sequence, uint64_t{0}, lit::unit_sample_count, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_last_sequence, uint64_t{0}, lit::unit_sample_count, 11
                           MetricMode::LastPoint);
   }
   for (auto task : starttasks)
@@ -131,7 +131,7 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns) const {
   auto lag_ns = utls::elapsed_time_ns(timestamp_ns);
 
   if (metricMan) {
-    metricMan->sendMetric(metric_prefix + lit::tdc_sample_time_lag, lag_ns, lit::unit_nanoseconds, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_sample_time_lag, lag_ns, lit::unit_nanoseconds, 11,
                           MetricMode::Average);
   }
   if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
@@ -144,7 +144,7 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns) const {
     TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing system; host_time-sample_time="
                     << lag_ns / utls::onesecond_ns << " seconds.";
     if (metricMan) {
-      metricMan->sendMetric(metric_prefix + lit::tdc_laggy_samples, uint64_t{1}, lit::unit_samples_per_second, 1,
+      metricMan->sendMetric(metric_prefix + lit::tdc_laggy_samples, uint64_t{1}, lit::unit_samples_per_second, 11,
                             MetricMode::Rate);
     }
   }
@@ -154,17 +154,17 @@ void TDCChan::monitor() {
   if (!enabled) return;
 
   if (metricMan) {
-    metricMan->sendMetric(metric_prefix + lit::tdc_bytes_read, uint64_t{bytes_read}, lit::unit_bytes, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_bytes_read, uint64_t{bytes_read}, lit::unit_bytes, 11,
                           MetricMode::LastPoint);
-    metricMan->sendMetric(metric_prefix + lit::tdc_read_count, uint64_t{sample_read_count}, lit::unit_sample_count, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_read_count, uint64_t{sample_read_count}, lit::unit_sample_count, 11,
                           MetricMode::LastPoint);
-    metricMan->sendMetric(metric_prefix + lit::tdc_drain_count, uint64_t{sample_drain_count}, lit::unit_sample_count, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_drain_count, uint64_t{sample_drain_count}, lit::unit_sample_count, 11,
                           MetricMode::LastPoint);
     metricMan->sendMetric(metric_prefix + lit::tdc_missed_count, uint64_t{missed_sample_count}, lit::unit_sample_count,
-                          1, MetricMode::LastPoint);
+                          11, MetricMode::LastPoint);
     metricMan->sendMetric(metric_prefix + lit::tdc_dropped_count, uint64_t{sample_drop_count}, lit::unit_sample_count,
-                          1, MetricMode::LastPoint);
+                          11, MetricMode::LastPoint);
     metricMan->sendMetric(metric_prefix + lit::tdc_last_sequence, uint64_t{last_seen_sample_seq},
-                          lit::unit_sample_count, 1, MetricMode::LastPoint);
+                          lit::unit_sample_count, 11, MetricMode::LastPoint);
   }
 }

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
@@ -85,7 +85,7 @@ void TDCChan::read() {
       TLOG(TLVL_WARNING) << "Detected a gap in the channel " << int{id}
                          << " sample sequence; last_seen_sample_seq/gap=" << last_seen_sample_seq << "/" << gap;
       if (metricMan) {
-        metricMan->sendMetric(metric_prefix + lit::tdc_sequence_gap, gap, lit::unit_sample_count, 1,
+        metricMan->sendMetric(metric_prefix + lit::tdc_sequence_gap, gap, lit::unit_sample_count, 11,
                               MetricMode::Accumulate);
       }
     }
@@ -93,7 +93,7 @@ void TDCChan::read() {
   }
 
   if (metricMan) {
-    metricMan->sendMetric(metric_prefix + lit::tdc_sample_rate, uint64_t(read_count), lit::unit_samples_per_second, 1,
+    metricMan->sendMetric(metric_prefix + lit::tdc_sample_rate, uint64_t(read_count), lit::unit_samples_per_second, 11,
                           MetricMode::Rate);
   }
   bytes_read += read_count * sizeof(fmctdc_time);

--- a/sbndaq-artdaq/Generators/SBND/SPECTDCTimestampReader_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDCTimestampReader_generator.cc
@@ -135,8 +135,8 @@ bool SPECTDCTimestampReader::getNext_(artdaq::FragmentPtrs& fragments) {
     ss << ", create_time=" << std::setw(5) << create_time_ms << " ms, " << last_frag_ovl;
     TLOG(TLVL_DEBUG_11) << ss.str().c_str();
     if (metricMan) {
-      metricMan->sendMetric("Fragments Sent", 1, "Events", 1, MetricMode::Rate);
-      metricMan->sendMetric("Fragment Create Time", create_time_ms, "ms", 1, MetricMode::Average | MetricMode::Maximum);
+      metricMan->sendMetric("Fragments Sent", 1, "Events", 11, MetricMode::Rate);
+      metricMan->sendMetric("Fragment Create Time", create_time_ms, "ms", 11, MetricMode::Average | MetricMode::Maximum);
     }
     if (0 != events_to_generate_ && ev_counter() > events_to_generate_) {
       requestStop();
@@ -156,11 +156,11 @@ bool SPECTDCTimestampReader::getNext_(artdaq::FragmentPtrs& fragments) {
 
   if (metricMan) {
     if (next_status_report_time_us_ < utls::hosttime_us()) {
-      metricMan->sendMetric("PoolBuffer Free Block Count", buffer_->freeBlockCount(), "Samples", 1,
+      metricMan->sendMetric("PoolBuffer Free Block Count", buffer_->freeBlockCount(), "Samples", 11,
                             MetricMode::LastPoint);
-      metricMan->sendMetric("PoolBuffer Fully Drained Count", buffer_->fullyDrainedCount(), "Times", 1,
+      metricMan->sendMetric("PoolBuffer Fully Drained Count", buffer_->fullyDrainedCount(), "Times", 11,
                             MetricMode::LastPoint);
-      metricMan->sendMetric("PoolBuffer Low Watermark", buffer_->lowWaterMark(), "Samples", 1, MetricMode::LastPoint);
+      metricMan->sendMetric("PoolBuffer Low Watermark", buffer_->lowWaterMark(), "Samples", 11, MetricMode::LastPoint);
       next_status_report_time_us_ = utls::hosttime_us() + 5 * utls::onesecond_us;
     }
   }


### PR DESCRIPTION

Migrating metric levels from 1 to 11 to allow for the separation of sbndaq metric levels from those used by artdaq. All sbndaq configuration files need to be migrated, where the `level` option in `metrics.graphite` should be replaced with the `level_string` setting, e.g., `level_string: "1,2,11-20".`
While this change is straightforward, it requires further testing at SBND.
```
metrics: {

brFile: {

metricPluginType: "file"
#A string containing a comma-separated list of levels to enable. Ranges are supported.
level_string: "1,2,11-20"

fileName: "/scratch/log/br_%UID%_metrics.log"

uniquify: true

}
send_system_metrics: true

send_process_metrics: true

graphite: {

namespace: "sbnd.sbndpmt00."

host: "10.226.36.34"
#A string containing a comma-separated list of levels to enable. Ranges are supported.
level_string: "1,2,11-20"

metricPluginType: "graphite"

port: 2003

reporting_interval: 10

}
```