### PR TITLE
Add SPECTDCFragmentPreProcessor

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/CMakeLists.txt
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/CMakeLists.txt
@@ -15,6 +15,8 @@ cet_make_library(
     TDCTimeUtils.cc
     StringUtils.cc
     TAI2UTCAdjustment.cc
+    SPECTDCFragmentPreProcessor.cc
+    SPECTDCFragmentPreProcessor_utils.cc
   LIBRARIES
     ${LIBRARY_CORE_LIB_LIST}
     sbndaq-artdaq_fmctdclib

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDCFragmentPreProcessor.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDCFragmentPreProcessor.cc
@@ -88,7 +88,7 @@ void SPECTDCFragmentPreProcessor::filterFragmentsByTimestamp(artdaq::FragmentPtr
   partitionPoint_ = std::max(acceptBeforeTimestamp, oldestMostRecentPoint_);
   for (auto& fragment : fragments) {
     if (!fragment) continue;
-    if (fragment->timestamp() <= partitionPoint_) {
+    if (fragment->timestamp() < partitionPoint_) {
       acceptedFragments.push_back(std::move(fragment));
     } else {
       pendingFragments_.push_back(std::move(fragment));

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDCFragmentPreProcessor.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDCFragmentPreProcessor.cc
@@ -1,0 +1,84 @@
+#include "sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDCFragmentPreProcessor.hh"
+
+#define TRACE_NAME "SPECTDCFragmentPreProcessor"
+
+#include <chrono>
+#include <iostream>
+#include <numeric>
+#include <unordered_map>
+#include "tracemf.h"
+#include "sbndaq-artdaq-core/Overlays/SBND/TDCTimestampFragment.hh"
+
+using sbndaq::SPECTDCFragmentPreProcessor;
+
+SPECTDCFragmentPreProcessor::~SPECTDCFragmentPreProcessor() {
+  if (fragmentCounter_ + pendingFragments_.size() != seenFragmentCount_) {
+    TLOG(TLVL_INFO) << "Processed fragments (" << fragmentCounter_ << " processed + " << pendingFragments_.size()
+                    << " pending) does not equal total fragments seen (" << seenFragmentCount_ << ")\n";
+  }
+
+  pendingFragments_.clear();
+}
+
+bool SPECTDCFragmentPreProcessor::processFragments(artdaq::FragmentPtrs& fragments) noexcept {
+  std::lock_guard<std::mutex> lock(processingMutex_);
+  try {
+    if (fragments.empty() && pendingFragments_.empty()) return true;
+    seenFragmentCount_ += fragments.size();
+    validateFragments(fragments);
+    mergePendingFragments(fragments);
+    qsortFragmentsByTimestamp(fragments);
+    const auto currentTime = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                 std::chrono::system_clock::now().time_since_epoch())
+                                 .count();
+    acceptBeforeTimestamp_ = currentTime - releaseFragmentTimeout_;
+    filterFragmentsByTimestamp(fragments, acceptBeforeTimestamp_);
+    assignSequentialIDs(fragments, true);
+    return true;
+  } catch (const std::exception& e) {
+    TLOG(TLVL_ERROR) << "Caught exception in processFragments: " << e.what() << "\n";
+    return false;
+  }
+}
+
+void SPECTDCFragmentPreProcessor::filterFragmentsByTimestamp(artdaq::FragmentPtrs& fragments,
+                                                             std::uint64_t acceptBeforeTimestamp) {
+  if (fragments.empty()) return;
+  /*This function implements the oldest-most-recent algorithm, which retains artdaq fragments based
+    on the timestamp up to the oldest sample among recent samples across all active TDC channels.
+    Fragments older then this timestamp are moved to the pendingFragments list. Additionally, artdaq
+    fragments are retained if they remain pending beyond a configurable timeout period, which may
+    occur when certain channels stop receiving data.*/
+  using sbndaq::TDCTimestampFragment;
+  artdaq::FragmentPtrs acceptedFragments;
+  struct ChannelInfo {
+    uint64_t timestamp{0};
+    artdaq::FragmentPtr* fragment{nullptr};
+  };
+  std::unordered_map<std::uint32_t, ChannelInfo> channelLatest;
+  channelLatest.reserve(32);
+  for (auto it = fragments.rbegin(); it != fragments.rend(); ++it) {
+    auto& fragment = *it;
+    if (!fragment) continue;
+    auto& info = channelLatest[TDCTimestampFragment(*fragment).getTDCTimestamp()->vals.channel];
+    const auto timestamp = fragment->timestamp();
+    if (timestamp > info.timestamp) {
+      info.timestamp = timestamp;
+      info.fragment = &fragment;
+    }
+  }
+  oldestMostRecentPoint_ = std::transform_reduce(
+      channelLatest.begin(), channelLatest.end(), std::numeric_limits<uint64_t>::max(),
+      [](uint64_t a, uint64_t b) { return std::min(a, b); },
+      [](const auto& pair) { return pair.second.timestamp; });
+  partitionPoint_ = std::max(acceptBeforeTimestamp, oldestMostRecentPoint_);
+  for (auto& fragment : fragments) {
+    if (!fragment) continue;
+    if (fragment->timestamp() <= partitionPoint_) {
+      acceptedFragments.push_back(std::move(fragment));
+    } else {
+      pendingFragments_.push_back(std::move(fragment));
+    }
+  }
+  fragments = std::move(acceptedFragments);
+}

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDCFragmentPreProcessor.hh
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDCFragmentPreProcessor.hh
@@ -1,0 +1,74 @@
+#ifndef sbndaq_artdaq_Generators_SPECTDCFragmentPreProcessor_hh
+#define sbndaq_artdaq_Generators_SPECTDCFragmentPreProcessor_hh
+
+#include <cstddef>
+#include <cstdint>
+#include <list>
+#include <mutex>
+#include <stdexcept>
+
+#include "artdaq-core/Data/Fragment.hh"
+
+namespace sbndaq {
+class SPECTDCFragmentPreProcessor {
+ public:
+  explicit SPECTDCFragmentPreProcessor(std::uint64_t timeout_us = 1250000 )
+      : releaseFragmentTimeout_{timeout_us * 1000} {};
+
+  ~SPECTDCFragmentPreProcessor();
+
+  [[nodiscard]] bool processFragments(artdaq::FragmentPtrs& fragments) noexcept;
+  [[nodiscard]] const artdaq::FragmentPtrs& getPendingFragments() const noexcept { return pendingFragments_; };
+  [[nodiscard]] std::uint64_t oldestMostRecentPoint() const noexcept { return oldestMostRecentPoint_; }
+  [[nodiscard]] std::uint64_t partitionPoint() const noexcept { return partitionPoint_; }
+  [[nodiscard]] std::uint64_t acceptBeforeTimestamp() const noexcept { return acceptBeforeTimestamp_; }
+  [[nodiscard]] std::uint64_t seenFragmentCount() const noexcept { return seenFragmentCount_; }
+  [[nodiscard]] std::uint64_t fragmentCounter() const noexcept { return fragmentCounter_; }
+
+ private:
+  [[nodiscard]] std::uint64_t fragmentCounter_inc() noexcept { return fragmentCounter_++; }
+  std::uint64_t releaseFragmentTimeout_{0};
+  std::uint64_t fragmentCounter_{0};
+  std::uint64_t oldestMostRecentPoint_{0};
+  std::uint64_t partitionPoint_{0};
+  std::uint64_t acceptBeforeTimestamp_{0};
+  std::uint64_t seenFragmentCount_{0};
+  artdaq::FragmentPtrs pendingFragments_;
+  mutable std::mutex processingMutex_;
+
+  // private methods
+  void filterFragmentsByTimestamp(artdaq::FragmentPtrs& fragments, std::uint64_t acceptBeforeTimestamp);
+
+  void mergePendingFragments(artdaq::FragmentPtrs& fragments) {
+    if (pendingFragments_.empty()) return;
+    fragments.splice(fragments.end(), std::move(pendingFragments_));
+  }
+
+  void qsortFragmentsByTimestamp(artdaq::FragmentPtrs& fragments) {
+    if (fragments.size() <= 1) return;
+    fragments.sort([](const auto& a, const auto& b) { return a->timestamp() < b->timestamp(); });
+  }
+
+  void assignSequentialIDs(artdaq::FragmentPtrs& fragments, bool useFragmentCounterInc = false) {
+    if (fragments.empty()) return;
+    auto it = fragments.begin();
+    for (std::size_t i = 0; it != fragments.end(); ++i, ++it) {
+      (*it)->setSequenceID(useFragmentCounterInc ? fragmentCounter_inc() : fragmentCounter_inc() + i);
+    }
+  }
+
+  void validateFragments(const artdaq::FragmentPtrs& fragments) const {
+    for (const auto& fragment : fragments) {
+      if (!fragment) throw std::invalid_argument("Null fragment pointer detected");
+    }
+  }
+};
+
+void reportFistLastFragments(const artdaq::FragmentPtrs& fragments, const std::string& label);
+void reportAllFragments(const artdaq::FragmentPtrs& fragments, const std::string& label, std::uint64_t partition = 0, bool delta = false);
+std::string formatTimestamp(std::uint64_t timestamp, std::uint64_t reference = 0, bool delta = false);
+bool runVerboseFragmentProcessing(SPECTDCFragmentPreProcessor& processor, artdaq::FragmentPtrs& fragments);
+
+}  // namespace sbndaq
+
+#endif  // sbndaq_artdaq_Generators_SPECTDCFragmentPreProcessor_hh

--- a/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDCFragmentPreProcessor_utils.cc
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDCFragmentPreProcessor_utils.cc
@@ -1,0 +1,209 @@
+#include "sbndaq-artdaq/Generators/SBND/SPECTDC/SPECTDCFragmentPreProcessor.hh"
+
+#define TRACE_NAME "SPECTDCFragmentPreProcessor_utils"
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "trace.h"
+#include "sbndaq-artdaq-core/Overlays/SBND/TDCTimestampFragment.hh"
+
+namespace {
+constexpr std::size_t kMaxDisplayEntries = 8;
+constexpr std::size_t kMaxChanDigits = 2;
+constexpr std::size_t kMinSeqDigits = 8;
+std::size_t kSeqDigits = kMinSeqDigits;
+}  // namespace
+
+namespace sbndaq {
+
+void updateSeqPaddingSize(uint64_t num) noexcept {
+  if (num == 0) kSeqDigits = kMinSeqDigits;
+  kSeqDigits = std::max<std::size_t>(kMinSeqDigits,
+                                     static_cast<std::size_t>(std::log10(num)) + 2);
+}
+
+std::string formatTimestamp(const std::uint64_t timestamp, const std::uint64_t reference, const bool delta) {
+  std::stringstream ss;
+  uint64_t seconds = timestamp / 1000000000;
+  uint64_t last_two = (seconds % 100);
+  seconds = seconds / 100;
+  uint64_t subsecA = (timestamp % 1000000000) / 1000000;
+  uint64_t subsecB = (timestamp % 1000000) / 1000;
+  uint64_t subsecC = timestamp % 1000;
+  if (reference == 0) {
+    ss << " ";
+  } else if (timestamp < reference) {
+    ss << "-";
+  } else {
+    ss << "+";
+  }
+  ss << seconds << '.' << std::setfill('0') << std::setw(2) << last_two
+     << '\'' << std::setfill('0') << std::setw(3) << subsecA
+     << '.' << std::setfill('0') << std::setw(3) << subsecB
+     << '.' << std::setfill('0') << std::setw(3) << subsecC;
+  if (delta) {
+    int64_t delta_time = (timestamp >= reference) ? timestamp - reference : reference - timestamp;
+    uint64_t delta_seconds = delta_time / 1000000000;
+    uint64_t delta_last_two = (delta_seconds % 100);
+    delta_seconds = delta_seconds / 100;
+    uint64_t delta_subsecA = (delta_time % 1000000000) / 1000000;
+    uint64_t delta_subsecB = (delta_time % 1000000) / 1000;
+    uint64_t delta_subsecC = delta_time % 1000;
+
+    ss << " [" << ((timestamp < reference) ? "-" : "+")
+       << delta_seconds << '.' << std::setfill('0') << std::setw(2) << delta_last_two
+       << '\'' << std::setfill('0') << std::setw(3) << delta_subsecA
+       << '.' << std::setfill('0') << std::setw(3) << delta_subsecB
+       << '.' << std::setfill('0') << std::setw(3) << delta_subsecC << "]";
+  }
+  return ss.str();
+}
+
+void reportFistLastFragments(const artdaq::FragmentPtrs& fragments, const std::string& label) {
+  using sbndaq::TDCTimestampFragment;
+  std::stringstream buffer;
+  buffer << label << ":";
+  TLOG(TLVL_DEBUG + 10) << buffer.str() << '\n';
+  buffer.str("");
+
+  if (fragments.empty()) {
+    buffer << "No fragments to report";
+    TLOG(TLVL_DEBUG + 10) << buffer.str() << '\n';
+    buffer.str("");
+  } else {
+    buffer << "Total fragments: " << fragments.size() << " "
+           << "First: (seq,chan,timestamp)=("
+           << std::setfill(' ') << std::setw(kSeqDigits) << fragments.front()->sequenceID()
+           << "," << std::setfill(' ') << std::setw(kMaxChanDigits) << TDCTimestampFragment(*fragments.front()).getTDCTimestamp()->vals.channel
+           << "," << formatTimestamp(fragments.front()->timestamp()) << ") "
+           << "Last: (seq,chan,timestamp)=("
+           << std::setfill(' ') << std::setw(kSeqDigits) << fragments.back()->sequenceID()
+           << "," << std::setfill(' ') << std::setw(kMaxChanDigits) << TDCTimestampFragment(*fragments.front()).getTDCTimestamp()->vals.channel
+           << "," << formatTimestamp(fragments.back()->timestamp()) << ")";
+    TLOG(TLVL_DEBUG + 10) << buffer.str() << '\n';
+    buffer.str("");
+  }
+}
+
+void reportAllFragments(const artdaq::FragmentPtrs& fragments, const std::string& label, const std::uint64_t partition, const bool delta) {
+  using sbndaq::TDCTimestampFragment;
+  std::stringstream buffer;
+  buffer << label << ":";
+  TLOG(TLVL_DEBUG + 11) << buffer.str() << '\n';
+  buffer.str("");
+
+  if (fragments.empty()) {
+    buffer << "No fragments";
+    TLOG(TLVL_DEBUG + 11) << buffer.str() << '\n';
+    buffer.str("");
+    return;
+  }
+
+  buffer << "Total fragments: " << fragments.size();
+  TLOG(TLVL_DEBUG + 11) << buffer.str() << '\n';
+  buffer.str("");
+
+  auto it = fragments.begin();
+  if (fragments.size() < 3 * kMaxDisplayEntries) {
+    for (; it != fragments.end(); ++it) {
+      if (*it) {
+        buffer << "(seq,chan,timestamp)=(" << std::setfill(' ') << std::setw(kSeqDigits) << (*it)->sequenceID()
+               << "," << std::setfill(' ') << std::setw(kMaxChanDigits) << TDCTimestampFragment(*(it->get())).getTDCTimestamp()->vals.channel
+               << "," << formatTimestamp((*it)->timestamp(), partition, delta) << ")";
+        TLOG(TLVL_DEBUG + 11) << buffer.str() << '\n';
+        buffer.str("");
+      } else {
+        buffer << "Invalid fragment pointer";
+        TLOG(TLVL_DEBUG + 11) << buffer.str() << '\n';
+        buffer.str("");
+      }
+    }
+  } else {
+    for (std::size_t i = 0; i < kMaxDisplayEntries && it != fragments.end(); ++i, ++it) {
+      if (*it) {
+        buffer << "(seq,chan,timestamp)=(" << std::setfill(' ') << std::setw(kSeqDigits) << (*it)->sequenceID()
+               << "," << std::setfill(' ') << std::setw(kMaxChanDigits) << TDCTimestampFragment(*(it->get())).getTDCTimestamp()->vals.channel
+               << "," << formatTimestamp((*it)->timestamp(), partition, delta) << ")";
+        TLOG(TLVL_DEBUG + 11) << buffer.str() << '\n';
+        buffer.str("");
+      } else {
+        buffer << "Invalid fragment pointer";
+        TLOG(TLVL_DEBUG + 11) << buffer.str() << '\n';
+        buffer.str("");
+      }
+    }
+
+    buffer << "...";
+    TLOG(TLVL_DEBUG + 11) << buffer.str() << '\n';
+    buffer.str("");
+
+    auto total = fragments.size();
+    it = std::next(fragments.begin(), total - 2 * kMaxDisplayEntries);
+    for (; it != fragments.end(); ++it) {
+      if (*it) {
+        buffer << "(seq,chan,timestamp)=(" << std::setfill(' ') << std::setw(kSeqDigits) << (*it)->sequenceID()
+               << "," << std::setfill(' ') << std::setw(kMaxChanDigits)
+               << TDCTimestampFragment(*(it->get())).getTDCTimestamp()->vals.channel
+               << "," << formatTimestamp((*it)->timestamp(), partition, delta) << ")";
+        TLOG(TLVL_DEBUG + 11) << buffer.str() << '\n';
+        buffer.str("");
+      } else {
+        buffer << "Invalid fragment pointer";
+        TLOG(TLVL_DEBUG + 11) << buffer.str() << '\n';
+        buffer.str("");
+      }
+    }
+  }
+}
+
+bool runVerboseFragmentProcessing(SPECTDCFragmentPreProcessor& processor, artdaq::FragmentPtrs& fragments) {
+  const auto initailEventCount = fragments.size();
+  const auto now =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+
+  reportAllFragments(fragments, "Before Processing", now, true);
+
+  const auto startTime = std::chrono::high_resolution_clock::now();
+  const bool processingSucceeded = processor.processFragments(fragments);
+  const auto stopTime = std::chrono::high_resolution_clock::now();
+
+  const auto currentTime =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+
+  reportAllFragments(fragments, "After Processing", processor.oldestMostRecentPoint(), true);
+
+  auto padding = kSeqDigits - kMinSeqDigits + 3;
+  TLOG(TLVL_DEBUG + 12) << std::setw(padding) << "" << "       partition/acceptBefore: " << formatTimestamp(processor.partitionPoint(), processor.acceptBeforeTimestamp(), true) << '\n';
+  TLOG(TLVL_DEBUG + 12) << std::setw(padding) << "" << "   oldestMostRecent/partition: " << formatTimestamp(processor.oldestMostRecentPoint(), processor.partitionPoint(), true) << '\n';
+  TLOG(TLVL_DEBUG + 12) << std::setw(padding) << "" << "acceptBefore/oldestMostRecent: " << formatTimestamp(processor.acceptBeforeTimestamp(), processor.oldestMostRecentPoint(), true) << '\n';
+  TLOG(TLVL_DEBUG + 12) << std::setw(padding) << "" << "        currentTime/partition: " << formatTimestamp(currentTime, processor.partitionPoint(), true) << '\n';
+  TLOG(TLVL_DEBUG + 12) << std::setw(padding) << "" << "    expect/have pending frags: " << (processor.oldestMostRecentPoint() <= processor.acceptBeforeTimestamp() ? "no" : "yes")
+                        << "/" << (processor.getPendingFragments().empty() ? "no" : "yes") << '\n';
+
+  reportAllFragments(processor.getPendingFragments(), "Pending Fragments", processor.oldestMostRecentPoint(), true);
+
+  const auto processingDuration = std::chrono::duration_cast<std::chrono::microseconds>(stopTime - startTime);
+
+  std::stringstream ss;
+  ss << "Performance Results:";
+  TLOG(TLVL_DEBUG + 12) << ss.str() << '\n';
+  ss.str("");
+
+  ss << "- Processed (" << std::boolalpha << processingSucceeded << ") " << initailEventCount << " frags in " << processingDuration.count() << " usecs";
+  TLOG(TLVL_DEBUG + 12) << ss.str() << '\n';
+  ss.str("");
+
+  ss << "- Accepted/Penfing counts: " << fragments.size() << "/" << processor.getPendingFragments().size();
+  TLOG(TLVL_DEBUG + 12) << ss.str() << '\n';
+
+  updateSeqPaddingSize(processor.fragmentCounter());
+
+  return processingSucceeded;
+}
+
+}  // namespace sbndaq

--- a/sbndaq-artdaq/Generators/SBND/SPECTDCTimestampReader.hh
+++ b/sbndaq-artdaq/Generators/SBND/SPECTDCTimestampReader.hh
@@ -12,6 +12,7 @@
 #include "sbndaq-artdaq-core/Overlays/SBND/TDCTimestampFragment.hh"
 
 #include "SPECTDC/SPECTDC_Interface.hh"
+#include "SPECTDC/SPECTDCFragmentPreProcessor.hh"
 
 #include <atomic>
 #include <random>
@@ -49,6 +50,8 @@ class SPECTDCTimestampReader : public artdaq::CommandableFragmentGenerator {
   std::unique_ptr<PoolBuffer> buffer_;
   std::unique_ptr<SPECTDCInterface::SPECCard> hardware_;
   std::unique_ptr<share::WorkerThread> data_thread_;
+  std::unique_ptr<sbndaq::SPECTDCFragmentPreProcessor> preprocessor_;
+  
   TDCTimestampFragment::Metadata metadata_;
   bool configured_;
   uint64_t sleep_on_no_data_us_;
@@ -56,6 +59,8 @@ class SPECTDCTimestampReader : public artdaq::CommandableFragmentGenerator {
   uint64_t events_to_generate_;
   bool separate_data_thread_;
   bool separate_monitoring_thread_;
+  uint64_t preprocessor_nodata_timeout_us_;
+  bool preprocessor_verbose_processing_;
   uint64_t next_hardware_poll_time_us_;
   uint64_t next_status_report_time_us_;
   bool stop_requested_;


### PR DESCRIPTION
### Description

The processor orders TDC fragments by timestamp using a buffered approach. It validates and merges fragments, then calculates a partition point by finding each channel's newest timestamp and selecting the oldest among these. Fragments older than this point proceed for processing with sequential IDs, while newer ones enter a pending queue. A timeout (1.25s default) prevents indefinite fragment holds. The system uses mutex locks for thread safety and maintains processing counters while handling errors.
### Related Repository Branches

### Testing details
To enable event preprocessing, add parameter `preprocessor_nodata_timeout_us_=1250000` to specdtc.fcl. The timeout is specified in microseconds; setting it to 0 disables preprocessing. For algorithm debugging, set `preprocessor_verbose_processing_=true` and enable trace levels `DEBUG+10` through `DEBUG+12` for `SPECTDCFragmentPreProcessor_utils`. Review `SPECTDCFragmentPreProcessor_utils.cc` and `SPECTDCTimestampReader_generator.cc` for implementation details.