### PR TITLE
Migrate metric reporting levels to allow finer-grained customization …

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
@@ -179,8 +179,8 @@ bool sbndaq::TriggerBoardReader::getNext_(artdaq::FragmentPtrs & frags) {
   TLOG( 20, "TriggerBoardReader") << "Sending " << frags.size() <<  " fragments" << std::endl ;
 
   if( artdaq::Globals::metricMan_ ) {
-    artdaq::Globals::metricMan_->sendMetric("PTB_Fragments_Sent", (double) frags.size(), "Fragments", 0, artdaq::MetricMode::Average) ;
-    artdaq::Globals::metricMan_->sendMetric("PTB_Bytes_Sent",     (double) sent_bytes,   "Bytes",     0, artdaq::MetricMode::Average) ;
+    artdaq::Globals::metricMan_->sendMetric("PTB_Fragments_Sent", (double) frags.size(), "Fragments", 11, artdaq::MetricMode::Average) ;
+    artdaq::Globals::metricMan_->sendMetric("PTB_Bytes_Sent",     (double) sent_bytes,   "Bytes",     11, artdaq::MetricMode::Average) ;
   }
 
   return ! _error_state.load() ;
@@ -234,10 +234,10 @@ artdaq::Fragment* sbndaq::TriggerBoardReader::CreateFragment() {
 	  // publish the dedicated metrics
 	  if ( artdaq::Globals::metricMan_ ) {
 	    
-	    artdaq::Globals::metricMan_->sendMetric("PTB_Spill_H0L0", (double) _metric_spill_h0l0_counter, "Particles", 0, artdaq::MetricMode::Accumulate ) ;
-	    artdaq::Globals::metricMan_->sendMetric("PTB_Spill_H0L1", (double) _metric_spill_h0l1_counter, "Particles", 0, artdaq::MetricMode::Accumulate ) ;
-	    artdaq::Globals::metricMan_->sendMetric("PTB_Spill_H1L0", (double) _metric_spill_h1l0_counter, "Particles", 0, artdaq::MetricMode::Accumulate ) ;
-	    artdaq::Globals::metricMan_->sendMetric("PTB_Spill_H1L1", (double) _metric_spill_h1l1_counter, "Particles", 0, artdaq::MetricMode::Accumulate ) ;
+	    artdaq::Globals::metricMan_->sendMetric("PTB_Spill_H0L0", (double) _metric_spill_h0l0_counter, "Particles", 11, artdaq::MetricMode::Accumulate ) ;
+	    artdaq::Globals::metricMan_->sendMetric("PTB_Spill_H0L1", (double) _metric_spill_h0l1_counter, "Particles", 11, artdaq::MetricMode::Accumulate ) ;
+	    artdaq::Globals::metricMan_->sendMetric("PTB_Spill_H1L0", (double) _metric_spill_h1l0_counter, "Particles", 11, artdaq::MetricMode::Accumulate ) ;
+	    artdaq::Globals::metricMan_->sendMetric("PTB_Spill_H1L1", (double) _metric_spill_h1l1_counter, "Particles", 11, artdaq::MetricMode::Accumulate ) ;
 	    
 	  } // if there is a metric manager      
 	  
@@ -280,21 +280,21 @@ artdaq::Fragment* sbndaq::TriggerBoardReader::CreateFragment() {
 	  double cs_rate   = _metric_CS_counter  * TriggerBoardReader::PTB_Clock() / _metric_TS_max / _rollover ;
 
 	  // publish metrics
-	  artdaq::Globals::metricMan_->sendMetric("PTB_Word_rate", word_rate, "Hz", 0, artdaq::MetricMode::Average) ;
+	  artdaq::Globals::metricMan_->sendMetric("PTB_Word_rate", word_rate, "Hz", 11, artdaq::MetricMode::Average) ;
 
-	  artdaq::Globals::metricMan_->sendMetric("PTB_HLT_rate", hlt_rate, "Hz", 0, artdaq::MetricMode::Average) ;
-	  artdaq::Globals::metricMan_->sendMetric("PTB_LLT_rate", llt_rate, "Hz", 0, artdaq::MetricMode::Average) ;
+	  artdaq::Globals::metricMan_->sendMetric("PTB_HLT_rate", hlt_rate, "Hz", 11, artdaq::MetricMode::Average) ;
+	  artdaq::Globals::metricMan_->sendMetric("PTB_LLT_rate", llt_rate, "Hz", 11, artdaq::MetricMode::Average) ;
 
-	  artdaq::Globals::metricMan_->sendMetric("PTB_Beam_Trig_rate", beam_rate, "Hz", 0, artdaq::MetricMode::Average) ;
-	  artdaq::Globals::metricMan_->sendMetric("PTB_Good_Part_rate", good_part_rate, "Hz", 0, artdaq::MetricMode::Average) ;
+	  artdaq::Globals::metricMan_->sendMetric("PTB_Beam_Trig_rate", beam_rate, "Hz", 11, artdaq::MetricMode::Average) ;
+	  artdaq::Globals::metricMan_->sendMetric("PTB_Good_Part_rate", good_part_rate, "Hz", 11, artdaq::MetricMode::Average) ;
 
-	  artdaq::Globals::metricMan_->sendMetric("PTB_Beam_Eff", beam_eff, "ratio", 0, artdaq::MetricMode::Average) ;
+	  artdaq::Globals::metricMan_->sendMetric("PTB_Beam_Eff", beam_eff, "ratio", 11, artdaq::MetricMode::Average) ;
 
-	  artdaq::Globals::metricMan_->sendMetric("PTB_CS_rate",  cs_rate,  "Hz", 0, artdaq::MetricMode::Average) ;
+	  artdaq::Globals::metricMan_->sendMetric("PTB_CS_rate",  cs_rate,  "Hz", 11, artdaq::MetricMode::Average) ;
 
 	  for ( unsigned short i = 0 ; i < _metric_HLT_names.size() ; ++i ) {
 	    double temp_rate = _metric_HLT_counters[i] * TriggerBoardReader::PTB_Clock() / _metric_TS_max / _rollover ;
-	    artdaq::Globals::metricMan_->sendMetric( _metric_HLT_names[i], temp_rate,  "Hz", 0, artdaq::MetricMode::Average) ;
+	    artdaq::Globals::metricMan_->sendMetric( _metric_HLT_names[i], temp_rate,  "Hz", 11, artdaq::MetricMode::Average) ;
 	  }
 
 


### PR DESCRIPTION
Migrating metric levels from 1 to 11 to allow for the separation of sbndaq metric levels from those used by artdaq. All sbndaq configuration files need to be migrated, where the `level` option in `metrics.graphite` should be replaced with the `level_string` setting, e.g., `level_string: "1,2,11-20".`
While this change is straightforward, it requires further testing at SBND.
```
metrics: {

brFile: {

metricPluginType: "file"
#A string containing a comma-separated list of levels to enable. Ranges are supported.
level_string: "1,2,11-20"

fileName: "/scratch/log/br_%UID%_metrics.log"

uniquify: true

}
send_system_metrics: true

send_process_metrics: true

graphite: {

namespace: "sbnd.sbndpmt00."

host: "10.226.36.34"
#A string containing a comma-separated list of levels to enable. Ranges are supported.
level_string: "1,2,11-20"

metricPluginType: "graphite"

port: 2003

reporting_interval: 10

}
```