### PR TITLE
Wind down the TPCs

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC2StreamNUandSNXMIT_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC2StreamNUandSNXMIT_generator.cc
@@ -152,19 +152,22 @@ void sbndaq::NevisTPC2StreamNUandSNXMIT::ConfigureStop() {
     WriteSNData_thread_->stop();
   }
   //  FireCALIB_thread_->stop();
-  FireController_thread_->stop();
+  if( fControllerTriggerFreq > 0 ){//only stop thread if it met conditions to get started
+    FireController_thread_->stop();
+  }
   MonitorCrate_thread_->stop();
 
   if( fDumpBinary ){
-    TLOG(TLVL_INFO)<< "Closig raw binary file " << binFileNameNU;
+    TLOG(TLVL_INFO)<< "Closing raw binary file " << binFileNameNU;
     binFileNU.close(); // temp
 
     if( fSNReadout ){
-      TLOG(TLVL_INFO)<< "Closig raw binary file " << binFileNameSN;
+      TLOG(TLVL_INFO)<< "Closing raw binary file " << binFileNameSN;
       binFileSN.close(); // temp
     }
   }
   delete[] SNBuffer_;
+  fNUXMITReader->dmaStop();
 
   TLOG(TLVL_INFO)<< "Successful " << __func__ ;
   mf::LogInfo("NevisTPC2StreamNUandSNXMIT") << "Successful " << __func__;

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
@@ -84,13 +84,16 @@ void sbndaq::NevisTPC_generatorBase::stopAll(){
 }
 
 void sbndaq::NevisTPC_generatorBase::stop(){
+  TLOG(TLVL_INFO)<<"stop() transition called";
   ConfigureStop();  
   stopAll();
+  TLOG(TLVL_INFO)<<"stop() transition finished";
 }
 
 void sbndaq::NevisTPC_generatorBase::stopNoMutex(){
   
-  stopAll();
+  //stopAll();
+  //Both stopNoMutex and stop are getting called, with stopNoMutex first. We need to ConfigureStop() before stopAll(), so will just wait for the stop() function to get called.
 }
 
 size_t sbndaq::NevisTPC_generatorBase::CircularBuffer::Insert(size_t n_words, std::unique_ptr<uint16_t[]> const& dataptr){
@@ -140,10 +143,10 @@ bool sbndaq::NevisTPC_generatorBase::GetData(){
     n_words = GetFEMCrateData()/sizeof(uint16_t);
     auto current_time = std::chrono::steady_clock::now();
     auto elapsed_time = std::chrono::duration_cast<std::chrono::seconds>(current_time - start_time).count();
-    if (elapsed_time > 5){
+    if (elapsed_time > 60){ //60 second timeout for more ability to do low rate nonstandard trigger configurations
 
       char line[132];
-      sprintf(line,"There is no data for 5 seconds"); //,current_event,header->getEventNum());                                                                 
+      sprintf(line,"There is no data for 60 seconds"); //,current_event,header->getEventNum());                                                                 
       TRACE(TERROR,line);
       throw std::runtime_error(line);
 

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
@@ -41,6 +41,7 @@ void sbndaq::NevisTPC_generatorBase::Initialize(){
   fSamplesPerChannel = ps_.get<uint32_t>("SamplesPerChannel",9600);
   fNChannels         = ps_.get<uint32_t>("NChannels",64);
   fUseCompression    = ps_.get<bool>("UseCompression",false);
+  fTimeoutSec        = ps_.get<uint32_t>("TimeoutSec", 60);
    
   DMABufferSizeBytes_ = ps_.get<uint32_t>("DMABufferSize",1e6);	
   DMABuffer_.reset(new uint16_t[DMABufferSizeBytes_]);
@@ -143,7 +144,7 @@ bool sbndaq::NevisTPC_generatorBase::GetData(){
     n_words = GetFEMCrateData()/sizeof(uint16_t);
     auto current_time = std::chrono::steady_clock::now();
     auto elapsed_time = std::chrono::duration_cast<std::chrono::seconds>(current_time - start_time).count();
-    if (elapsed_time > 60){ //60 second timeout for more ability to do low rate nonstandard trigger configurations
+    if (elapsed_time > fTimeoutSec){ //fcl configurable timeout (in seconds) for more ability to do low rate nonstandard trigger configurations
 
       char line[132];
       sprintf(line,"There is no data for 60 seconds"); //,current_event,header->getEventNum());                                                                 

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.hh
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.hh
@@ -71,6 +71,7 @@ protected:
   uint32_t fSamplesPerChannel;
   uint32_t fNChannels;
   bool fUseCompression;
+  uint32_t fTimeoutSec;
 
   std::vector<artdaq::Fragment::fragment_id_t> fragment_ids;
   std::vector<uint64_t> FEMIDs_;

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/XMITReader.cpp
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/XMITReader.cpp
@@ -317,7 +317,11 @@ namespace nevistpc {
 
   }
 
-
+  void XMITReader::dmaStop( )
+  {
+    dmaAbort();
+    dmaClearRegister();
+  }
 
 
 }  // end of namespace nevistpc

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/XMITReader.h
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/nevishwutils/XMITReader.h
@@ -46,6 +46,7 @@ namespace nevistpc{
     void setupTXModeRegister();
 
     virtual std::streamsize readsome ( char* buffer, std::streamsize requestedSize );
+    virtual void dmaStop(); //Erin: stop the xmit
     virtual ~XMITReader(){};
   private:
     bool dmaLockBuffer ( dma_buffer& dma );


### PR DESCRIPTION
Changes so that the TPCs will fully wind down at stop instead of crashing because of time outs and recovering

### Description

Checked if FireContorllerThread was started before stopping it
Made sure ConfigureStop happened before the DataWorker Thread ended
Stopped the XMIT reader 
Changed no trigger timeout to 60 seconds to allow for low rate triggers 


### Testing details
Tested with all components included at SBND, stopped cleanly 
Run 15828

