### PR TITLE
Change the way the PTB fragment timestamp is created

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
@@ -205,6 +205,14 @@ artdaq::Fragment* sbndaq::TriggerBoardReader::CreateFragment() {
     timestamp = _last_timestamp ;
   }
 
+  //borrowed from the CAEN code
+  boost::posix_time::ptime fTimeServer = boost::posix_time::microsec_clock::universal_time();
+ //get the server time so we can use the second part
+  boost::posix_time::ptime fTimeEpoch = boost::posix_time::ptime(boost::gregorian::date(1970,1,1));
+  boost::posix_time::time_duration fTimeDiff= fTimeServer-fTimeEpoch;//current time since last epoch
+  uint64_t fServerStartLoopTime=fTimeDiff.total_nanoseconds();//put it in ns
+  uint64_t fServerStartLoopTimeNS=fServerStartLoopTime%(1000000000);//take just the ns (subsecond) part
+
   unsigned int word_counter = 0 ;
   unsigned int group_counter = 0 ;
 
@@ -399,6 +407,52 @@ artdaq::Fragment* sbndaq::TriggerBoardReader::CreateFragment() {
     }
 
   }
+
+  //Make a hybrid timestamp that uses the PTB server time for the second part of the ptb fragment timestamp and info from the PTB itself for the sub-second part
+
+  long timestampPTB_ns= timestamp%(1000000000);//take just hte ns part of the timestamp from the PTB
+  artdaq::Fragment::timestamp_t timestampPTB = artdaq::Fragment::InvalidTimestamp ;
+  timestampPTB=timestamp;
+  // Scheme borrowed from what Antoni developed for CRT.                                                          
+  // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783
+  
+  timestamp= fServerStartLoopTime - fServerStartLoopTimeNS + timestampPTB_ns
+    + (timestampPTB_ns - (long)fServerStartLoopTimeNS < -500000000) * 1000000000
+    - (timestampPTB_ns - (long)fServerStartLoopTimeNS >  500000000) * 1000000000;  
+
+  //more code from the CAENs to check for time drifts
+  artdaq::Fragment::timestamp_t ts_now; //server time
+  {
+    using namespace boost::gregorian;
+    using namespace boost::posix_time;
+      
+    ptime t_now(microsec_clock::universal_time());
+    ptime time_t_epoch(date(1970,1,1));
+    time_duration diff = t_now - time_t_epoch;
+      
+    ts_now = diff.total_nanoseconds();
+  }
+
+
+  //timestamp=the timestamp from the fragment I think
+  if( timestamp>(ts_now+1e6) ){
+    TLOG(TLVL_WARNING) << "Fragment assigned timestamp is after timestamp from fragment creation! Something funky is happening with the clocks/timing."
+		       << "ts_frag (PTB hybrid timestamp) - ts_now (Server NTP timestamp) = " << timestamp - ts_now << " ns! ts_frag= "<<timestamp<<"  ts_now= "<<ts_now
+      <<"\n ptb_self_timestamp = "<<timestampPTB<<"  ptb_self_timestamp-hybrid_ts=  "<< timestampPTB-timestamp
+		       << TLOG_ENDL;
+
+  }
+  else if( ts_now>timestamp+5e9 ){
+    TLOG(TLVL_ERROR) << "Fragment being packged more than 5 seconds after timestamp: "
+		     << "ts_now - ts_frag = " << (long long)ts_now-(long long)timestamp << " ns!"
+		     << TLOG_ENDL;
+  }
+  else if( ts_now>timestamp+1e9 ){
+    TLOG(TLVL_WARNING) << "Fragment being packged more than 1 second after timestamp: "
+		       << "ts_now - ts_frag = " << ts_now-timestamp << " ns!"
+		       << TLOG_ENDL;
+  }
+
 
 
   fragptr -> resizeBytes( word_counter * word_bytes ) ;


### PR DESCRIPTION
 Change the way the PTB fragment timestamp is created to only use the subsecond part of the timestamp from the PTB itself, and the second part of the server time. Uses code from CAENs (which in turn came from CRTs) to account for roll over cases. Does nothing to the timestamps in the fragments of LLTs and HLTs.

### Description

Makes the PTB fragment timestamp get calculated in the same way the CAEN and CRT fragment timestamps do. This fixes an ongoing issue we had been having where the PTB has missing the relevant fragments associated with the event and instead grabbing ones offset in time.


### Testing details
Has been running out of the shifter area for over a week, starting with run 15362-15655. We have now been consistently seeing the HLT/LLT data that we had been missing