### PR TITLE
Update CAENVMELib to v4.0.2

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -22,7 +22,7 @@ product               version      optional
 artdaq                v3_13_02
 sbndaq_artdaq_core    v1_10_02
 caencomm              v1_7_0
-caenvme               v4_0_1
+caenvme               v4_0_2
 caendigitizer         v2_17_3b
 pqxx                  v7_7_4c
 epics                 v7_0_7b


### PR DESCRIPTION
### Description

CAEN is deprecating A3818 cards. The suggested replacement is the new A5818 card.
ICARUS has received 2 A5818 cards for testing. If testing is successful, we will be using them as spares.
However, A5818s require **CAENVMELib >= 4.0.2**.
While we don't need this library for the initial testing, it would be better to update the dependency now.

### Testing details
No testing has been performed yet.