### PR TITLE
Feature/eyandel triggraf

### DIFF
--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/CRTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/CRTMetricProducer_module.cc
@@ -153,6 +153,7 @@ void sbndaq::MetricProducer::produce(art::Event& evt)
 
 
   for (int i=0;i<7;++i) {CRTMetricInfo->hitsperplane[i] = hitsperplane[i];}
+  for (uint i=0;i<ts1s.size();i++){CRTMetricInfo->ts1inbeam.push_back(ts1s.at(i));}
 
   if (fVerbose) {
     std::cout << "CRT hit count during beam spill ";
@@ -208,7 +209,7 @@ void sbndaq::MetricProducer::analyze_crt_fragment(artdaq::Fragment & frag)
 	  metricMan->sendMetric(
 				"CRT_T1_in_beam",
 				(double)thistime,
-				"CRT T1 times for hits in beam", 12, artdaq::MetricMode::LastPoint);
+				"CRT T1 times for hits in beam", 15, artdaq::MetricMode::LastPoint);
 	}
       }
       //CRTMetricInfo->hitsperplane[plane]++;

--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/CRTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/CRTMetricProducer_module.cc
@@ -63,6 +63,7 @@ private:
 
   //metric variables
   int hitsperplane[7];
+  std::vector<uint32_t> ts1s;
 
   //graphana metric
   int num_t1_resets;
@@ -134,13 +135,13 @@ void sbndaq::MetricProducer::produce(art::Event& evt)
       metricMan->sendMetric(
           "T1_resets_per_event",
           num_t1_resets,
-          "CRT T1 resets per event", 5, artdaq::MetricMode::LastPoint);
+          "CRT T1 resets per event", 11, artdaq::MetricMode::LastPoint);
 
       for (int i=0;i<7;++i){
         metricMan->sendMetric(
             std::string("CRT_hits_beam_plane_")+std::to_string(i),
             hitsperplane[i],
-            "CRT hits in beam window per plane per event", 5, artdaq::MetricMode::LastPoint);
+            "CRT hits in beam window per plane per event", 11, artdaq::MetricMode::LastPoint);
       }
 
       if (fVerbose) {
@@ -171,6 +172,10 @@ void sbndaq::MetricProducer::produce(art::Event& evt)
   // add to event
   evt.put(std::move(CRTMetricInfo));
 
+  //clear
+  ts1s.clear();
+  ts1s.shrink_to_fit();
+
 }
 
 
@@ -195,7 +200,17 @@ void sbndaq::MetricProducer::analyze_crt_fragment(artdaq::Fragment & frag)
     if (thisflag & 0x2 && !(thisflag & 0xC) ) {
       // check ts1 for beam window
       auto thistime=bevt->ts1;
-      if ((int)thistime>fBeamWindowStart && (int)thistime<fBeamWindowEnd) hitsperplane[plane]++;
+      if ((int)thistime>fBeamWindowStart && (int)thistime<fBeamWindowEnd) {
+	hitsperplane[plane]++;
+	ts1s.push_back(thistime);
+	if(metricMan != nullptr) {
+	  //send t1 to grafana
+	  metricMan->sendMetric(
+				"CRT_T1_in_beam",
+				(double)thistime,
+				"CRT T1 times for hits in beam", 12, artdaq::MetricMode::LastPoint);
+	}
+      }
       //CRTMetricInfo->hitsperplane[plane]++;
     }
   }

--- a/sbndaq-artdaq/Generators/Common/BernCRT_GeneratorBase.cc
+++ b/sbndaq-artdaq/Generators/Common/BernCRT_GeneratorBase.cc
@@ -203,12 +203,20 @@ void sbndaq::BernCRT_GeneratorBase::FillFragment(uint64_t const& feb_id,
     }
   }
 
+  char missing_t0 = 0;
+  char missing_t1 = 0;
+
   if(!discard_data) {
     //loop over all the CRTHit events in our buffer (for this FEB)
     for(size_t i_e=0; i_e<buffer_end; ++i_e) {
       const std::vector<BernCRTHitV2> & data     = feb.buffer[i_e].hits;
       const BernCRTFragmentMetadataV2 & metadata = feb.buffer[i_e].metadata;
       const uint64_t & fragment_timestamp        = feb.buffer[i_e].fragment_timestamp;
+
+      for(auto hit : data){
+        if (hit.flags>>0 == 0){missing_t0++;}
+        if (hit.flags>>1 == 0){missing_t1++;}
+      }
 
       if(i_e == 0) { //send metrics only once for each FillFragment call
         if(metricMan != nullptr) {
@@ -224,6 +232,20 @@ void sbndaq::BernCRT_GeneratorBase::FillFragment(uint64_t const& feb_id,
               std::string("feb_poll_period_ms_")+std::to_string(feb.fragment_id & 0xff),
               (metadata.this_poll_end() - metadata.last_poll_end()) * 1e6,
               "CRT poll period", 11, artdaq::MetricMode::Maximum);
+        }
+      }
+
+      if(i_e == buffer_end-1) { //send metrics at end of each FillFragment call
+        if(metricMan != nullptr) {
+          //send flag metrics
+          metricMan->sendMetric(
+              std::string("FEB_missing_PPS_")+std::to_string(feb.fragment_id & 0xff),
+              missing_t0,
+              "CRT missing PPS per poll", 15, artdaq::MetricMode::LastPoint);
+          metricMan->sendMetric(
+              std::string("FEB_missing_T1_")+std::to_string(feb.fragment_id & 0xff),
+              missing_t1,
+              "CRT missing T1 per poll", 15, artdaq::MetricMode::LastPoint);
         }
       }
 


### PR DESCRIPTION
### Description

Upgrade grafana commands to newer level system. Replace grafana metrics in CRT boardreader that were made and heavily tested in CRT## runs but didn't get pushed to develop. Add output of "T1 in beam" metric to software trigger.


### Related Repository Branches

feature/eyandel_triggraf in sbndaq-artdaq-core

### Testing details
_(Note: edit as appropriate.)_
- *Where it was tested*: SBN-ND
- *Run number associated with test*: 11330
- Other information: 
