### PR TITLE
Add in a module for filestreaming by HLT type for SBND

### DIFF
--- a/sbndaq-artdaq/ArtModules/SBND/CMakeLists.txt
+++ b/sbndaq-artdaq/ArtModules/SBND/CMakeLists.txt
@@ -8,6 +8,7 @@ cet_build_plugin( EventAna art::module LIBRARIES REG ${BUILD_PLUGIN_CORE_LIB_LIS
 cet_build_plugin( CRTHitAna art::module LIBRARIES REG ${BUILD_PLUGIN_CORE_LIB_LIST} )
 cet_build_plugin( CRTSinglePEAna art::module LIBRARIES REG ${BUILD_PLUGIN_CORE_LIB_LIST} )
 cet_build_plugin( SBNDPMTV1730Ana art::module LIBRARIES REG ${BUILD_PLUGIN_CORE_LIB_LIST} )
+cet_build_plugin( SBNDGateFilter art::module LIBRARIES REG ${BUILD_PLUGIN_CORE_LIB_LIST} )
 
 include(ArtdaqCorePlugins)
 cet_build_plugin(SBND artdaq::fragmentNameHelper LIBRARIES REG ${BUILD_PLUGIN_FRAGNAMEHELPER_LIB_LIST})

--- a/sbndaq-artdaq/ArtModules/SBND/SBNDGateFilter_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SBNDGateFilter_module.cc
@@ -1,0 +1,195 @@
+/////////////////////////////////////////////////////////////////////
+// Class: ICARUSGateFilter_module.cc
+// Module Type: analyzer
+// File: ICARUSGateFilter_module.cc
+// Description: Filter if Gate Matches
+/////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/EDFilter.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Utilities/ExceptionMessages.h"
+
+#include "sbndaq-artdaq-core/Overlays/SBND/PTBFragment.hh"
+#include "artdaq-core/Data/ContainerFragment.hh"
+
+
+#include "artdaq/DAQdata/Globals.hh"
+#include "artdaq-core/Data/Fragment.hh"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <vector>
+#include <iostream>
+
+#ifdef TRACE_NAME
+#undef TRACE_NAME
+#endif
+
+#define TRACE_NAME "SBNDGateFilter_module"
+
+namespace sbnd {
+  class SBNDGateFilter;
+}
+
+
+class sbnd::SBNDGateFilter : public art::EDFilter {
+public:
+  explicit SBNDGateFilter(fhicl::ParameterSet const & pset);
+  virtual ~SBNDGateFilter();
+
+  virtual bool filter(art::Event & evt) override;
+  //template <class T>  
+  std::vector<uint64_t> GetAllHLTs(artdaq::ContainerFragment *trigfrag);
+  std::vector<uint64_t> GetHLT(sbndaq::CTBFragment ptb_fragment);
+  bool ApplyGateFilter(std::vector<uint64_t> triggers); //(artdaq::ContainerFragment *trigfrag);
+
+private:
+  std::string fInputLabel, fInputContainerInstance, fInputNonContainerInstance;
+  int ftrigger_type;
+  std::vector<uint64_t> fexcluded_triggers;
+};
+
+sbnd::SBNDGateFilter::SBNDGateFilter(fhicl::ParameterSet const & pset)
+  : EDFilter(pset),
+    fInputLabel(pset.get<std::string>("InputLabel", "daq")),
+    fInputContainerInstance(pset.get<std::string>("InputContainerInstance", "ContainerPTB")), 
+    fInputNonContainerInstance(pset.get<std::string>("InputNonContainerInstance", "PTB")), 
+    ftrigger_type(pset.get<int>("trigger_type",-1)),
+    fexcluded_triggers( pset.get< std::vector<uint64_t> >("excluded_triggers", {}))
+{
+}
+
+sbnd::SBNDGateFilter::~SBNDGateFilter()
+{
+}
+
+std::vector<uint64_t> sbnd::SBNDGateFilter::GetAllHLTs(artdaq::ContainerFragment*  ptb_container_fragment){
+  std::vector<uint64_t> triggers;  
+  
+  for (size_t f=0; f<ptb_container_fragment->block_count(); ++f){//loop over container of fragments
+    artdaq::Fragment frag=*ptb_container_fragment->at(f).get();
+    sbndaq::CTBFragment ptb_fragment(frag);
+    //==============
+    std::vector fragTriggers=GetHLT(ptb_fragment); //Not sure that there could really be multiple HLTs in a single fragment but just in case I'll make it vector
+    triggers.insert(triggers.end(), fragTriggers.begin(), fragTriggers.end() );//append list of triggers in this fragment to all of the HLTs in the container
+  }//end loop over fragments
+  
+  return triggers;
+}
+
+
+
+std::vector<uint64_t> sbnd::SBNDGateFilter::GetHLT(sbndaq::CTBFragment ptb_fragment){
+  std::vector<uint64_t> triggers;  
+
+  for ( size_t i = 0; i < ptb_fragment.NWords(); i++ ) {//loop over words in fragment       
+    //if  (ptb_fragment.Word(i)->IsHLT()==false) continue;  
+    if  (ptb_fragment.Word(i)->word_type !=0x2 ) continue; //0x2 is the type for an HLT (0x1 for LLT) 
+    uint64_t hlttrigger=ptb_fragment.Trigger(i)->trigger_word & 0x1FFFFFFFFFFFFFFF;
+    hlttrigger= log(1.*hlttrigger)/log(2.) ; 
+    if(hlttrigger>=20) continue; //HLT triggers greater then 20 are reserved for non event triggers
+    triggers.emplace_back(hlttrigger);
+  }
+  
+  return triggers;
+}
+
+
+
+
+
+//template <class T> 
+bool sbnd::SBNDGateFilter::ApplyGateFilter(std::vector<uint64_t> triggers)//artdaq::ContainerFragment*  ptb_container_fragment)//(T trigfrag)
+{
+
+  TLOG(TLVL_DEBUG) << "ApplyGateFilter function start";
+  if(triggers.size()==0){
+    TLOG(TLVL_WARNING) << "This event has no HLT fragments or none with trigger numbers then 20. It fails filter.";
+    return false;
+  }
+
+  if(triggers.size()>1){
+    TLOG(TLVL_INFO) << "This event has "<<triggers.size()<<" HLTs in it. Filter will pass if any are trigger type == "<<ftrigger_type<<".";
+  }
+
+  std::string trigstring="";
+  bool passesFilter=false;
+
+  for(int hlttrigger: triggers){
+    if(fexcluded_triggers.size()>0){//Need to loop through all of the excluded trigger types to check for them for each present HLT 
+      for(  int excluded_trigger : fexcluded_triggers){
+	if (hlttrigger==excluded_trigger){
+	  TLOG(TLVL_DEBUG) << "This Event contains an excluded trigger type " << hlttrigger << "==" << excluded_trigger<< " so fails the filter.";
+	  return false;
+	}
+      }
+    }//end loop over excluded triggers
+    
+    if( hlttrigger==ftrigger_type || ftrigger_type==-1){
+      TLOG(TLVL_INFO) << "This Event has trigger type " << hlttrigger << "==" << ftrigger_type
+		       << "  and passes filter.";
+      passesFilter=true;
+      if(fexcluded_triggers.size()==0) break;//no need to keep looking through the triggers if none are excluded
+    }
+    trigstring+= std::to_string(hlttrigger)+", ";
+  }//end loop hlts 
+
+
+
+
+  if (passesFilter) return true;
+  
+  TLOG(TLVL_WARN) << "This Event has trigger type { " << trigstring.c_str()  << "} ==" 
+		   << ftrigger_type << " and fails filter.";
+  return false;
+
+}
+
+
+
+bool sbnd::SBNDGateFilter::filter(art::Event & evt)
+{
+  TLOG_ENTEX(TLVL_DEBUG);// << "SBNDGateFilter::filter" 
+  TLOG(TLVL_DEBUG) << "filter:l157";
+  art::EventNumber_t eventNumber = evt.event();
+
+  // Look for fragments
+  // HLT trigger words: 1-BNB Zero bias, 2-BNB+Light, 
+  // 3-Offbeam Zero bias, 4-Offbeam+Light, 5-Crossing Muon
+ 
+  TLOG(TLVL_DEBUG) << "filter:l163";
+  art::InputTag itag(fInputLabel, fInputContainerInstance);
+  auto cont_frags = evt.getHandle<artdaq::Fragments>(itag);
+  TLOG(TLVL_DEBUG) << "filter: got some sort of fragments maybe";
+
+  if(cont_frags) 
+  {
+    //Are these always container fragments? 
+    for(auto const& cont : *cont_frags){
+      artdaq::ContainerFragment contf(cont);                                               
+      //if (contf.fragment_type() != sbndaq::detail::FragmentType::PTB) continue; 
+      bool filter_result = false;
+      artdaq::ContainerFragment* contf2=&contf;
+      std::vector hlts=GetAllHLTs(&contf);
+      filter_result = ApplyGateFilter(hlts);//&contf);//<artdaq::ContainerFragment>(contf);
+      TLOG(TLVL_DEBUG) << "filter:l179";
+      return filter_result;
+    }
+  }
+  
+
+  else if(!cont_frags) {
+    TLOG(TLVL_WARN) << "Run " << evt.run() << ", subrun " << evt.subRun() << ", event " << eventNumber << " has zero HLT word Fragments in module, not separating by beam type!";
+  }
+
+  TLOG(TLVL_DEBUG) << "filter:l89";
+  
+  return false;
+}
+
+DEFINE_ART_MODULE(sbnd::SBNDGateFilter)

--- a/sbndaq-artdaq/ArtModules/SBND/SBNDGateFilter_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SBNDGateFilter_module.cc
@@ -131,7 +131,7 @@ bool sbnd::SBNDGateFilter::ApplyGateFilter(std::vector<uint64_t> triggers)//artd
     }//end loop over excluded triggers
     
     if( hlttrigger==ftrigger_type || ftrigger_type==-1){
-      TLOG(TLVL_INFO) << "This Event has trigger type " << hlttrigger << "==" << ftrigger_type
+      TLOG(TLVL_DEBUG) << "This Event has trigger type " << hlttrigger << "==" << ftrigger_type
 		       << "  and passes filter.";
       passesFilter=true;
       if(fexcluded_triggers.size()==0) break;//no need to keep looking through the triggers if none are excluded
@@ -144,7 +144,7 @@ bool sbnd::SBNDGateFilter::ApplyGateFilter(std::vector<uint64_t> triggers)//artd
 
   if (passesFilter) return true;
   
-  TLOG(TLVL_WARN) << "This Event has trigger type { " << trigstring.c_str()  << "} ==" 
+  TLOG(TLVL_DEBUG) << "This Event has trigger type { " << trigstring.c_str()  << "} ==" 
 		   << ftrigger_type << " and fails filter.";
   return false;
 

--- a/sbndaq-artdaq/ArtModules/SBND/filters_standard.fcl
+++ b/sbndaq-artdaq/ArtModules/SBND/filters_standard.fcl
@@ -1,0 +1,44 @@
+
+bnbzerobiasfilter: {
+  module_type: "SBNDGateFilter" 
+  raw_data_label: "daq" 
+  #BNB  #zerobias
+  trigger_type: 1 #zerobias
+}
+
+bnblightfilter: {
+  module_type: "SBNDGateFilter" 
+  raw_data_label: "daq" 
+  #BNB
+  trigger_type: 2 #light
+}
+
+offbeamzerobiasfilter: {
+  module_type: "SBNDGateFilter" 
+  raw_data_label: "daq" 
+  #OffBeamBNB
+  trigger_type: 3 #zerobias
+}
+
+
+offbeamlightfilter: {
+  module_type: "SBNDGateFilter" 
+  raw_data_label: "daq" 
+  #OffBeamBNB
+  trigger_type: 4 #light
+  #light
+}
+
+crossingmuonfilter: {
+  module_type: "SBNDGateFilter" 
+  raw_data_label: "daq" 
+  trigger_type: 5
+  #crossing muon... might need more of these for different subsets of crossing muon
+}
+
+randomtriggerfilter: {
+  module_type: "SBNDGateFilter" 
+  raw_data_label: "daq" 
+  trigger_type: 0
+  #random strobe trigger from the PTB itself
+}

--- a/sbndaq-artdaq/ArtModules/SBND/filters_standard.fcl
+++ b/sbndaq-artdaq/ArtModules/SBND/filters_standard.fcl
@@ -1,44 +1,65 @@
-
+#BEGIN_PROLOG
 bnbzerobiasfilter: {
-  module_type: "SBNDGateFilter" 
+
+  module_type: SBNDGateFilter 
+
   raw_data_label: "daq" 
   #BNB  #zerobias
-  trigger_type: 1 #zerobias
-}
+  trigger_type: [1] #zerobias
+  #zerobias
+  excluded_triggers: [3, 4, 14, 15] 
 
+}
 bnblightfilter: {
-  module_type: "SBNDGateFilter" 
+
+  module_type: SBNDGateFilter 
+
   raw_data_label: "daq" 
   #BNB
-  trigger_type: 2 #light
-}
-
-offbeamzerobiasfilter: {
-  module_type: "SBNDGateFilter" 
-  raw_data_label: "daq" 
-  #OffBeamBNB
-  trigger_type: 3 #zerobias
-}
-
-
-offbeamlightfilter: {
-  module_type: "SBNDGateFilter" 
-  raw_data_label: "daq" 
-  #OffBeamBNB
-  trigger_type: 4 #light
+  trigger_type: [2] #light
   #light
-}
+  excluded_triggers: [3, 4, 14, 15] 
 
+}
+offbeamzerobiasfilter: {
+
+  module_type: SBNDGateFilter 
+
+  raw_data_label: "daq" 
+  #OffBeamBNB
+  trigger_type: [3] #zerobias
+  #zerobias
+  excluded_triggers: [1, 2, 14, 15] 
+
+}
+offbeamlightfilter: {
+
+  module_type: SBNDGateFilter 
+
+  raw_data_label: "daq" 
+  #OffBeamBNB
+  trigger_type: [4] #light
+  #light
+  excluded_triggers: [1, 2, 14, 15] 
+
+}
 crossingmuonfilter: {
-  module_type: "SBNDGateFilter" 
-  raw_data_label: "daq" 
-  trigger_type: 5
-  #crossing muon... might need more of these for different subsets of crossing muon
-}
 
