### PR TITLE
Fix LVDS logic registers

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -97,13 +97,13 @@ namespace sbndaq
       READOUT_CONTROL    = 0xEF00,
       // Animesh & Aiwu add registers for the LVDS logic
       FP_LVDS_Logic_G1   = 0x1084,
-      FP_LVDS_Logic_G2   = 0x1184,
-      FP_LVDS_Logic_G3   = 0x1284,
-      FP_LVDS_Logic_G4   = 0x1384,
-      FP_LVDS_Logic_G5   = 0x1484,
-      FP_LVDS_Logic_G6   = 0x1584,
-      FP_LVDS_Logic_G7   = 0x1684,
-      FP_LVDS_Logic_G8   = 0x1784,
+      FP_LVDS_Logic_G2   = 0x1284,
+      FP_LVDS_Logic_G3   = 0x1484,
+      FP_LVDS_Logic_G4   = 0x1684,
+      FP_LVDS_Logic_G5   = 0x1884,
+      FP_LVDS_Logic_G6   = 0x1A84,
+      FP_LVDS_Logic_G7   = 0x1C84,
+      FP_LVDS_Logic_G8   = 0x1E84,
       // Animesh & Aiwu add end
       // Animesh & Aiwu add registers for the LVDS output width
       FP_LVDS_OutWidth_Ch1   = 0x1070,


### PR DESCRIPTION
### Description

This PR fixes a bug in the addresses of the registers that control the LVDS self-trigger logic.
The addresses were hardcoded in `CAENV1730Readout.hh` as `0x1n84` with `n=0,...,7`.
However, according to the CAEN manual and confirmed with CAEN support:

> For a couple of channels of adjacent channels, this register sets the logic to generate the trigger request signal upon
> the self‐triggers from the two channels of the couple. Please, refer to the digitizer User Manual (Self‐Trigger section)
> for complete description.
> In case of DT, NIM and 8‐channel VME boards: n = 0 (CH0‐CH1), 2 (CH2‐CH3), 4 (CH4‐CH5), 6 (CH6‐ Ch7). In case of
> 16‐channel VME boards, also n = 8 (CH8‐CH9), n = A (CH10‐CH11), n = C (CH12‐ CH13), n = E (CH14‐CH15) are admitted

I'm fixing the list of addresses with `0x1n84` with `n=0,2,...,C,E` as reported in the manual.
Please note that other channel registers (like `0x1n70`) use `n=0,...,F` instead.

#### How does it affect ICARUS?

ICARUS was not affected in the past years ~~thanks to sheer, dumb luck~~ . 
The value we are writing in the registers is `0x3` (= OR) which is the same as the *default* value. 
As a result, even if `0x1884`, `0x1A84`, `0x1C84`, and `0x1E84` were not being set by our configuration, the default values were the same and we never noticed.
CAEN experts also confirmed to us that writing in the odd-numbered registers doesn't do any damage: the registers exist, but the FPGA does nothing with them.

#### How does it affect SBND?

SBND was not using the hardcoded registers, so no it's not affected.
Addresses are being built dynamically & correctly inside a loop in `ConfigureSelfTriggerMode()`:
```
for(uint32_t chn=0; chn<fNChannels; ++chn){
  // GVS: inserted triggerLogic for each PAIR of channels.
  if(chn%2==0){    
    retcod = CAEN_DGTZ_ReadRegister(fHandle,SLF_TRG_LG_CH+(chn<<8),&aux);
    TLOG_ARB(TCONFIG,TRACE_NAME) << "Self-trigger logic to channel " << chn << " old value " << std::hex << aux << std::dec;
    TLOG_ARB(TCONFIG,TRACE_NAME) << "Set channels " << chn << "/" << chn+1 << " self trigger logic to " << fCAEN.triggerLogic
    /* << " self trigger pulse type to " << fCAEN.ovthValue*/ << TLOG_ENDL;
    retcod = CAEN_DGTZ_WriteRegister(fHandle,SLF_TRG_LG_CH+(chn<<8), 
                                                                   (fCAEN.triggerLogic & 0x3)/* + ((fCAEN.ovthValue & 0x1) <<2)*/);
```

### Testing details
No specific testing is needed apart from standard integration tests.
For ICARUS: checking the logfile will show immediately if all the registers are being set to `0x3` after the change. 
