### PR TITLE
Update TDCChan drain rate for handling flash trigger rate of 120-140Hz

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_drain.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_drain.cc
@@ -76,6 +76,6 @@ bool TDCChan::configure_drain_buffer() {
         ++drained_count;
       }
     }
-    utls::thread_sleep_ms(1);
+    utls::thread_sleep_us(50);
   }
 }


### PR DESCRIPTION
### Description

Put description of request here. Include _Fixes #XXX_ to link to an issue.

_If the full description is in a PR from a different repo, simply link that here, and delete the rest._

### Related Repository Branches

List related branches from other repos here (links to PRs even better!), if not linked above.

### Testing details
_(Note: edit as appropriate.)_
- *Where it was tested*: SBN-ND
- *Run number associated with test*: 17260
- Other information: Run with offbeam and fake flash trigger average at 120 Hz. The drain rate of TDC was varied, so that old data is frequently flushed out.
