### PR TITLE
CAENV1730 Metadata Update and CAENV1730 Generator Timestamp Update

### DIFF
--- a/sbndaq-artdaq/ArtModules/Common/CAENV1730Dump_module.cc
+++ b/sbndaq-artdaq/ArtModules/Common/CAENV1730Dump_module.cc
@@ -69,6 +69,7 @@ private:
 
   //--default values
   uint32_t nChannels;//    = 16;
+  uint32_t postTrigger;
   uint32_t Ttt_DownSamp;// =  4; 
  /* the trigger time resolution is 16ns when waveforms are sampled at
                                * 500MHz sampling. The trigger timestamp is
@@ -203,8 +204,10 @@ void sbndaq::CAENV1730Dump::analyze_caen_fragment(artdaq::Fragment & frag)  {
     hEventCounter->Fill(header.eventCounter);
     hTriggerTimeTag->Fill(t0);
     nt_header->Fill(fEvent,header.eventCounter,t0);
-    nChannels = md->nChannels;
+    nChannels = md->nChannels();
+    postTrigger = md->getPostTrigger();
     std::cout << "\tNumber of channels: " << nChannels << "\n";
+    std::cout << "\tPost Trigger Percent: " << postTrigger << "\n";
     
     //--get the number of 32-bit words (quad_bytes) from the header
     uint32_t ev_size_quad_bytes = header.eventSize;

--- a/sbndaq-artdaq/ArtModules/Common/CAENV1730WaveformAna_module.cc
+++ b/sbndaq-artdaq/ArtModules/Common/CAENV1730WaveformAna_module.cc
@@ -100,7 +100,7 @@ void sbndaq::CAENV1730WaveformAna::analyze(art::Event const & evt)
     //get the number of 32-bit words from the header
     size_t const& ev_size(header.eventSize);
     
-    size_t nChannels = md->nChannels; //fixme
+    size_t nChannels = md->nChannels(); //fixme
     fWvfmsVec.resize(nChannels);
     
     //use that to get the number of 16-bit words for each channel

--- a/sbndaq-artdaq/ArtModules/Common/EventAna_module.cc
+++ b/sbndaq-artdaq/ArtModules/Common/EventAna_module.cc
@@ -153,6 +153,7 @@ private:
 
   //--default values
   uint32_t nChannels;//    = 16;
+  uint32_t postTrigger;
   uint32_t Ttt_DownSamp;// =  4;
  /* the waveforms are sampled at 500MHz sampling. The trigger timestamp is
                                * sampled 4 times slower than input channels*/