-randomtriggerfilter: {
-  module_type: "SBNDGateFilter" 
+  module_type: SBNDGateFilter 
+
   raw_data_label: "daq" 
-  trigger_type: 0
-  #random strobe trigger from the PTB itself
+
+  trigger_type: [14, 15] 
+  #crossing muon... might need more of these for different subsets of crossing muon
+  excluded_triggers: [1, 2, 3, 4] 
+
+}
+randomtriggerfilter: {
+
+  module_type: SBNDGateFilter 
+
+  raw_data_label: "daq" 
+
+  trigger_type: [0]
+
 }

--- a/sbndaq-artdaq/ArtModules/SBND/run_sbndgatefilter.fcl
+++ b/sbndaq-artdaq/ArtModules/SBND/run_sbndgatefilter.fcl
@@ -1,0 +1,45 @@
+#include "filters_standard.fcl"
+
+process_name: SBNDGateFilter
+
+services: {
+}
+
+#source is a root file
+source:
+{
+  module_type: RootInput
+}
+
+outputs:
+{
+  out:{
+    module_type: RootOutput
+    fileName: "sbndgatefilter.root"
+  }
+}
+
+physics:
+{
+
+ producers:{
+ }
+
+ filters:{
+    bnbzerobiasfilter : @local::bnbzerobiasfilter
+ }
+
+ analyzers:{ 
+ }
+
+ bnbzerobias: [bnbzerobiasfilter]
+
+ #define the output stream, there could be more than one if using filters 
+ stream1:  [ out ]
+
+ trigger_paths: [ bnbzerobias ]
+
+ #end_paths is a keyword and contains the paths that do not modify the art::Event, 
+ #ie analyzers and output streams.  these all run simultaneously
+ end_paths:     [ stream1]  
+}


### PR DESCRIPTION
### Description

Added SBNDGateFilter to allow for sorting data into different file streams based on the HLT. 
Takes in a list of trigger types to look for and trigger types to exclude. If the fragment contains any of the excluded triggers it fails the filter, and otherwise passes if it includes any of the searched for triggers. 

### Testing details
Run 17651 -- tested with the full commissioning trigger menu that files are sorted as expected 
