### PR TITLE
Lnguyen/tdc debug

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
@@ -64,7 +64,7 @@ constexpr auto as_microseconds = uint64_t{1'000};
 uint64_t hosttime();
 uint64_t hosttime_us();
 uint64_t hosttime_ns();
-double elapsed_time_ns(uint64_t);
+uint64_t elapsed_time_ns(uint64_t);
 void thread_sleep(uint64_t);
 void thread_sleep_us(uint64_t);
 void thread_sleep_ms(uint64_t);

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
@@ -64,7 +64,7 @@ constexpr auto as_microseconds = uint64_t{1'000};
 uint64_t hosttime();
 uint64_t hosttime_us();
 uint64_t hosttime_ns();
-uint64_t elapsed_time_ns(uint64_t);
+double elapsed_time_ns(uint64_t);
 void thread_sleep(uint64_t);
 void thread_sleep_us(uint64_t);
 void thread_sleep_ms(uint64_t);
@@ -112,7 +112,7 @@ class TDCChan : public Device {
   bool configure_drain_buffer();
   bool configure_channel_status();
   bool configure_channel_disable();
-  void monitor_timestamp(uint64_t) const;
+  void monitor_timestamp(uint64_t ts, int id) const;
 
  private:
   uint8_t id = 0;

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
@@ -61,6 +61,7 @@ constexpr auto onesecond_ns = uint64_t{1'000'000'000};
 constexpr auto as_seconds = uint64_t{1'000'000'000};
 constexpr auto as_milliseconds = uint64_t{1'000'000};
 constexpr auto as_microseconds = uint64_t{1'000};
+constexpr auto max_sample_time_lag_ns = 10'000'000; 
 uint64_t hosttime();
 uint64_t hosttime_us();
 uint64_t hosttime_ns();
@@ -175,7 +176,6 @@ class TDCCard : public Device {
   unsigned int deviceid = 0;
   int polltime_ms = 50;
   bool blocking_reads = true;
-  uint64_t max_sample_time_lag_ns = 100'000'000;
 
   // used internally
   uint64_t total_bytes_read = 0;

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
@@ -61,7 +61,7 @@ constexpr auto onesecond_ns = uint64_t{1'000'000'000};
 constexpr auto as_seconds = uint64_t{1'000'000'000};
 constexpr auto as_milliseconds = uint64_t{1'000'000};
 constexpr auto as_microseconds = uint64_t{1'000};
-constexpr auto max_sample_time_lag_ns = 100'000'000; 
+constexpr auto max_sample_time_lag_ns = 300'000'000; 
 uint64_t hosttime();
 uint64_t hosttime_us();
 uint64_t hosttime_ns();

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
@@ -139,6 +139,7 @@ class TDCChan : public Device {
   uint64_t missed_sample_count = 0;
   uint64_t sample_drop_count = 0;
   uint64_t last_seen_sample_seq = 0;
+  uint64_t last_seen_sample_ts = 0;
   bool inhibit = true;
   std::string metric_prefix;
   friend class TDCCard;

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
@@ -176,6 +176,8 @@ class TDCCard : public Device {
   unsigned int deviceid = 0;
   int polltime_ms = 50;
   bool blocking_reads = true;
+  uint64_t max_time_gap_ns = 160;
+
 
   // used internally
   uint64_t total_bytes_read = 0;

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDC_Interface.hh
@@ -61,7 +61,7 @@ constexpr auto onesecond_ns = uint64_t{1'000'000'000};
 constexpr auto as_seconds = uint64_t{1'000'000'000};
 constexpr auto as_milliseconds = uint64_t{1'000'000};
 constexpr auto as_microseconds = uint64_t{1'000};
-constexpr auto max_sample_time_lag_ns = 10'000'000; 
+constexpr auto max_sample_time_lag_ns = 100'000'000; 
 uint64_t hosttime();
 uint64_t hosttime_us();
 uint64_t hosttime_ns();

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/StringLiterals.hh
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/StringLiterals.hh
@@ -18,6 +18,7 @@ constexpr auto buffer_mode_circular = "circular";
 constexpr auto tdc_sample_time_lag = "Sample Time Lag";
 constexpr auto tdc_laggy_samples = "Laggy Samples";
 constexpr auto tdc_sequence_gap = "Sequence Gap";
+constexpr auto tdc_ts_gap = "Timestamp Gap";
 constexpr auto tdc_sample_rate = "Sample Rate";
 constexpr auto tdc_bytes_read = "Sample Bytes Read";
 constexpr auto tdc_read_count = "Sample Read Total";

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -127,40 +127,34 @@ bool TDCChan::stop() {
   return true;
 }
 
-void TDCChan::monitor_timestamp(uint64_t timestamp_ns) const {
+void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
 
-  auto lag_ns = utls::elapsed_time_ns(timestamp_ns);
+  double lag_ns = utls::elapsed_time_ns(timestamp_ns);
   //lag_ns = host time - server time
-  //do we alwasy expect host time > server time?  
+  //do we alwasy expect host time > server time? 
+  //lag_ns > 0 then host time > server time
+  //lag_ns < 0 then host time < server time 
 
   if (metricMan) {
     metricMan->sendMetric(metric_prefix + lit::tdc_sample_time_lag, lag_ns, lit::unit_nanoseconds, 11,
                           MetricMode::Average);
   }
 
-  if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
+  if (std::abs(lag_ns) < fmctdc.max_sample_time_lag_ns) return;
 
   
-  if (lag_ns <= utls::onesecond_ns) {
+  if (std::abs(lag_ns) <= utls::onesecond_ns) {
  
     //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; host_time-sample_time="
     //                    << lag_ns << " ns.";
 
-
-    TLOG(TLVL_WARN) << "Wrong TDC sample time. Lag ns = host time - sample time < 1 second. Lag ns = " << lag_ns << " ns.";
+    TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Lag ns = host time - sample time < 1 second. Lag ns = " << lag_ns << " ns.";
   } else {
  
-    if (lag_ns == 18446744073) {
-      TLOG(TLVL_WARN) << "Sample time is later than host time. Sample time > Host time!!";
-    }
-    else{
+    //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing system; host_time-sample_time="
+    //              << lag_ns / utls::onesecond_ns << " seconds.";
 
-      //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing system; host_time-sample_time="
-      //              << lag_ns / utls::onesecond_ns << " seconds.";
-
-      // Start of debugging
-      TLOG(TLVL_WARN) << "Wrong TDC sample time. Lag ns = host time - sample > 1 second. Lag ns = " << lag_ns << " ns.";
-    } 
+    TLOG(TLVL_WARN) << "Channel " << ch_id <<". Wrong TDC sample time. Lag ns = host time - sample > 1 second. Lag ns = " << lag_ns << " ns.";
 
     if (metricMan) {
       metricMan->sendMetric(metric_prefix + lit::tdc_laggy_samples, uint64_t{1}, lit::unit_samples_per_second, 11,

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -138,7 +138,8 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
                           MetricMode::Average);
   }
 
-  if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
+  //move the return statement to the end so debug messages can show up
+  //if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
 
   if (lag_ns <= utls::onesecond_ns) {
  
@@ -159,6 +160,9 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
                             MetricMode::Rate);
     }
   }
+
+  if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
+
 }
 
 void TDCChan::monitor() {

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -129,7 +129,7 @@ bool TDCChan::stop() {
 
 void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
 
-  double lag_ns = utls::elapsed_time_ns(timestamp_ns);
+  uint64_t lag_ns = utls::elapsed_time_ns(timestamp_ns);
   //lag_ns = host time - server time
   //do we alwasy expect host time > server time? 
   //lag_ns > 0 then host time > server time
@@ -140,21 +140,21 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
                           MetricMode::Average);
   }
 
-  if (std::abs(lag_ns) < fmctdc.max_sample_time_lag_ns) return;
+  if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
 
   
-  if (std::abs(lag_ns) <= utls::onesecond_ns) {
+  if (lag_ns <= utls::onesecond_ns) {
  
     //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; host_time-sample_time="
     //                    << lag_ns << " ns.";
 
-    TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Lag ns = host time - sample time < 1 second. Lag ns = " << lag_ns << " ns.";
+    TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Lag ns = |host time - sample time| < 1 second. Lag ns = " << lag_ns << " ns.";
   } else {
  
     //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing system; host_time-sample_time="
     //              << lag_ns / utls::onesecond_ns << " seconds.";
 
-    TLOG(TLVL_WARN) << "Channel " << ch_id <<". Wrong TDC sample time. Lag ns = host time - sample > 1 second. Lag ns = " << lag_ns << " ns.";
+    TLOG(TLVL_WARN) << "Channel " << ch_id <<". Wrong TDC sample time. Lag ns = |host time - sample time| > 1 second. Lag ns = " << lag_ns << " ns.";
 
     if (metricMan) {
       metricMan->sendMetric(metric_prefix + lit::tdc_laggy_samples, uint64_t{1}, lit::unit_samples_per_second, 11,

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -129,6 +129,7 @@ bool TDCChan::stop() {
 
 void TDCChan::monitor_timestamp(uint64_t timestamp_ns) const {
   auto lag_ns = utls::elapsed_time_ns(timestamp_ns);
+  //lag_ns = host time - server time
 
   if (metricMan) {
     metricMan->sendMetric(metric_prefix + lit::tdc_sample_time_lag, lag_ns, lit::unit_nanoseconds, 11,
@@ -136,14 +137,19 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns) const {
   }
   if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
 
+  
   if (lag_ns <= utls::onesecond_ns) {
+    // Start of debugging
+    TLOG(TLVL_WARN) << "Lag ns = host time - sample time < 1 second. Lag ns = " << lag_ns << " ns.";
+    // End of debugging
+
     TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; host_time-sample_time="
                         << lag_ns << " ns.";
 
   } else {
 
     // Start of debugging
-    TLOG(TLVL_WARN) << "Lag ns > 1 second. Lag ns = " << lag_ns << " ns.";
+    TLOG(TLVL_WARN) << "Lag ns =host time - sample > 1 second. Lag ns = " << lag_ns << " ns.";
     // End of debugging
 
     TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing system; host_time-sample_time="

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -129,17 +129,17 @@ bool TDCChan::stop() {
 
 void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
 
-  uint64_t lag_ns = utls::elapsed_time_ns(timestamp_ns);
   //lag_ns = host time - server time
   //do we alwasy expect host time > server time? 
+  uint64_t lag_ns = utls::elapsed_time_ns(timestamp_ns);
 
   if (metricMan) {
     metricMan->sendMetric(metric_prefix + lit::tdc_sample_time_lag, lag_ns, lit::unit_nanoseconds, 11,
                           MetricMode::Average);
   }
 
-  //move the return statement to the end so debug messages can show up
-  //if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
+  //what does this return statement do?? lag_ns can be meaningless
+  if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
 
   if (lag_ns <= utls::onesecond_ns) {
  
@@ -153,15 +153,13 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
     //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing system; host_time-sample_time="
     //              << lag_ns / utls::onesecond_ns << " seconds.";
 
-    TLOG(TLVL_WARN) << "Channel " << ch_id <<". Wrong TDC sample time. Lag ns = |host time - sample time| > 1 second. Lag ns = " << lag_ns << " ns. Bad if sample time > host time. Is there TimeUtils Warning before this??";
+    TLOG(TLVL_WARN) << "Channel " << ch_id <<". Wrong TDC sample time. Lag ns = |host time - sample time| > 1 second. Lag ns = " << lag_ns << " ns could be bogus. Bad if sample time > host time. Is there TimeUtils Warning before this??";
 
     if (metricMan) {
       metricMan->sendMetric(metric_prefix + lit::tdc_laggy_samples, uint64_t{1}, lit::unit_samples_per_second, 11,
                             MetricMode::Rate);
     }
   }
-
-  if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
 
 }
 

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -128,6 +128,7 @@ bool TDCChan::stop() {
 }
 
 void TDCChan::monitor_timestamp(uint64_t timestamp_ns) const {
+
   auto lag_ns = utls::elapsed_time_ns(timestamp_ns);
   //lag_ns = host time - server time
   //do we alwasy expect host time > server time?  
@@ -136,25 +137,29 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns) const {
     metricMan->sendMetric(metric_prefix + lit::tdc_sample_time_lag, lag_ns, lit::unit_nanoseconds, 11,
                           MetricMode::Average);
   }
+
   if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
 
   
   if (lag_ns <= utls::onesecond_ns) {
-
-    TLOG(TLVL_WARN) << "Wrong TDC sample time. Lag ns = host time - sample time < 1 second. Lag ns = " << lag_ns << " ns.";
+ 
     //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; host_time-sample_time="
     //                    << lag_ns << " ns.";
 
+
+    TLOG(TLVL_WARN) << "Wrong TDC sample time. Lag ns = host time - sample time < 1 second. Lag ns = " << lag_ns << " ns.";
   } else {
  
     if (lag_ns == 18446744073) {
       TLOG(TLVL_WARN) << "Sample time is later than host time. Sample time > Host time!!";
     }
     else{
-      // Start of debugging
-      TLOG(TLVL_WARN) << "Wrong TDC sample time. Lag ns = host time - sample > 1 second. Lag ns = " << lag_ns << " ns.";
+
       //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing system; host_time-sample_time="
       //              << lag_ns / utls::onesecond_ns << " seconds.";
+
+      // Start of debugging
+      TLOG(TLVL_WARN) << "Wrong TDC sample time. Lag ns = host time - sample > 1 second. Lag ns = " << lag_ns << " ns.";
     } 
 
     if (metricMan) {

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -132,8 +132,6 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
   uint64_t lag_ns = utls::elapsed_time_ns(timestamp_ns);
   //lag_ns = host time - server time
   //do we alwasy expect host time > server time? 
-  //lag_ns > 0 then host time > server time
-  //lag_ns < 0 then host time < server time 
 
   if (metricMan) {
     metricMan->sendMetric(metric_prefix + lit::tdc_sample_time_lag, lag_ns, lit::unit_nanoseconds, 11,
@@ -142,19 +140,21 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
 
   if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
 
-  
   if (lag_ns <= utls::onesecond_ns) {
  
     //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; host_time-sample_time="
     //                    << lag_ns << " ns.";
 
     TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Lag ns = |host time - sample time| < 1 second. Lag ns = " << lag_ns << " ns.";
+    TLOG(TLVL_WARN) << "Bad if sample time > host time. Is there TimeUtils Warning before this??";
+
   } else {
  
     //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing system; host_time-sample_time="
     //              << lag_ns / utls::onesecond_ns << " seconds.";
 
     TLOG(TLVL_WARN) << "Channel " << ch_id <<". Wrong TDC sample time. Lag ns = |host time - sample time| > 1 second. Lag ns = " << lag_ns << " ns.";
+    TLOG(TLVL_WARN) << "Bad if sample time > host time. Is there TimeUtils Warning before this??";
 
     if (metricMan) {
       metricMan->sendMetric(metric_prefix + lit::tdc_laggy_samples, uint64_t{1}, lit::unit_samples_per_second, 11,

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -145,16 +145,14 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
     //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; host_time-sample_time="
     //                    << lag_ns << " ns.";
 
-    TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Lag ns = |host time - sample time| < 1 second. Lag ns = " << lag_ns << " ns.";
-    TLOG(TLVL_WARN) << "Bad if sample time > host time. Is there TimeUtils Warning before this??";
+    TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Lag ns = |host time - sample time| < 1 second. Lag ns = " << lag_ns << " ns. Bad if sample time > host time. Is there TimeUtils Warning before this??";
 
   } else {
  
     //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing system; host_time-sample_time="
     //              << lag_ns / utls::onesecond_ns << " seconds.";
 
-    TLOG(TLVL_WARN) << "Channel " << ch_id <<". Wrong TDC sample time. Lag ns = |host time - sample time| > 1 second. Lag ns = " << lag_ns << " ns.";
-    TLOG(TLVL_WARN) << "Bad if sample time > host time. Is there TimeUtils Warning before this??";
+    TLOG(TLVL_WARN) << "Channel " << ch_id <<". Wrong TDC sample time. Lag ns = |host time - sample time| > 1 second. Lag ns = " << lag_ns << " ns. Bad if sample time > host time. Is there TimeUtils Warning before this??";
 
     if (metricMan) {
       metricMan->sendMetric(metric_prefix + lit::tdc_laggy_samples, uint64_t{1}, lit::unit_samples_per_second, 11,

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -137,10 +137,15 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns) const {
   if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
 
   if (lag_ns <= utls::onesecond_ns) {
-    TLOG(TLVL_DEBUG_10) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; host_time-sample_time="
+    TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; host_time-sample_time="
                         << lag_ns << " ns.";
 
   } else {
+
+    // Start of debugging
+    TLOG(TLVL_WARN) << "Lag ns > 1 second. Lag ns = " << lag_ns << " ns.";
+    // End of debugging
+
     TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing system; host_time-sample_time="
                     << lag_ns / utls::onesecond_ns << " seconds.";
     if (metricMan) {

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -136,16 +136,15 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
                           MetricMode::Average);
   }
 
-  if (lag_ns < fmctdc.max_sample_time_lag_ns) return;
+  if (lag_ns < utls::max_sample_time_lag_ns) return;
 
   if (lag_ns <= utls::onesecond_ns) {
 
-    TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Host time > sample time; host_time-sample_time = " << lag_ns << " ns. NTP drift is larger than 100 ms! Check White Rabbit and NTP synchronisation.";
+    TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Host time > sample time; host_time-sample_time = " << lag_ns / utls::as_milliseconds << " ms. NTP drift is larger than 100 ms! Check White Rabbit and NTP synchronisation.";
 
   } else {
 
-    TLOG(TLVL_ERROR) << "Channel " << ch_id << ". Wrong TDC sample time. Host time > sample time; host_time-sample_time = " << lag_ns / 1e9 << " s. NTP drift is larger than 1 s! Check White Rabbit and NTP synchronisation.";
-
+    TLOG(TLVL_ERROR) << "Channel " << ch_id << ". Wrong TDC sample time. Host time > sample time; host_time-sample_time = " << lag_ns / utls::as_seconds << " s. NTP drift is larger than 1 s! Check White Rabbit and NTP synchronisation.";
 
     if (metricMan) {
       metricMan->sendMetric(metric_prefix + lit::tdc_laggy_samples, uint64_t{1}, lit::unit_samples_per_second, 11,

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -138,13 +138,13 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
 
   if (lag_ns < utls::max_sample_time_lag_ns) return;
 
-  if (lag_ns <= utls::onesecond_ns) {
+  if (lag_ns < utls::onesecond_ns) {
 
-    TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Host time > sample time; host_time-sample_time = " << lag_ns / utls::as_milliseconds << " ms. NTP drift is larger than 100 ms! Check White Rabbit and NTP synchronisation.";
+    TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Host time > sample time; host_time-sample_time = " << lag_ns / utls::as_milliseconds << " ms. NTP drift > 100 ms! Check White Rabbit and NTP synchronisation.";
 
   } else {
 
-    TLOG(TLVL_ERROR) << "Channel " << ch_id << ". Wrong TDC sample time. Host time > sample time; host_time-sample_time = " << lag_ns / utls::as_seconds << " s. NTP drift is larger than 1 s! Check White Rabbit and NTP synchronisation.";
+    TLOG(TLVL_ERROR) << "Channel " << ch_id << ". Wrong TDC sample time. Host time > sample time; host_time-sample_time = " << lag_ns / utls::as_seconds << " s. NTP drift >= 1 s! Check White Rabbit and NTP synchronisation.";
 
     if (metricMan) {
       metricMan->sendMetric(metric_prefix + lit::tdc_laggy_samples, uint64_t{1}, lit::unit_samples_per_second, 11,

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan.cc
@@ -140,7 +140,7 @@ void TDCChan::monitor_timestamp(uint64_t timestamp_ns, int ch_id) const {
 
   if (lag_ns < utls::onesecond_ns) {
 
-    TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Host time > sample time; host_time-sample_time = " << lag_ns / utls::as_milliseconds << " ms. NTP drift > 100 ms! Check White Rabbit and NTP synchronisation.";
+    TLOG(TLVL_WARN) << "Channel " << ch_id << ". Wrong TDC sample time. Host time > sample time; host_time-sample_time = " << lag_ns / utls::as_milliseconds << " ms. NTP drift > 300 ms! Check White Rabbit and NTP synchronisation.";
 
   } else {
 

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_drain.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_drain.cc
@@ -76,6 +76,6 @@ bool TDCChan::configure_drain_buffer() {
         ++drained_count;
       }
     }
-    utls::thread_sleep_ms(1);
+    utls::thread_sleep_us(500);
   }
 }

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
@@ -56,6 +56,7 @@ void TDCChan::read() {
   auto gap = uint64_t{0};
   for (decltype(read_count) i = 0; i < read_count; i++) {
     auto ts = make_timestamp(id, name, tdcts_arr[i]);
+
     if (fmctdc.tai2utc) adjust_tai2utc(ts, fmctdc.tai2utc);
 
     if (fmctdc.monitor_timestamps) monitor_timestamp(ts.timestamp_ns());

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
@@ -59,7 +59,7 @@ void TDCChan::read() {
 
     if (fmctdc.tai2utc) adjust_tai2utc(ts, fmctdc.tai2utc);
 
-    if (fmctdc.monitor_timestamps) monitor_timestamp(ts.timestamp_ns());
+    if (fmctdc.monitor_timestamps) monitor_timestamp(ts.timestamp_ns(), int{id});
     sample_info = as_string(ts);
 
     if (monitor_only) {

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
@@ -90,7 +90,20 @@ void TDCChan::read() {
                               MetricMode::Accumulate);
       }
     }
+
     last_seen_sample_seq = tdcts_arr[i].seq_id;
+
+    auto ts_gap = uint64_t{0};
+    ts_gap = ts.timestamp_ns() - last_seen_sample_ts; 
+    last_seen_sample_ts = ts.timestamp_ns();
+    if (ts_gap < 5e5) {
+      TLOG(TLVL_WARNING) << "Detected a time gap < 500 us in the channel " << int{id}
+                         << "; ts gap = " << ts_gap << " ns.";
+    }
+    if (metricMan) {
+      metricMan->sendMetric(metric_prefix + lit::tdc_ts_gap, uint64_t{ts_gap},
+                          lit::unit_sample_count, 11, MetricMode::LastPoint);
+    }
   }
 
   if (metricMan) {

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
@@ -98,7 +98,7 @@ void TDCChan::read() {
     last_seen_sample_ts = ts.timestamp_ns();
 
     if (ts_gap < fmctdc.max_time_gap_ns ) {
-      TLOG(TLVL_WARNING) << "Detected a time gap " << fmctdc.max_time_gap_ns << " in the channel " << int{id}
+      TLOG(TLVL_WARNING) << "Detected a time gap < " << fmctdc.max_time_gap_ns << " in the channel " << int{id}
                          << "; ts gap = " << ts_gap << " us.";
     }
     if (metricMan) {

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
@@ -96,9 +96,10 @@ void TDCChan::read() {
     auto ts_gap = uint64_t{0};
     ts_gap = ts.timestamp_ns() - last_seen_sample_ts; 
     last_seen_sample_ts = ts.timestamp_ns();
-    if (ts_gap < 5e3) {
-      TLOG(TLVL_WARNING) << "Detected a time gap < 5 us in the channel " << int{id}
-                         << "; ts gap = " << ts_gap/1e3 << " ns.";
+
+    if (ts_gap < utls::as_microseconds ) {
+      TLOG(TLVL_WARNING) << "Detected a time gap < 0.1 us in the channel " << int{id}
+                         << "; ts gap = " << ts_gap/utls::as_microseconds << " us.";
     }
     if (metricMan) {
       metricMan->sendMetric(metric_prefix + lit::tdc_ts_gap, uint64_t{ts_gap},

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
@@ -97,9 +97,9 @@ void TDCChan::read() {
     ts_gap = ts.timestamp_ns() - last_seen_sample_ts; 
     last_seen_sample_ts = ts.timestamp_ns();
 
-    if (ts_gap < utls::as_microseconds ) {
-      TLOG(TLVL_WARNING) << "Detected a time gap < 0.1 us in the channel " << int{id}
-                         << "; ts gap = " << ts_gap/utls::as_microseconds << " us.";
+    if (ts_gap < fmctdc.max_time_gap_ns ) {
+      TLOG(TLVL_WARNING) << "Detected a time gap " << fmctdc.max_time_gap_ns << " in the channel " << int{id}
+                         << "; ts gap = " << ts_gap << " us.";
     }
     if (metricMan) {
       metricMan->sendMetric(metric_prefix + lit::tdc_ts_gap, uint64_t{ts_gap},

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCChan_read.cc
@@ -96,9 +96,9 @@ void TDCChan::read() {
     auto ts_gap = uint64_t{0};
     ts_gap = ts.timestamp_ns() - last_seen_sample_ts; 
     last_seen_sample_ts = ts.timestamp_ns();
-    if (ts_gap < 5e5) {
-      TLOG(TLVL_WARNING) << "Detected a time gap < 500 us in the channel " << int{id}
-                         << "; ts gap = " << ts_gap << " ns.";
+    if (ts_gap < 5e3) {
+      TLOG(TLVL_WARNING) << "Detected a time gap < 5 us in the channel " << int{id}
+                         << "; ts gap = " << ts_gap/1e3 << " ns.";
     }
     if (metricMan) {
       metricMan->sendMetric(metric_prefix + lit::tdc_ts_gap, uint64_t{ts_gap},

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -21,9 +21,8 @@ uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
     //TLOG(TLVL_WARNING) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; sample_time-host_time="
     //                   << sample_time_ns - host_time_ns << " ns.";
 
-    TLOG(TLVL_WARNING) << "!!! Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns.";
-    TLOG(TLVL_WARNING) << "Sample time = " << sample_time_ns << " ns.";
-    TLOG(TLVL_WARNING) << "Host time = " << host_time_ns << " ns.";
+    TLOG(TLVL_WARNING) << "!!! Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns. Sample time = " << sample_time_ns << " ns. Host time = " << host_time_ns << " ns.";
+
     return sample_time_ns - host_time_ns; 
   }
 

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -21,18 +21,10 @@ uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
     //TLOG(TLVL_WARNING) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; sample_time-host_time="
     //                   << sample_time_ns - host_time_ns << " ns.";
 
-    TLOG(TLVL_WARNING) << "Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns.";
+    TLOG(TLVL_WARNING) << "!!! Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns.";
     TLOG(TLVL_WARNING) << "Sample time = " << sample_time_ns << " ns.";
     TLOG(TLVL_WARNING) << "Host time = " << host_time_ns << " ns.";
     return sample_time_ns - host_time_ns; 
-
-  }else{
-    //debug warning of fragment is not too far back in the past?
-    if( (host_time_ns - sample_time_ns) > 1e7 ){
-      TLOG(TLVL_WARNING) << "Host time < sample time; host_time-sample_time = " << host_time_ns - sample_time_ns << " ns.";
-      TLOG(TLVL_WARNING) << "Sample time = " << sample_time_ns << " ns.";
-      TLOG(TLVL_WARNING) << "Host time = " << host_time_ns << " ns.";
-    }
   }
 
   //expect host_time > server_time, otherwise bogus number subtracting uint64_t

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -11,7 +11,7 @@ using std::chrono::seconds;
 
 using clk = std::chrono::system_clock;
 
-double utls::elapsed_time_ns(uint64_t sample_time_ns) {
+uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
   uint64_t host_time_ns =
       std::chrono::duration_cast<nanoseconds>(clk::time_point{clk::now()}.time_since_epoch()).count();
 
@@ -24,7 +24,7 @@ double utls::elapsed_time_ns(uint64_t sample_time_ns) {
     TLOG(TLVL_WARNING) << "Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns.";
     TLOG(TLVL_WARNING) << "Sample time = " << sample_time_ns << " ns.";
     TLOG(TLVL_WARNING) << "Host time = " << host_time_ns << " ns.";
-    return host_time_ns - sample_time_ns; 
+    return sample_time_ns - host_time_ns; 
 
   }else{
     //debug warning of fragment is not too far back in the past?
@@ -33,12 +33,10 @@ double utls::elapsed_time_ns(uint64_t sample_time_ns) {
       TLOG(TLVL_WARNING) << "Sample time = " << sample_time_ns << " ns.";
       TLOG(TLVL_WARNING) << "Host time = " << host_time_ns << " ns.";
     }
-
-    return sample_time_ns - host_time_ns; 
   }
 
   //expect host_time > server_time, otherwise bogus number subtracting uint64_t
-  //return host_time_ns - sample_time_ns;
+  return host_time_ns - sample_time_ns;
 }
 
 uint64_t utls::hosttime() {

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -14,14 +14,21 @@ using clk = std::chrono::system_clock;
 uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
   uint64_t host_time_ns =
       std::chrono::duration_cast<nanoseconds>(clk::time_point{clk::now()}.time_since_epoch()).count();
-  if (sample_time_ns > host_time_ns)
-    TLOG(TLVL_WARNING) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; sample_time-host_time="
+
+  if (sample_time_ns > host_time_ns){
+
+    //TLOG(TLVL_WARNING) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; sample_time-host_time="
+    //                   << sample_time_ns - host_time_ns << " ns.";
+
+    TLOG(TLVL_WARNING) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time="
                        << sample_time_ns - host_time_ns << " ns.";
+
+  }
 
   //if host_time_ns - sample_time_ns is negative then most likely give bogus number: 18446744073
   //expect host_time > server_time
   
-  return (double)host_time_ns - (double)sample_time_ns;
+  return host_time_ns - sample_time_ns;
 }
 
 uint64_t utls::hosttime() {

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -11,7 +11,7 @@ using std::chrono::seconds;
 
 using clk = std::chrono::system_clock;
 
-uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
+double utls::elapsed_time_ns(uint64_t sample_time_ns) {
   uint64_t host_time_ns =
       std::chrono::duration_cast<nanoseconds>(clk::time_point{clk::now()}.time_since_epoch()).count();
 
@@ -21,21 +21,24 @@ uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
     //TLOG(TLVL_WARNING) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; sample_time-host_time="
     //                   << sample_time_ns - host_time_ns << " ns.";
 
-    TLOG(TLVL_WARNING) << "Sample time > host time; sample_time-host_time="
-                       << sample_time_ns - host_time_ns << " ns.";
+    TLOG(TLVL_WARNING) << "Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns.";
+    TLOG(TLVL_WARNING) << "Sample time = " << sample_time_ns << " ns.";
+    TLOG(TLVL_WARNING) << "Host time = " << host_time_ns << " ns.";
+    return host_time_ns - sample_time_ns; 
 
   }else{
     //debug warning of fragment is not too far back in the past?
     if( (host_time_ns - sample_time_ns) > 1e7 ){
-    TLOG(TLVL_WARNING) << "Host time < sample time; host_time-sample_time="
-                       << host_time_ns - sample_time_ns << " ns.";
-	}
+      TLOG(TLVL_WARNING) << "Host time < sample time; host_time-sample_time = " << host_time_ns - sample_time_ns << " ns.";
+      TLOG(TLVL_WARNING) << "Sample time = " << sample_time_ns << " ns.";
+      TLOG(TLVL_WARNING) << "Host time = " << host_time_ns << " ns.";
+    }
+
+    return sample_time_ns - host_time_ns; 
   }
 
-  //if host_time_ns - sample_time_ns is negative then most likely give bogus number: 18446744073
-  //expect host_time > server_time
-  
-  return host_time_ns - sample_time_ns;
+  //expect host_time > server_time, otherwise bogus number subtracting uint64_t
+  //return host_time_ns - sample_time_ns;
 }
 
 uint64_t utls::hosttime() {

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -21,12 +21,13 @@ uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
     //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; sample_time-host_time="
     //                   << sample_time_ns - host_time_ns << " ns.";
 
-    TLOG(TLVL_WARN) << "!!! Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns. Sample time = " << sample_time_ns << " ns. Host time = " << host_time_ns << " ns.";
+    TLOG(TLVL_WARN) << " !!! Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns. Sample time = " << sample_time_ns << " ns. Host time = " << host_time_ns << " ns.";
 
-    return sample_time_ns - host_time_ns; 
+    //for debugging: just so not giving bogus number for monitoring timestamp
+    //return sample_time_ns - host_time_ns; 
   }
 
-  //expect host_time > server_time, otherwise bogus number subtracting uint64_t
+  //expect host_time > server_time, otherwise bogus number subtracting uint64_t to negative number
   return host_time_ns - sample_time_ns;
 }
 

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -15,14 +15,21 @@ uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
   uint64_t host_time_ns =
       std::chrono::duration_cast<nanoseconds>(clk::time_point{clk::now()}.time_since_epoch()).count();
 
+  //pull window is +-10ms so what do I expect of host_time to server_time?
   if (sample_time_ns > host_time_ns){
 
     //TLOG(TLVL_WARNING) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; sample_time-host_time="
     //                   << sample_time_ns - host_time_ns << " ns.";
 
-    TLOG(TLVL_WARNING) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time="
+    TLOG(TLVL_WARNING) << "Sample time > host time; sample_time-host_time="
                        << sample_time_ns - host_time_ns << " ns.";
 
+  }else{
+    //debug warning of fragment is not too far back in the past?
+    if( (host_time_ns - sample_time_ns) > 1e7 ){
+    TLOG(TLVL_WARNING) << "Host time < sample time; host_time-sample_time="
+                       << host_time_ns - sample_time_ns << " ns.";
+	}
   }
 
   //if host_time_ns - sample_time_ns is negative then most likely give bogus number: 18446744073

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -18,10 +18,10 @@ uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
   //pull window is +-10ms so what do I expect of host_time to server_time?
   if (sample_time_ns > host_time_ns){
 
-    //TLOG(TLVL_WARNING) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; sample_time-host_time="
+    //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; sample_time-host_time="
     //                   << sample_time_ns - host_time_ns << " ns.";
 
-    TLOG(TLVL_WARNING) << "!!! Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns. Sample time = " << sample_time_ns << " ns. Host time = " << host_time_ns << " ns.";
+    TLOG(TLVL_WARN) << "!!! Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns. Sample time = " << sample_time_ns << " ns. Host time = " << host_time_ns << " ns.";
 
     return sample_time_ns - host_time_ns; 
   }

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -18,7 +18,10 @@ uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
     TLOG(TLVL_WARNING) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; sample_time-host_time="
                        << sample_time_ns - host_time_ns << " ns.";
 
-  return host_time_ns - sample_time_ns;
+  //if host_time_ns - sample_time_ns is negative then most likely give bogus number: 18446744073
+  //expect host_time > server_time
+  
+  return (double)host_time_ns - (double)sample_time_ns;
 }
 
 uint64_t utls::hosttime() {

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -17,13 +17,19 @@ uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
       std::chrono::duration_cast<nanoseconds>(clk::time_point{clk::now()}.time_since_epoch()).count();
   
   if (sample_time_ns > host_time_ns){
-    
-    if((sample_time_ns - host_time_ns) > max_sample_time_lag_ns ) {
-      TLOG(TLVL_WARNING) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< sample_time_ns - utls::as_seconds << " ms. NTP drift is larger than 100 ms! Check White Rabbit and NTP synchronisation.";
-    }
+
+    auto lag_ns = sample_time_ns - host_time_ns;  
+
+    if ( lag_ns < utls::max_sample_time_lag_ns) return 0;       
  
-    if((sample_time_ns - host_time_ns) > utls::onesecond_ns) {
-      TLOG(TLVL_ERROR) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< (sample_time_ns - host_time_ns) / utls::as_seconds << " s. NTP drift is larger than 1s! Check White Rabbit and NTP synchronisation.";
+    if ( lag_ns <= utls::onesecond_ns ) {
+
+      TLOG(TLVL_WARNING) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< lag_ns - utls::as_seconds << " ms. NTP drift is larger than 100 ms! Check White Rabbit and NTP synchronisation.";
+
+    } else {
+ 
+      TLOG(TLVL_ERROR) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< lag_ns / utls::as_seconds << " s. NTP drift is larger than 1s! Check White Rabbit and NTP synchronisation.";
+
     }
 
     return 0;

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -16,18 +16,15 @@ uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
   uint64_t host_time_ns =
       std::chrono::duration_cast<nanoseconds>(clk::time_point{clk::now()}.time_since_epoch()).count();
   
- // if (host_time_ns > sample_time_ns) {
- // }
-
   if (sample_time_ns > host_time_ns){
     
-    //if((sample_time_ns - host_time_ns) > fmctdc.max_sample_time_lag_ns ) {
-    //  TLOG(TLVL_WARNING) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns. NTP drift is larger than 100 ms! Check White Rabbit and NTP synchronisation.";
-    //}
+    if((sample_time_ns - host_time_ns) > max_sample_time_lag_ns ) {
+      TLOG(TLVL_WARNING) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< sample_time_ns - utls::as_seconds << " ms. NTP drift is larger than 100 ms! Check White Rabbit and NTP synchronisation.";
+    }
  
-    //if((sample_time_ns - host_time_ns) > utls::onesecond_ns) {
-    //  TLOG(TLVL_ERROR) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< (sample_time_ns - host_time_ns) / utils::onesecond_ns << " ns. NTP drift is larger than 1s! Check White Rabbit and NTP synchronisation.";
-    //}
+    if((sample_time_ns - host_time_ns) > utls::onesecond_ns) {
+      TLOG(TLVL_ERROR) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< (sample_time_ns - host_time_ns) / utls::as_seconds << " s. NTP drift is larger than 1s! Check White Rabbit and NTP synchronisation.";
+    }
 
     return 0;
   }

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -24,7 +24,7 @@ uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
  
     if ( lag_ns < utls::onesecond_ns ) {
 
-      TLOG(TLVL_WARNING) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< lag_ns - utls::as_seconds << " ms. NTP drift > 100 ms! Check White Rabbit and NTP synchronisation.";
+      TLOG(TLVL_WARNING) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< lag_ns - utls::as_seconds << " ms. NTP drift > 300 ms! Check White Rabbit and NTP synchronisation.";
 
     } else {
  

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -22,13 +22,13 @@ uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
 
     if ( lag_ns < utls::max_sample_time_lag_ns) return 0;       
  
-    if ( lag_ns <= utls::onesecond_ns ) {
+    if ( lag_ns < utls::onesecond_ns ) {
 
-      TLOG(TLVL_WARNING) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< lag_ns - utls::as_seconds << " ms. NTP drift is larger than 100 ms! Check White Rabbit and NTP synchronisation.";
+      TLOG(TLVL_WARNING) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< lag_ns - utls::as_seconds << " ms. NTP drift > 100 ms! Check White Rabbit and NTP synchronisation.";
 
     } else {
  
-      TLOG(TLVL_ERROR) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< lag_ns / utls::as_seconds << " s. NTP drift is larger than 1s! Check White Rabbit and NTP synchronisation.";
+      TLOG(TLVL_ERROR) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< lag_ns / utls::as_seconds << " s. NTP drift >= 1s! Check White Rabbit and NTP synchronisation.";
 
     }
 

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/TDCTimeUtils.cc
@@ -10,24 +10,28 @@ using std::chrono::nanoseconds;
 using std::chrono::seconds;
 
 using clk = std::chrono::system_clock;
+using namespace sbndaq::SPECTDCInterface;
 
 uint64_t utls::elapsed_time_ns(uint64_t sample_time_ns) {
   uint64_t host_time_ns =
       std::chrono::duration_cast<nanoseconds>(clk::time_point{clk::now()}.time_since_epoch()).count();
+  
+ // if (host_time_ns > sample_time_ns) {
+ // }
 
-  //pull window is +-10ms so what do I expect of host_time to server_time?
   if (sample_time_ns > host_time_ns){
+    
+    //if((sample_time_ns - host_time_ns) > fmctdc.max_sample_time_lag_ns ) {
+    //  TLOG(TLVL_WARNING) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns. NTP drift is larger than 100 ms! Check White Rabbit and NTP synchronisation.";
+    //}
+ 
+    //if((sample_time_ns - host_time_ns) > utls::onesecond_ns) {
+    //  TLOG(TLVL_ERROR) << "Wrong TDC sample time. Sample time > host time; sample_time-host_time = "<< (sample_time_ns - host_time_ns) / utils::onesecond_ns << " ns. NTP drift is larger than 1s! Check White Rabbit and NTP synchronisation.";
+    //}
 
-    //TLOG(TLVL_WARN) << "Wrong TDC sample time, check the NTP and WhiteRabbit timing systems; sample_time-host_time="
-    //                   << sample_time_ns - host_time_ns << " ns.";
-
-    TLOG(TLVL_WARN) << " !!! Sample time > host time; sample_time-host_time = "<< sample_time_ns - host_time_ns << " ns. Sample time = " << sample_time_ns << " ns. Host time = " << host_time_ns << " ns.";
-
-    //for debugging: just so not giving bogus number for monitoring timestamp
-    //return sample_time_ns - host_time_ns; 
+    return 0;
   }
-
-  //expect host_time > server_time, otherwise bogus number subtracting uint64_t to negative number
+  
   return host_time_ns - sample_time_ns;
 }
 


### PR DESCRIPTION
### Description

- Fix monitoring timestamp of SBND in cases of subtracting unsigned integers returning negative.

- Added channel ID to monitoring timestamp to track which channel is sending errors.

- Added warning messages if NTP drift time > 100 ms and error messages if NTP drift time > 1s.

- Added new Grafana metric to report timestamp gap between samples in a channel.

_If the full description is in a PR from a different repo, simply link that here, and delete the rest._

### Related Repository Branches

List related branches from other repos here (links to PRs even better!), if not linked above.

### Testing details
_(Note: edit as appropriate.)_
- *Where it was tested*: SBN-ND
- *Run number associated with test*: 
- Other information: 