@@ -926,8 +927,10 @@ void sbndaq::EventAna::analyze_caen_fragment(artdaq::Fragment & frag)  {
   hEventCounter->Fill(header.eventCounter);
   hTriggerTimeTag->Fill((int)t0);
   nt_header->Fill(fEvent,header.eventCounter,t0);
-  nChannels = md->nChannels;
+  nChannels = md->nChannels();
+  postTrigger = md->getPostTrigger();
   if (fverbose)       std::cout << "\tNumber of channels: " << nChannels << "\n";
+  if (fverbose)       std::cout << "\tPost Trigger Percent: " << postTrigger << "\n";
 
   //--get the number of 32-bit words (quad_bytes) from the header
   uint32_t ev_size_quad_bytes = header.eventSize;

--- a/sbndaq-artdaq/ArtModules/Common/MultiDump_module.cc
+++ b/sbndaq-artdaq/ArtModules/Common/MultiDump_module.cc
@@ -538,7 +538,7 @@ void sbndaq::MultiDump::analyze_caen_fragment(artdaq::Fragment & frag)  {
   hEventCounter->Fill(header.eventCounter);
   hTriggerTimeTag->Fill((int)t0);
   nt_header->Fill(fEvent,header.eventCounter,t0);
-  nChannels = md->nChannels;
+  nChannels = md->nChannels();
   if (fverbose)       std::cout << "\tNumber of channels: " << nChannels << "\n";
 
   //--get the number of 32-bit words (quad_bytes) from the header

--- a/sbndaq-artdaq/ArtModules/SBND/CRTHitAna_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/CRTHitAna_module.cc
@@ -942,7 +942,7 @@ void sbndaq::CRTHitAna::analyze_caen_fragment(artdaq::Fragment & frag)  {
   hEventCounter->Fill(header.eventCounter);
   hTriggerTimeTag->Fill((int)t0);
   nt_header->Fill(fEvent,header.eventCounter,t0);
-  nChannels = md->nChannels;
+  nChannels = md->nChannels();
   if (fverbose)       std::cout << "\tNumber of channels: " << nChannels << "\n";
   
   //--get the number of 32-bit words (quad_bytes) from the header

--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -430,7 +430,7 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::find_beam_spill(const artdaq::Fr
   sbndaq::CAENV1730Event const* event_ptr = bb.Event();
   sbndaq::CAENV1730EventHeader header = event_ptr->Header;
   // - not used-  seqID = static_cast<int>(frag.sequenceID());
-  size_t nChannels = md->nChannels;
+  size_t nChannels = md->nChannels();
   //  if (fVerbose) std::cout << "\tNumber of channels: " << nChannels << "\n";
   //  if (fVerbose) std::cout << "Timestamp in metadata is " << md->timeStampNSec<<std::endl;
 
@@ -503,7 +503,7 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::analyzeCAEN1730Fragment(const ar
   std::map<int,int>::iterator it = map_fragid_index.find(fragId);
   int findex = it->second;
 
-  size_t nChannels = md->nChannels;
+  size_t nChannels = md->nChannels();
   if (fVerbose) std::cout << "\tNumber of channels: " << nChannels << "\n";
 
   uint32_t ev_size_quad_bytes = header.eventSize;

--- a/sbndaq-artdaq/ArtModules/SBND/testStandTrigger/testStandTriggerProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/testStandTrigger/testStandTriggerProducer_module.cc
@@ -217,7 +217,7 @@ void sbndaq::testStandTriggerProducer::analyze_caen_fragment(artdaq::Fragment & 
   TTT_ns = t0*8;
   if (fVerbose)       std::cout << "\n\tTriggerTimeTag in ns is " << TTT_ns << "\n";  // 500 MHz is 2 ns per tick
 
-  nChannels = md->nChannels;
+  nChannels = md->nChannels();
   if (fVerbose)       std::cout << "\tNumber of channels: " << nChannels << "\n";
   
   //--get the number of 32-bit words (quad_bytes) from the header

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -200,6 +200,7 @@ namespace sbndaq
     bool fOutputClkPhase;
 
     bool fUseTimeTagForTimeStamp;
+    bool fUseTimeTagShiftForTimeStamp;
     uint32_t fTimeOffsetNanoSec;
 
     // Animesh & Aiwu add fhicl parameters - LVDS logic

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -321,6 +321,9 @@ void sbndaq::CAENV1730Readout::loadConfiguration(fhicl::ParameterSet const& ps)
 
   fUseTimeTagForTimeStamp = ps.get<bool>("UseTimeTagForTimeStamp",true);
   TLOG(TINFO) <<"fUseTimeTagForTimeStamp=" << fUseTimeTagForTimeStamp;
+  
+  fUseTimeTagShiftForTimeStamp = ps.get<bool>("UseTimeTagShiftForTimeStamp",false);
+  TLOG(TINFO) <<"fUseTimeTagShiftForTimeStamp=" << fUseTimeTagShiftForTimeStamp;
 
   fTimeOffsetNanoSec = ps.get<uint32_t>("TimeOffsetNanoSec",0); //0ms by default
   TLOG(TINFO) <<"fTimeOffsetNanoSec=" << fTimeOffsetNanoSec;
@@ -1552,6 +1555,17 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 	- (fTTT_ns - (long)fMeanPollTimeNS >  500000000) * 1000000000
 	- fTimeOffsetNanoSec;
     }
+    else if(fUseTimeTagShiftForTimeStamp){
+      fTTT = uint32_t{header->triggerTimeTag}; // 
+      fTTT_ns = fTTT*8 - fCAEN.recordLength * fCAEN.postPercent * 2;
+      
+      // Scheme borrowed from what Antoni developed for CRT.
+      // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783
+      fTS = fMeanPollTime - fMeanPollTimeNS + fTTT_ns
+	+ (fTTT_ns - (long)fMeanPollTimeNS < -500000000) * 1000000000
+	- (fTTT_ns - (long)fMeanPollTimeNS >  500000000) * 1000000000
+	- fTimeOffsetNanoSec;
+    }
     else{
       fTS = fTimeDiffPollEnd.total_nanoseconds() - fTimeOffsetNanoSec;;
     }
@@ -1639,7 +1653,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
   double min_fragment_create_time = 10000.0;
   struct timespec now;
   clock_gettime(CLOCK_REALTIME,&now);
-  const auto metadata = CAENV1730FragmentMetadata(fNChannels,fCAEN.recordLength,now.tv_sec,now.tv_nsec,ch_temps);
+  const auto metadata = CAENV1730FragmentMetadata(fNChannels,fCAEN.recordLength,now.tv_sec,now.tv_nsec,fCAEN.postPercent,ch_temps);
   const auto fragment_datasize_bytes = metadata.ExpectedDataSize();
   TLOG(TMAKEFRAG)<< "Created CAENV1730FragmentMetadata with expected data size of "
                  << fragment_datasize_bytes << " bytes.";
@@ -1728,6 +1742,22 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 	TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
 	
 	ts_frag = (t_truetriggertime*8); //in 1ns ticks
+      }
+      else if(fUseTimeTagShiftForTimeStamp){
+	const auto TTT = uint32_t {header->triggerTimeTag};
+	
+	using namespace boost::gregorian;
+	using namespace boost::posix_time;
+	
+	ptime t_now(second_clock::universal_time());
+	ptime time_t_epoch(date(1970,1,1));
+	time_duration diff = t_now - time_t_epoch;
+	uint32_t t_offset_s = diff.total_seconds();
+	uint64_t t_offset_ticks = diff.total_seconds()*125000000; //in 8ns ticks
+	uint64_t t_truetriggertime = t_offset_ticks + TTT;
+	TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
+	
+	ts_frag = (t_truetriggertime*8) - fCAEN.recordLength * fCAEN.postPercent * 2; //in 1ns ticks
       }
       else{
 	using namespace boost::gregorian;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1557,7 +1557,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     }
     else if(fUseTimeTagShiftForTimeStamp){
       fTTT = uint32_t{header->triggerTimeTag}; // 
-      fTTT_ns = fTTT*8 - fCAEN.recordLength * fCAEN.postPercent * 2;
+      fTTT_ns = fTTT*8 - fCAEN.recordLength * fCAEN.postPercent / 100 * 2;
       
       // Scheme borrowed from what Antoni developed for CRT.
       // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783
@@ -1757,7 +1757,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 	uint64_t t_truetriggertime = t_offset_ticks + TTT;
 	TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
 	
-	ts_frag = (t_truetriggertime*8) - fCAEN.recordLength * fCAEN.postPercent * 2; //in 1ns ticks
+	ts_frag = (t_truetriggertime*8) - fCAEN.recordLength * fCAEN.postPercent / 100 * 2; //in 1ns ticks
       }
       else{
 	using namespace boost::gregorian;


### PR DESCRIPTION
### Description

Update CAENV1730 Generator:
- Store new CAENV1730 Metadata format
- New fcl parameter for new fragment timestamp creation

Update on some analysis modules to handle new CAENV1730 Metadata format

### Related Repository Branches
[sbndaq-artdaq-core#91](https://github.com/SBNSoftware/sbndaq-artdaq-core/pull/91)

### Testing details
_(Note: edit as appropriate.)_
- *Where it was tested*: SBN-ND
- *Run number associated with test*: run 9405, 9676, 9677 on sbnd-evb03 
- Other information: Details of test is described in [SBN-doc-33612](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=33612)
