### PR TITLE
sbndaq-artdaq updates for SBND

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/MBBReader.hh
+++ b/sbndaq-artdaq/Generators/SBND/MBBReader.hh
@@ -29,12 +29,16 @@ namespace sbndaq
      void stopNoMutex() override {}
 
      void setupMBB(fhicl::ParameterSet const& MBB_config);
-     void SyncFEMBs();
+     void SyncFEMBs(int option, uint32_t pls_prd);
 
     uint32_t stop_femb_daq;
     uint32_t start_femb_daq;
     uint32_t sleep_time;
-    bool sync_fembs;     
+    bool sync_fembs; 
+    bool use_opt1;
+    bool use_opt2;
+    bool use_opt3;
+    uint32_t mbb_pls_prd;    
 std::unique_ptr<MBB> mbb;
   };
 }

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC2StreamNUandSNXMIT_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC2StreamNUandSNXMIT_generator.cc
@@ -204,7 +204,7 @@ bool sbndaq::NevisTPC2StreamNUandSNXMIT::MonitorCrate() {
   if( next_monitor_cycle_time > std::chrono::steady_clock::now() ) return false;
 
   fCrate->getXMITModule()->readStatus();
-  fCrate->FEMtestfunction();
+  //  fCrate->FEMtestfunction();
   TLOG(TSTATUS) << "Called " << __func__ ;
   // To do: add other board status checks. Follow uboonedaq/projects/sebs/configManager_CrateMonitor.cpp
   next_monitor_cycle_time = std::chrono::steady_clock::now() + std::chrono::seconds( fMonitorPeriod );

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC2StreamNUandSNXMIT_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC2StreamNUandSNXMIT_generator.cc
@@ -204,6 +204,7 @@ bool sbndaq::NevisTPC2StreamNUandSNXMIT::MonitorCrate() {
   if( next_monitor_cycle_time > std::chrono::steady_clock::now() ) return false;
 
   fCrate->getXMITModule()->readStatus();
+  fCrate->FEMtestfunction();
   TLOG(TSTATUS) << "Called " << __func__ ;
   // To do: add other board status checks. Follow uboonedaq/projects/sebs/configManager_CrateMonitor.cpp
   next_monitor_cycle_time = std::chrono::steady_clock::now() + std::chrono::seconds( fMonitorPeriod );

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.cpp
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.cpp
@@ -84,7 +84,8 @@ namespace nevistpc{
   TriggerModuleSPtr Crate::getTriggerModule(){
     return _trigger_module;
   }
-
+  /*
+This function is added to debug FEMs is software but hasnot tested yet
   void Crate::FEMtestfunction(){
     if(getNumberOfTPCFEMs() > 1){
     for(size_t tpc_it = 0; tpc_it < getNumberOfTPCFEMs(); tpc_it++){
@@ -92,7 +93,7 @@ namespace nevistpc{
 
     }}
   }
-
+*/
   void Crate::linkSetup(){
     
     // Reset link port receiver PLL for all FEMs except farthest left

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.cpp
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.cpp
@@ -85,6 +85,14 @@ namespace nevistpc{
     return _trigger_module;
   }
 
+  void Crate::FEMtestfunction(){
+    if(getNumberOfTPCFEMs() > 1){
+    for(size_t tpc_it = 0; tpc_it < getNumberOfTPCFEMs(); tpc_it++){
+      getTPCFEM(tpc_it)->readStatus();
+
+    }}
+  }
+
   void Crate::linkSetup(){
     
     // Reset link port receiver PLL for all FEMs except farthest left
@@ -399,7 +407,10 @@ namespace nevistpc{
 	// To do: This function needs to be updated/overloaded to configure the zero suppression
 	getTPCFEM(tpc_it)->fem_setup(crateconfig);
 	TLOG(TLVL_INFO) << "Crate: FEM in slot " << getTPCFEM(tpc_it)->module_number() << " all set.";
+	getTPCFEM(tpc_it)->readStatus();
+
       }
+
     }
 
     // Setup tx mode registers (this is done twice for some reason...)
@@ -487,6 +498,7 @@ namespace nevistpc{
       for( size_t tpc_it = 0; tpc_it < getNumberOfTPCFEMs(); tpc_it++ ){
 	usleep(10000);
 	getTPCFEM(tpc_it)->fem_setup(crateconfig);
+	getTPCFEM(tpc_it)->readStatus();
 	TLOG(TLVL_INFO) << "Crate: FEM in slot " << getTPCFEM(tpc_it)->module_number() << " all set.";
       }
     }

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.h
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.h
@@ -29,7 +29,7 @@ namespace nevistpc{
     bool hasTrigger;
     
     void linkSetup();
-    void FEMtestfunction();
+    //    void FEMtestfunction();
     // Configure Trigger Board, FEM, XMIT Module and XMITReader for readout of the NU stream with external triggers
     // It follows uboonedaq run2Stream but SN stream has been removed
     void runNUStream(fhicl::ParameterSet const& _p);

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.h
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/Crate.h
@@ -29,6 +29,7 @@ namespace nevistpc{
     bool hasTrigger;
     
     void linkSetup();
+    void FEMtestfunction();
     // Configure Trigger Board, FEM, XMIT Module and XMITReader for readout of the NU stream with external triggers
     // It follows uboonedaq run2Stream but SN stream has been removed
     void runNUStream(fhicl::ParameterSet const& _p);

--- a/sbndaq-artdaq/Generators/SBND/WIBReader.hh
+++ b/sbndaq-artdaq/Generators/SBND/WIBReader.hh
@@ -38,12 +38,14 @@ namespace sbndaq
      void setupWIBFakeData(int datamode); // This function is developed by looking into Modified_WIB_fake_data.py at "/home/nfs/sbnd/BNL_CE/SBND_CE"
      void setupNoiseMinConfig(int FEMB_NO, int tries); // This is the Minimum configuration suggested by Shanshan to see FEMB noise after WIB config
      void IssueWIBSYNC();
+     void wib_qsfp_reset();
      void FEMBHsLinkCheck(int FEMB_NO, int tries);
      void InitFEMBRegCheck(uint32_t expected_val, std::string reg_addrs, int FEMB_NO, int tries);
      void disable_dat_stream_and_sync_to_NEVIS();
      void FEMB_DECTECT(int FEMB_NO, uint32_t FEMB_V);// This function is a modified version of a function availble in shanshan's python script to configure WIB/FEMB
      bool Retry_Read(std::map<std::string,double> &map, std::string var_name, double val, char check_type, int Tries); // check_types allowed are e, g, l
      void FEMB_DECTECT_V2(int FEMB_NO, uint32_t FEMB_V, int Tries); // This function is a modified version of a function availble in shanshan's python script to configure WIB/FEMB 
+     void FEMB_DETECT_FOR_DAMAGED_FEMB(int FEMB_NO, uint32_t FEMB_V, int Tries); // call this for only damaged FEMB
      void FEMB_DETECT_ALL(std::vector<bool> &FEMB_NOs, uint32_t FEMB_V, int Tries); // This function is a modified version of a function availble in shanshan's python script to configure WIB/FEMB
      void FEMB_SCAN(std::vector<bool> &FEMB_NOs, uint32_t FEMB_V); // This function is a modified version of a function copied from shanshan's python script to configure WIB/FEMB
      void setupFEMB(size_t iFEMB, fhicl::ParameterSet const& FEMB_configure);
@@ -51,6 +53,7 @@ namespace sbndaq
      void prepFEMB_MBB_Calib(int FEMB_NO);
      void prepFEMB_MBB_Calib(std::vector<bool> enable_FEMBs); 
      void Do_Err_Check(std::vector<bool> enable_FEMBs); // perform error checking for bad channels
+     void Change_TST_Pulse_Separation(int FEMB_NO, uint32_t pls_sep); // Change the separation between negative and positvie pulse
      bool use_semaphores;
      uint64_t semaphore_acquire_timeout_ms;
      bool calibration_mode;

--- a/sbndaq-artdaq/Generators/SBND/WIBReader_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/WIBReader_generator.cc
@@ -93,6 +93,9 @@ namespace sbndaq
     TLOG_INFO(identification) << "CRATE ADDRESS : " << std::hex << int(wib->Read("CRATE_ADDR")) << TLOG_ENDL;
     TLOG_INFO(identification) << "FIRMWARE TRACKER : " << std::hex << int(wib->Read(0x100)) << TLOG_ENDL;
 
+    wib->Write(0x0D, 0);
+    TLOG_INFO(identification) << "*********** WIB with IP " << wib->GetAddress() << " Register 0x0D value : " << wib->Read(0x0D) << TLOG_ENDL;
+
     if(!calibration_mode) disconnectWIB_releaseSemaphores(); 
     TLOG_INFO(identification) << "WIBReader constructor completed";
  }
@@ -121,6 +124,11 @@ namespace sbndaq
    TLOG_INFO(identification) << "************* Now Starting setupWIB  ****************" << TLOG_ENDL;
    
    wib = std::make_unique<WIB>(wib_address,wib_table,femb_table,true);
+
+   // Setting register 0x0D to 1 to indicate board reader has started configuring WIB. 
+   // This may be useful for other problem such as BNL diagnostic tool and DCS.
+   wib->Write(0x0D, 1);
+   TLOG_INFO(identification) << "*********** WIB with IP " << wib->GetAddress() << " Register 0x0D value : " << wib->Read(0x0D) << TLOG_ENDL;
    
    if(reset_wib_qsfp) wib_qsfp_reset(); 
    


### PR DESCRIPTION
### Description

Various updates:
* Add a function to send an external pulse from MBB to FEMBs to check the data synchronization
* Add a WIB board reader function to test channel mapping
* Change test pulse width, prepare FEMBs to receive a calibration pulse from MBB and enable damaged FEMB.

### Related Repository Branches

* sbndaq:feature/vmeddage_CE_WE_Testing_March_18_2024
* wibtools:feature/vmeddage_CE_WE_Testing_March_18_2024

### Testing details
_(Note: edit as appropriate.)_
- *Where it was tested*: SBN-ND
- *Run number associated with test*: 12085
- Other information: none
