### PR TITLE
Feature/exit timer manager

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -19,6 +19,7 @@
 //#include "CircularBuffer.hh"
 #include "PoolBuffer.hh"
 #include "workerThread.hh"
+#include "sbndaq-artdaq/Generators/Common/ExitTimerManager.hh"
 
 #include <string>
 #include <unordered_map>
@@ -297,7 +298,7 @@ namespace sbndaq
 
     CAEN_DGTZ_ErrorCode	WriteRegisterBitmask(int32_t handle, uint32_t address,
 					     uint32_t data, uint32_t bitmask); 
-    
+    ExitTimerManager exitTimerManager;    
   };
 
 }

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1305,7 +1305,7 @@ void sbndaq::CAENV1730Readout::stop()
   if(fVerbosity>0)
     TLOG_INFO("CAENV1730Readout") << "stop()" << TLOG_ENDL;
   TLOG_ARB(TSTOP,TRACE_NAME) << "stop()" << TLOG_ENDL;
-
+  exitTimerManager.startExitTimer(10);
   GetData_thread_->stop();
 
   CAEN_DGTZ_ErrorCode retcode;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -28,7 +28,8 @@ using namespace sbndaq;
 sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   CommandableFragmentGenerator(ps),
   fCAEN(ps),
-  fAcqMode(CAEN_DGTZ_SW_CONTROLLED)
+  fAcqMode(CAEN_DGTZ_SW_CONTROLLED),
+  exitTimerManager()
 {
   uint32_t data;
 

--- a/sbndaq-artdaq/Generators/Common/CMakeLists.txt
+++ b/sbndaq-artdaq/Generators/Common/CMakeLists.txt
@@ -23,6 +23,7 @@ cet_make_library(
     workerThread.cpp
     CircularBuffer.cc
     PoolBuffer.cc
+    ExitTimerManager.cc
   LIBRARIES
     pthread
     artdaq::DAQdata

--- a/sbndaq-artdaq/Generators/Common/ExitTimerManager.cc
+++ b/sbndaq-artdaq/Generators/Common/ExitTimerManager.cc
@@ -2,7 +2,7 @@
 #include "ExitTimerManager.hh"
 #define TRACE_NAME "ExitTimerManager"
 
-#include "trace.h"
+#include "artdaq/DAQdata/Globals.hh"
 using sbndaq::ExitTimerManager;
 
 void ExitTimerManager::startExitTimer(unsigned int seconds) {
@@ -11,7 +11,7 @@ void ExitTimerManager::startExitTimer(unsigned int seconds) {
     _timerThread = std::thread(&ExitTimerManager::startTimer, seconds);
     TLOG(TLVL_INFO) << "Timer started.";
   } else {
-    TLOG(TLVL_ERROR) << "Timer already started. Stopping and exiting...";
+    TLOG(TLVL_WARNING) << "Timer already started. Stopping and exiting...";
     stopTimer();
     std::exit(1);
   }

--- a/sbndaq-artdaq/Generators/Common/ExitTimerManager.cc
+++ b/sbndaq-artdaq/Generators/Common/ExitTimerManager.cc
@@ -10,11 +10,14 @@ void ExitTimerManager::startExitTimer(unsigned int seconds) {
   if (!_timerThread.joinable()) {
     _timerThread = std::thread(&ExitTimerManager::startTimer, seconds);
     TLOG(TLVL_INFO) << "Timer started.";
-  } else {
+  }
+  /*
+  else {
     TLOG(TLVL_WARNING) << "Timer already started. Stopping and exiting...";
     stopTimer();
     std::exit(1);
   }
+ */
 }
 
 void ExitTimerManager::startTimer(unsigned int seconds) {

--- a/sbndaq-artdaq/Generators/Common/ExitTimerManager.cc
+++ b/sbndaq-artdaq/Generators/Common/ExitTimerManager.cc
@@ -1,0 +1,30 @@
+
+#include "ExitTimerManager.hh"
+#define TRACE_NAME "ExitTimerManager"
+
+#include "trace.h"
+using sbndaq::ExitTimerManager;
+void ExitTimerManager::startExitTimer(unsigned int seconds) {
+  std::lock_guard<std::mutex> lock(_mutex);
+  if (!_timerThread.joinable()) {
+    _timerThread = std::thread(&ExitTimerManager::startTimer, seconds);
+    TLOG(TLVL_INFO) << "Timer started.";
+  } else {
+    TLOG(TLVL_ERROR) << "Timer already started. Stopping and exiting...";
+    stopTimer();
+    std::exit(1);
+  }
+}
+
+void ExitTimerManager::startTimer(unsigned int seconds) {
+  std::this_thread::sleep_for(std::chrono::seconds(seconds));
+  TLOG(TLVL_ERROR) << "Timer expired! Exiting...";
+  std::exit(1);
+}
+
+void ExitTimerManager::stopTimer() {
+  if (_timerThread.joinable()) {
+    _timerThread.join();
+  }
+  TLOG(TLVL_INFO) << "Timer stopped.";
+}

--- a/sbndaq-artdaq/Generators/Common/ExitTimerManager.cc
+++ b/sbndaq-artdaq/Generators/Common/ExitTimerManager.cc
@@ -4,6 +4,7 @@
 
 #include "trace.h"
 using sbndaq::ExitTimerManager;
+
 void ExitTimerManager::startExitTimer(unsigned int seconds) {
   std::lock_guard<std::mutex> lock(_mutex);
   if (!_timerThread.joinable()) {
@@ -28,3 +29,8 @@ void ExitTimerManager::stopTimer() {
   }
   TLOG(TLVL_INFO) << "Timer stopped.";
 }
+
+// void test_ExitTimerManager() {
+//   ExitTimerManager exitTimerManager;
+//   exitTimerManager.startExitTimer(3);
+// }

--- a/sbndaq-artdaq/Generators/Common/ExitTimerManager.hh
+++ b/sbndaq-artdaq/Generators/Common/ExitTimerManager.hh
@@ -1,0 +1,31 @@
+#ifndef _ExitTimerManager_H_
+#define _ExitTimerManager_H_
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <mutex>
+#include <thread>
+
+namespace sbndaq {
+class ExitTimerManager {
+public:
+  ExitTimerManager() = default;
+  ~ExitTimerManager() { stopTimer(); };
+  void startExitTimer(unsigned int seconds = 10);
+
+private:
+  static void startTimer(unsigned int seconds);
+  void stopTimer();
+  std::mutex _mutex;
+  std::thread _timerThread;
+};
+} // namespace sbndaq
+
+// int mainTest() {
+//   ExitTimerManager exitTimerManager;
+//   exitTimerManager.startExitTimer(3);
+//
+//   return 0;
+// }
+#endif // _ExitTimerManager_H_

--- a/sbndaq-artdaq/Generators/Common/ExitTimerManager.hh
+++ b/sbndaq-artdaq/Generators/Common/ExitTimerManager.hh
@@ -21,11 +21,4 @@ private:
   std::thread _timerThread;
 };
 } // namespace sbndaq
-
-// int mainTest() {
-//   ExitTimerManager exitTimerManager;
-//   exitTimerManager.startExitTimer(3);
-//
-//   return 0;
-// }
 #endif // _ExitTimerManager_H_


### PR DESCRIPTION
Adding the ExitTimerManager class, which expedites the stop transition by terminating the board reader process after a configurable wait time if it persists beyond that duration.