### PR TITLE
CAENV1730 new timestamp

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -200,6 +200,7 @@ namespace sbndaq
     bool fOutputClkPhase;
 
     bool fUseTimeTagForTimeStamp;
+    bool fUseTimeTagShiftForTimeStamp;
     uint32_t fTimeOffsetNanoSec;
 
     // Animesh & Aiwu add fhicl parameters - LVDS logic

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1546,7 +1546,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 
     if(fUseTimeTagForTimeStamp){
       fTTT = uint32_t{header->triggerTimeTag}; // 
-      fTTT_ns = fTTT*8;
+      fTTT_ns = fTTT*8.0;
       
       // Scheme borrowed from what Antoni developed for CRT.
       // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783
@@ -1557,7 +1557,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     }
     else if(fUseTimeTagShiftForTimeStamp){
       fTTT = uint32_t{header->triggerTimeTag}; // 
-      fTTT_ns = fTTT*8 - fCAEN.recordLength * fCAEN.postPercent / 100 * 2;
+      fTTT_ns = (fTTT*8) - ((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0);
       
       // Scheme borrowed from what Antoni developed for CRT.
       // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783
@@ -1757,7 +1757,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 	uint64_t t_truetriggertime = t_offset_ticks + TTT;
 	TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
 	
-	ts_frag = (t_truetriggertime*8) - fCAEN.recordLength * fCAEN.postPercent / 100 * 2; //in 1ns ticks
+	ts_frag = (t_truetriggertime*8) - ((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0); //in 1ns ticks
       }
       else{
 	using namespace boost::gregorian;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -321,6 +321,9 @@ void sbndaq::CAENV1730Readout::loadConfiguration(fhicl::ParameterSet const& ps)
 
   fUseTimeTagForTimeStamp = ps.get<bool>("UseTimeTagForTimeStamp",true);
   TLOG(TINFO) <<"fUseTimeTagForTimeStamp=" << fUseTimeTagForTimeStamp;
+  
+  fUseTimeTagShiftForTimeStamp = ps.get<bool>("UseTimeTagShiftForTimeStamp",false);
+  TLOG(TINFO) <<"fUseTimeTagShiftForTimeStamp=" << fUseTimeTagShiftForTimeStamp;
 
   fTimeOffsetNanoSec = ps.get<uint32_t>("TimeOffsetNanoSec",0); //0ms by default
   TLOG(TINFO) <<"fTimeOffsetNanoSec=" << fTimeOffsetNanoSec;
@@ -1552,6 +1555,17 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 	- (fTTT_ns - (long)fMeanPollTimeNS >  500000000) * 1000000000
 	- fTimeOffsetNanoSec;
     }
+    else if(fUseTimeTagShiftForTimeStamp){
+      fTTT = uint32_t{header->triggerTimeTag}; // 
+      fTTT_ns = fTTT*8 - fCAEN.recordLength * fCAEN.postPercent * 2;
+      
+      // Scheme borrowed from what Antoni developed for CRT.
+      // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783
+      fTS = fMeanPollTime - fMeanPollTimeNS + fTTT_ns
+	+ (fTTT_ns - (long)fMeanPollTimeNS < -500000000) * 1000000000
+	- (fTTT_ns - (long)fMeanPollTimeNS >  500000000) * 1000000000
+	- fTimeOffsetNanoSec;
+    }
     else{
       fTS = fTimeDiffPollEnd.total_nanoseconds() - fTimeOffsetNanoSec;;
     }
@@ -1639,7 +1653,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
   double min_fragment_create_time = 10000.0;
   struct timespec now;
   clock_gettime(CLOCK_REALTIME,&now);
-  const auto metadata = CAENV1730FragmentMetadata(fNChannels,fCAEN.recordLength,now.tv_sec,now.tv_nsec,ch_temps);
+  const auto metadata = CAENV1730FragmentMetadata(fNChannels,fCAEN.recordLength,now.tv_sec,now.tv_nsec,fCAEN.postPercent,ch_temps);
   const auto fragment_datasize_bytes = metadata.ExpectedDataSize();
   TLOG(TMAKEFRAG)<< "Created CAENV1730FragmentMetadata with expected data size of "
                  << fragment_datasize_bytes << " bytes.";
@@ -1728,6 +1742,22 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 	TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
 	
 	ts_frag = (t_truetriggertime*8); //in 1ns ticks
+      }
+      else if(fUseTimeTagShiftForTimeStamp){
+	const auto TTT = uint32_t {header->triggerTimeTag};
+	
+	using namespace boost::gregorian;
+	using namespace boost::posix_time;
+	
+	ptime t_now(second_clock::universal_time());
+	ptime time_t_epoch(date(1970,1,1));
+	time_duration diff = t_now - time_t_epoch;
+	uint32_t t_offset_s = diff.total_seconds();
+	uint64_t t_offset_ticks = diff.total_seconds()*125000000; //in 8ns ticks
+	uint64_t t_truetriggertime = t_offset_ticks + TTT;
+	TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
+	
+	ts_frag = (t_truetriggertime*8) - fCAEN.recordLength * fCAEN.postPercent * 2; //in 1ns ticks
       }
       else{
 	using namespace boost::gregorian;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1653,7 +1653,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
   double min_fragment_create_time = 10000.0;
   struct timespec now;
   clock_gettime(CLOCK_REALTIME,&now);
-  const auto metadata = CAENV1730FragmentMetadata(fNChannels,fCAEN.recordLength,now.tv_sec,now.tv_nsec,fCAEN.postPercent,ch_temps);
+  const auto metadata = CAENV1730FragmentMetadata(fNChannels,fCAEN.recordLength,now.tv_sec,now.tv_nsec,ch_temps);
   const auto fragment_datasize_bytes = metadata.ExpectedDataSize();
   TLOG(TMAKEFRAG)<< "Created CAENV1730FragmentMetadata with expected data size of "
                  << fragment_datasize_bytes << " bytes.";

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1546,7 +1546,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 
     if(fUseTimeTagForTimeStamp){
       fTTT = uint32_t{header->triggerTimeTag}; // 
-      fTTT_ns = fTTT*8.0;
+      fTTT_ns = fTTT*8;
       
       // Scheme borrowed from what Antoni developed for CRT.
       // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1557,7 +1557,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     }
     else if(fUseTimeTagShiftForTimeStamp){
       fTTT = uint32_t{header->triggerTimeTag}; // 
-      fTTT_ns = fTTT*8 - fCAEN.recordLength * fCAEN.postPercent * 2;
+      fTTT_ns = fTTT*8 - fCAEN.recordLength * fCAEN.postPercent / 100 * 2;
       
       // Scheme borrowed from what Antoni developed for CRT.
       // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783
@@ -1757,7 +1757,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 	uint64_t t_truetriggertime = t_offset_ticks + TTT;
 	TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
 	
-	ts_frag = (t_truetriggertime*8) - fCAEN.recordLength * fCAEN.postPercent * 2; //in 1ns ticks
+	ts_frag = (t_truetriggertime*8) - fCAEN.recordLength * fCAEN.postPercent / 100 * 2; //in 1ns ticks
       }
       else{
 	using namespace boost::gregorian;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1557,7 +1557,8 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     }
     else if(fUseTimeTagShiftForTimeStamp){
       fTTT = uint32_t{header->triggerTimeTag}; // 
-      fTTT_ns = (fTTT*8) - (((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0));
+      // TTT is 8 ticks/ns, record length is 2 ticks/ns. See CAEN V1730 manuals for details
+      fTTT_ns = (fTTT*8.0) - (((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0)); //in 1 ns
       
       // Scheme borrowed from what Antoni developed for CRT.
       // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783
@@ -1756,8 +1757,9 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 	uint64_t t_offset_ticks = diff.total_seconds()*125000000; //in 8ns ticks
 	uint64_t t_truetriggertime = t_offset_ticks + TTT;
 	TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
-	
-	ts_frag = (t_truetriggertime*8) - (((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0)); //in 1ns ticks
+
+	// TTT is 8 ticks/ns, record length is 2 ticks/ns. See CAEN V1730 manuals for details
+	ts_frag = (t_truetriggertime*8.0) - (((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0)); //in 1ns ticks
       }
       else{
 	using namespace boost::gregorian;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1557,7 +1557,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     }
     else if(fUseTimeTagShiftForTimeStamp){
       fTTT = uint32_t{header->triggerTimeTag}; // 
-      fTTT_ns = (fTTT*8) - ((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0);
+      fTTT_ns = (fTTT*8) - (((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0));
       
       // Scheme borrowed from what Antoni developed for CRT.
       // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783
@@ -1757,7 +1757,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 	uint64_t t_truetriggertime = t_offset_ticks + TTT;
 	TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
 	
-	ts_frag = (t_truetriggertime*8) - ((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0); //in 1ns ticks
+	ts_frag = (t_truetriggertime*8) - (((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0)); //in 1ns ticks
       }
       else{
 	using namespace boost::gregorian;


### PR DESCRIPTION
### Description

Add a fcl parameter to enable a new fragment timestamp mode

_If the full description is in a PR from a different repo, simply link that here, and delete the rest._

### Related Repository Branches

List related branches from other repos here (links to PRs even better!), if not linked above.

### Testing details
_(Note: edit as appropriate.)_
Where it was tested: SBN-ND
Run number associated with test: run 9405, 9676, 9677 on sbnd-evb03
Other information: Details of test is described in [SBN-doc-33612](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=33612)
