### PR TITLE
Remove generated_fragments_per_event

### DIFF
--- a/sbndaq-artdaq/Config/fhicl/BottomCRTDriver.fcl
+++ b/sbndaq-artdaq/Config/fhicl/BottomCRTDriver.fcl
@@ -13,7 +13,6 @@ fragment_receiver: {
   fragment_type: CRT
   fragment_ids: [ 0x30b1, 0x30b2, 0x30b3, 0x30b4, 0x30b5, 0x30b6, 0x30b7, 0x30b8, 0x30b9 ]  # In the case of just one fragment, "fragment_id: 0" would also work
   #fragment_ids: [ 0 ]  # In the case of just one fragment, "fragment_id: 0" would also work
-  generated_fragments_per_event: 9
   board_id: 999
 
   interface_type: 1

--- a/sbndaq-artdaq/Generators/Common/WhiteRabbitReadout.hh
+++ b/sbndaq-artdaq/Generators/Common/WhiteRabbitReadout.hh
@@ -90,7 +90,6 @@ namespace sbndaq
     uint64_t fEventCounter;
     uint64_t fLastEvent;
     //expected fragments
-    int generated_fragments_per_event_;
 
     std::atomic_bool running;
     std::mutex bufferLock;

--- a/sbndaq-artdaq/Generators/Common/WhiteRabbitReadout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/WhiteRabbitReadout_generator.cc
@@ -21,7 +21,6 @@
 // Constructor
 sbndaq::WhiteRabbitReadout::WhiteRabbitReadout(fhicl::ParameterSet const & ps):
   CommandableFragmentGenerator(ps),
-  generated_fragments_per_event_(ps.get<int>("generated_fragments_per_event",0)),
   ps_(ps)
 {
   fragmentId  = ps.get<uint32_t>("fragmentId");
@@ -337,14 +336,6 @@ bool sbndaq::WhiteRabbitReadout::getData()
 
 bool sbndaq::WhiteRabbitReadout::getNext_(artdaq::FragmentPtrs & frags)
 {
-
-  //copied from TriggerUDP code: if shouldn't send fragments, then don't create fragment/send
-  if(generated_fragments_per_event_== 0){
-    fLastEvent = fEventCounter;
-    ++fEventCounter;
-    return true;
-  }
-
   FillFragment(frags,true);
 
   for (auto const& frag : frags) {

--- a/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerUDP.hh
+++ b/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerUDP.hh
@@ -112,7 +112,6 @@ namespace sbndaq
     bool use_wr_time_;
     long wr_time_offset_ns_;
     //expected fragments
-    int generated_fragments_per_event_;
     static constexpr std::size_t BufferSize = 1500;
     char buffer[BufferSize] = {'\0'};
     // char buffer[1000] = {'\0'};

--- a/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerUDP_generator.cc
+++ b/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerUDP_generator.cc
@@ -37,7 +37,6 @@ sbndaq::ICARUSTriggerUDP::ICARUSTriggerUDP(fhicl::ParameterSet const& ps)
   , n_init_timeout_ms_(ps.get<size_t>("n_init_timeout_ms",1000))
   , use_wr_time_(ps.get<bool>("use_wr_time"))
   , wr_time_offset_ns_(ps.get<long>("wr_time_offset_ns",2e9))
-  , generated_fragments_per_event_(ps.get<int>("generated_fragments_per_event",0))
 {
   
   configsocket_ = socket(AF_INET, SOCK_STREAM, 0);
@@ -154,13 +153,6 @@ bool sbndaq::ICARUSTriggerUDP::getNext_(artdaq::FragmentPtrs& frags)
 
   if(data_input==""){
     TLOG(TLVL_DEBUG) << "No data after poll with timeout? " << data_input;
-    return true;
-  }
-
-  //if shouldn't send fragments, then don't create fragment/send
-  if(generated_fragments_per_event_==0){
-    fLastEvent = fEventCounter;
-    ++fEventCounter;
     return true;
   }
 

--- a/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV2.hh
+++ b/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV2.hh
@@ -140,7 +140,6 @@ namespace sbndaq
     bool use_wr_time_;
     long wr_time_offset_ns_;
     //expected fragments
-    int generated_fragments_per_event_;
     char buffer[1000] = {'\0'};
     uint8_t peekBuffer[2] = {0,0};
 

--- a/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV2_generator.cc
+++ b/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV2_generator.cc
@@ -37,7 +37,6 @@ sbndaq::ICARUSTriggerV2::ICARUSTriggerV2(fhicl::ParameterSet const& ps)
   , n_init_timeout_ms_(ps.get<size_t>("n_init_timeout_ms",1000))
   , use_wr_time_(ps.get<bool>("use_wr_time"))
   , wr_time_offset_ns_(ps.get<long>("wr_time_offset_ns",2e9))
-  , generated_fragments_per_event_(ps.get<int>("generated_fragments_per_event",0))
   , initialization_data_fpga_(ps.get<fhicl::ParameterSet>("fpga_init_params"))
   , initialization_data_spexi_(ps.get<fhicl::ParameterSet>("spexi_init_params"))
 {
@@ -283,15 +282,6 @@ bool sbndaq::ICARUSTriggerV2::getNext_(artdaq::FragmentPtrs& frags)
 
   if(data_input==""){
     TLOG(TLVL_DEBUG) << "No data after poll with timeout? " << data_input;
-    return true;
-  }
-
-  //if shouldn't send fragments, then don't create fragment/send
-  if(generated_fragments_per_event_==0){
-    fLastEvent = fEventCounter;
-    ++fEventCounter;
-    metricMan->sendMetric("EventRate",1, "Hz", 1,artdaq::MetricMode::Rate);
-    metricMan->sendMetric("EventCounter",uint64_t{fEventCounter}, "Triggers", 1,artdaq::MetricMode::LastPoint);
     return true;
   }
   

--- a/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV3.hh
+++ b/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV3.hh
@@ -190,7 +190,6 @@ namespace sbndaq
     bool use_wr_time_;
     long wr_time_offset_ns_;
     //expected fragments
-    int generated_fragments_per_event_;
     char buffer[1000] = {'\0'};
     uint8_t peekBuffer[2] = {0,0};
 

--- a/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV3_generator.cc
+++ b/sbndaq-artdaq/Generators/ICARUS/ICARUSTriggerV3_generator.cc
@@ -39,7 +39,6 @@ sbndaq::ICARUSTriggerV3::ICARUSTriggerV3(fhicl::ParameterSet const& ps)
   , n_init_timeout_ms_(ps.get<size_t>("n_init_timeout_ms",1000))
   , use_wr_time_(ps.get<bool>("use_wr_time"))
   , wr_time_offset_ns_(ps.get<long>("wr_time_offset_ns",2e9))
-  , generated_fragments_per_event_(ps.get<int>("generated_fragments_per_event",0))
   , initialization_data_fpga_(ps.get<fhicl::ParameterSet>("fpga_init_params"))
   , initialization_data_spexi_(ps.get<fhicl::ParameterSet>("spexi_init_params"))
 {
@@ -332,15 +331,6 @@ bool sbndaq::ICARUSTriggerV3::getNext_(artdaq::FragmentPtrs& frags)
     return true;
   }
 
-  //if shouldn't send fragments, then don't create fragment/send
-  if(generated_fragments_per_event_==0){
-    fLastEvent = fEventCounter;
-    ++fEventCounter;
-    metricMan->sendMetric("EventRate",1, "Hz", 11,artdaq::MetricMode::Rate);
-    metricMan->sendMetric("EventCounter",uint64_t{fEventCounter}, "Triggers", 11,artdaq::MetricMode::LastPoint);
-    return true;
-  }
-  
   icarus::ICARUSTriggerInfo datastream_info = icarus::parse_ICARUSTriggerV3String(buffer);
 
   uint64_t event_no = fEventCounter;


### PR DESCRIPTION
### Description

`generated_fragments_per_event` fhicl parameter is deprecated since sbndaq v1_08_05. While it doesn't cause harm, it produces warnings, which can be misleading. However the parameter is read by sbndaq code, and cannot be simply removed.
It appears to me that all occurrences in sbndaq code do nothing, and can be safely removed, which is done in this PR.

### Related Repository Branches

sbndaq v1_08_05 and artdaq version it uses
https://github.com/art-daq/artdaq/pull/213

### Testing details
- Not tested yet!!! It must be tested with a configuration with `generated_fragments_per_event` parameter removed
- *Run number associated with test*: ///update information after the test is done///

