### PR TITLE
Nevis system Frame Rollover fix

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.cc
@@ -284,10 +284,11 @@ bool sbndaq::NevisTB_generatorBase::FillNTBFragment(artdaq::FragmentPtrs &frags,
 
       rollCounter+=1;
       TLOG(TLVL_INFO) << "Trigger frames rolled over!!!! " << " this many times: " << rollCounter;
-      corrFrame = tframe + rollCounter*16777216;
-      TLOG(TLVL_INFO) << " Corrected Frame:  " << corrFrame <<  " Uncorrected Frame: " << tframe;
-
     }
+
+    corrFrame = tframe + rollCounter*16777216;
+    TLOG(TLVL_INFO) << " Corrected Frame:  " << corrFrame <<  " Uncorrected Frame: " << tframe;
+
 
     if(frame_diff > tolerance){  //looks like we rolled over
 

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.cc
@@ -287,7 +287,7 @@ bool sbndaq::NevisTB_generatorBase::FillNTBFragment(artdaq::FragmentPtrs &frags,
     }
 
     corrFrame = tframe + rollCounter*16777216;
-    TLOG(TLVL_DEBUG) << " Corrected Frame:  " << corrFrame <<  " Uncorrected Frame: " << tframe;
+    //TLOG(TLVL_INFO) << " Corrected Frame:  " << corrFrame <<  " Uncorrected Frame: " << tframe;
 
 
     if(frame_diff > tolerance){  //PPS and trigger offset shows a rollover happened in between the two

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.cc
@@ -278,7 +278,7 @@ bool sbndaq::NevisTB_generatorBase::FillNTBFragment(artdaq::FragmentPtrs &frags,
     int32_t   tolerance  = 16770000;
     int32_t   corrFrame;
 
-    TLOG(TLVL_INFO) << "Frame difference (between GPS and trigger): " << frame_diff;
+    //TLOG(TLVL_DEBUG) << "Frame difference (between GPS and trigger): " << frame_diff;
 
     if(tframe < prevFrame){
       //If rollover happens, current frame number will be smaller than previous frame number. in that case, increment the rollover counter
@@ -287,7 +287,7 @@ bool sbndaq::NevisTB_generatorBase::FillNTBFragment(artdaq::FragmentPtrs &frags,
     }
 
     corrFrame = tframe + rollCounter*16777216;
-    TLOG(TLVL_INFO) << " Corrected Frame:  " << corrFrame <<  " Uncorrected Frame: " << tframe;
+    TLOG(TLVL_DEBUG) << " Corrected Frame:  " << corrFrame <<  " Uncorrected Frame: " << tframe;
 
 
     if(frame_diff > tolerance){  //PPS and trigger offset shows a rollover happened in between the two

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.hh
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.hh
@@ -117,6 +117,7 @@ namespace sbndaq
 
     uint32_t framesize_;
     double NevisClockFreq_;
+    uint32_t FramesPerSecond_;
 
     bool GetNTBData();
     share::WorkerThreadUPtr GetNTBData_thread_;

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.hh
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTB_generatorBase.hh
@@ -32,7 +32,8 @@ namespace sbndaq
     zmq::context_t rec_context;
     zmq::socket_t _zmqGPSSubscriber;
     long long receivedNTPsecond;
-   
+    long long prev_timestamp;
+
     class GPSstamp {
     public:
     GPSstamp( uint32_t new_frame, uint16_t new_sample, uint16_t new_div ) 
@@ -131,10 +132,11 @@ namespace sbndaq
     int current_ntbevent, current_ntbframenum; // for checking consistency between FEMs within a run
     bool desyncCrash;
     uint64_t pseudo_ntbfragment; 
-
-    uint32_t GPSframe;
-    uint16_t GPSsample;
-    uint16_t GPSdiv;
+    int rollCounter;
+    int prevFrame;
+    long long GPSframe;
+    long long GPSsample;
+    long long GPSdiv;
 
       };
 }

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
@@ -344,12 +344,10 @@ bool sbndaq::NevisTPC_generatorBase::FillFragment(artdaq::FragmentPtrs &frags, b
   if ( prevFrame > frame )
   {
     rollCounter +=1;
-    TLOG(TLVL_INFO) << "Trigger frames rolled over!!!! " << " this many times: " << rollCounter;
-    corrFrame = frame + rollCounter*16777216;
+    TLOG(TLVL_INFO) << "TPC boardreader: Trigger frames rolled over!!!! " << " this many times: " << rollCounter;
   }
-  else{
-    corrFrame = frame;
-  }
+
+  corrFrame = frame + rollCounter*16777216;
   prevFrame = frame;
 
   metadata_ = NevisTPCFragmentMetadata(header->getEventNum(),corrFrame,fNChannels,fSamplesPerChannel,fUseCompression, frame);

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
@@ -350,7 +350,7 @@ bool sbndaq::NevisTPC_generatorBase::FillFragment(artdaq::FragmentPtrs &frags, b
   corrFrame = frame + rollCounter*16777216;  //new frame is uncorrected frame + 2^24 * number_of_rollovers
   
   prevFrame = frame;
-  TLOG(TLVL_DEBUG) << "TPC boardreader: Uncorrected frame number:  " << frame << " Corrected Frame number: " << corrFrame;
+  //TLOG(TLVL_INFO) << "TPC boardreader: Uncorrected frame number:  " << frame << " Corrected Frame number: " << corrFrame;
 
   metadata_ = NevisTPCFragmentMetadata(header->getEventNum(),corrFrame,fNChannels,fSamplesPerChannel,fUseCompression);
   frags.emplace_back( artdaq::Fragment::FragmentBytes(expected_size,

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
@@ -150,7 +150,7 @@ bool sbndaq::NevisTPC_generatorBase::GetData(){
     if (elapsed_time > fTimeoutSec){ //fcl configurable timeout (in seconds) for more ability to do low rate nonstandard trigger configurations
 
       char line[132];
-      sprintf(line,"There is no data for 60 seconds"); //,current_event,header->getEventNum());                                                                 
+      sprintf(line,"There is no data for %d seconds", fTimeoutSec); //,current_event,header->getEventNum());                                                                 
       TRACE(TERROR,line);
       throw std::runtime_error(line);
 

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
@@ -344,13 +344,13 @@ bool sbndaq::NevisTPC_generatorBase::FillFragment(artdaq::FragmentPtrs &frags, b
   if ( prevFrame > frame )
   {
     rollCounter +=1;
-    TLOG(TLVL_INFO) << "TPC boardreader: Trigger frames rolled over!!!! " << " this many times: " << rollCounter;
+    TLOG(TLVL_INFO) << "TPC boardreader: Trigger frames rolled over " << "this many times: " << rollCounter;
   }
 
-  corrFrame = frame + rollCounter*16777216;
+  corrFrame = frame + rollCounter*16777216;  //new frame is uncorrected frame + 2^24 * number_of_rollovers
   prevFrame = frame;
 
-  metadata_ = NevisTPCFragmentMetadata(header->getEventNum(),corrFrame,fNChannels,fSamplesPerChannel,fUseCompression, frame);
+  metadata_ = NevisTPCFragmentMetadata(header->getEventNum(),corrFrame,fNChannels,fSamplesPerChannel,fUseCompression);
   frags.emplace_back( artdaq::Fragment::FragmentBytes(expected_size,
                                                       metadata_.EventNumber(),          // Sequence ID
 						      fragment_id,                      // Fragment ID

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
@@ -350,7 +350,7 @@ bool sbndaq::NevisTPC_generatorBase::FillFragment(artdaq::FragmentPtrs &frags, b
   corrFrame = frame + rollCounter*16777216;  //new frame is uncorrected frame + 2^24 * number_of_rollovers
   
   prevFrame = frame;
-  TLOG(TLVL_INFO) << "TPC boardreader: Uncorrected frame number:  " << frame << " Corrected Frame number: " << corrFrame;
+  TLOG(TLVL_DEBUG) << "TPC boardreader: Uncorrected frame number:  " << frame << " Corrected Frame number: " << corrFrame;
 
   metadata_ = NevisTPCFragmentMetadata(header->getEventNum(),corrFrame,fNChannels,fSamplesPerChannel,fUseCompression);
   frags.emplace_back( artdaq::Fragment::FragmentBytes(expected_size,

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.cc
@@ -348,7 +348,9 @@ bool sbndaq::NevisTPC_generatorBase::FillFragment(artdaq::FragmentPtrs &frags, b
   }
 
   corrFrame = frame + rollCounter*16777216;  //new frame is uncorrected frame + 2^24 * number_of_rollovers
+  
   prevFrame = frame;
+  TLOG(TLVL_INFO) << "TPC boardreader: Uncorrected frame number:  " << frame << " Corrected Frame number: " << corrFrame;
 
   metadata_ = NevisTPCFragmentMetadata(header->getEventNum(),corrFrame,fNChannels,fSamplesPerChannel,fUseCompression);
   frags.emplace_back( artdaq::Fragment::FragmentBytes(expected_size,

--- a/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.hh
+++ b/sbndaq-artdaq/Generators/SBND/NevisTPC/NevisTPC_generatorBase.hh
@@ -29,6 +29,7 @@ public:
 protected:
   bool getNext_(artdaq::FragmentPtrs &output) override;
   void start() override;
+  virtual void runonsyncon() {};
   virtual void startFireCalibTrig(){};
   void stop() override;
   void stopNoMutex() override;
@@ -71,6 +72,7 @@ protected:
   uint32_t fSamplesPerChannel;
   uint32_t fNChannels;
   bool fUseCompression;
+  uint32_t fTimeoutSec;
 
   std::vector<artdaq::Fragment::fragment_id_t> fragment_ids;
   std::vector<uint64_t> FEMIDs_;
@@ -79,6 +81,9 @@ protected:
 
   int32_t _this_event;
   int32_t _subrun_event_0;
+
+  int32_t rollCounter;
+  int32_t prevFrame;
 
   typedef struct CircularBuffer {
     boost::circular_buffer<uint16_t> buffer;


### PR DESCRIPTION
### Description

Introduces two fixes: 
1) Correction to the GPS timestamp issued by NTB. When nevis clock frames roll over in between a PPS pulse and a trigger, the assigned trigger timestamp is ambiguous for one second. this fix ensures that 1 second of data is timestamped correctly. 
2) NTB and TPC boardreaders introduce a correction to the frame number (adding multiples of 2^24 when to account for rollovers)

### Testing details
- *Run number associated with test*: 
- Other information: 
