### PR TITLE
SBND exposure accounting

### DIFF
--- a/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
@@ -407,13 +407,13 @@ artdaq::Fragment* sbndaq::TriggerBoardReader::CreateFragment() {
 	numGates[0]++;
 	numGates[1]++;
 	numGates[4]++;
-	if (isVerbose) TRACE(TLVL_INFO, "LLT 30 occurred at timestamp: %lu and incrementing number of gates by 1 so numGates[0]: %d , numGates[1]: %d , numGates[3]: %d ", t->timestamp, numGates[0], numGates[1], numGates[3]); 
+	if (isVerbose) TRACE(TLVL_INFO, "LLT 30 occurred at timestamp: %lu and incrementing number of gates by 1 so numGates[0]: %d , numGates[1]: %d , numGates[4]: %d ", t->timestamp, numGates[0], numGates[1], numGates[4]); 
       }
 
       if (t -> IsTrigger(26)){
 	numGates[2]++;
 	numGates[3]++;
-	if (isVerbose) TRACE(TLVL_INFO, "LLT 30 occurred at timestamp: %lu and incrementing number of gates by 1 so numGates[2]: %d ", t->timestamp, numGates[2]); 
+	if (isVerbose) TRACE(TLVL_INFO, "LLT 26 occurred at timestamp: %lu and incrementing number of gates by 1 so numGates[2]: %d , numGates[3]: %d", t->timestamp, numGates[2], numGates[3]);
       }
 
       std::set<unsigned short> trigs = t -> Triggers(32) ;

--- a/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
@@ -31,11 +31,12 @@
 #include <unistd.h>
 #include <thread>
 
-int numGates[4] ={0,0,0,0}; //Index is numGate for different HLT--> numGates[0] = HLT 1, numGates[1] = HLT 2, numGates[2] = HLT 3, numGates[3] = HLT 6 
+int numGates[5] ={0,0,0,0,0}; //Index is numGate for different HLT--> numGates[0] = HLT 1, numGates[1] = HLT 2, numGates[2] = HLT 3, numGates[3] = HLT 4, numGates[4] = HLT 6
 uint64_t prevHLT01TS =0;
 uint64_t prevHLT02TS =0;
 uint64_t prevHLT03TS =0;
 uint64_t prevHLT04TS =0;
+uint64_t prevHLT06TS =0;
 
 bool isVerbose;
 
@@ -405,12 +406,13 @@ artdaq::Fragment* sbndaq::TriggerBoardReader::CreateFragment() {
       if (t ->IsTrigger(30) ) {
 	numGates[0]++;
 	numGates[1]++;
-	numGates[3]++;
+	numGates[4]++;
 	if (isVerbose) TRACE(TLVL_INFO, "LLT 30 occurred at timestamp: %lu and incrementing number of gates by 1 so numGates[0]: %d , numGates[1]: %d , numGates[3]: %d ", t->timestamp, numGates[0], numGates[1], numGates[3]); 
       }
 
       if (t -> IsTrigger(26)){
 	numGates[2]++;
+	numGates[3]++;
 	if (isVerbose) TRACE(TLVL_INFO, "LLT 30 occurred at timestamp: %lu and incrementing number of gates by 1 so numGates[2]: %d ", t->timestamp, numGates[2]); 
       }
 
@@ -472,14 +474,18 @@ artdaq::Fragment* sbndaq::TriggerBoardReader::CreateFragment() {
       }
       
       if (t -> IsTrigger(4)){
+	t -> setGateCounter(numGates[3]);
+	numGates[3]=0;
 	temp_PTBBR_word.setPrevTimestamp(prevHLT04TS);
 	//std::cout << "Previous HLT 4 TS: " << prevHLT04TS << std::endl; 
 	prevHLT04TS = t->timestamp;
       }
 
       if(t -> IsTrigger(6)){
-	t -> setGateCounter(numGates[3]);      //Setting the gate Counters for HLT 6
-	numGates[3]=0; //reset counter
+	t -> setGateCounter(numGates[4]);      //Setting the gate Counters for HLT 6
+	numGates[4]=0; //reset counter
+	temp_PTBBR_word.setPrevTimestamp(prevHLT06TS);
+	prevHLT06TS = t->timestamp;
       }
       
       //Adding the gate count to the HLT words

--- a/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
@@ -409,13 +409,7 @@ artdaq::Fragment* sbndaq::TriggerBoardReader::CreateFragment() {
 	numGates[4]++;
 	if (isVerbose) TRACE(TLVL_INFO, "LLT 30 occurred at timestamp: %lu and incrementing number of gates by 1 so numGates[0]: %d , numGates[1]: %d , numGates[4]: %d ", t->timestamp, numGates[0], numGates[1], numGates[4]); 
       }
-
-      if (t -> IsTrigger(26)){
-	numGates[2]++;
-	numGates[3]++;
-	if (isVerbose) TRACE(TLVL_INFO, "LLT 26 occurred at timestamp: %lu and incrementing number of gates by 1 so numGates[2]: %d , numGates[3]: %d", t->timestamp, numGates[2], numGates[3]);
-      }
-
+      
       std::set<unsigned short> trigs = t -> Triggers(32) ;
       for ( auto it = trigs.begin(); it != trigs.end() ; ++it ) {
 	++ _metric_LLT_counters[*it] ;
@@ -448,6 +442,13 @@ artdaq::Fragment* sbndaq::TriggerBoardReader::CreateFragment() {
       //const ptb::content::word::trigger_t * t = reinterpret_cast<const ptb::content::word::trigger_t *>( & temp_word  ) ;
       ptb::content::word::trigger_t * t = reinterpret_cast<ptb::content::word::trigger_t *>( & temp_word  ) ;
       
+      // Incrementing gate counter for off-beam gates using HLT 27, which should be issued when there is an off-beam gate that has *not* been inhibited by the beam protection logic
+      if (t -> IsTrigger(27)){
+	numGates[2]++;
+	numGates[3]++;
+	if (isVerbose) TRACE(TLVL_INFO, "HLT 27 occurred at timestamp: %lu and incrementing number of gates by 1 so numGates[2]: %d , numGates[3]: %d", t->timestamp, numGates[2], numGates[3]);
+      }
+
       //Setting the previous HLT timestamp and adding it to the new HLT word
       if (t -> IsTrigger(1)){
 	t -> setGateCounter(numGates[0]);      //Setting the gate Counters for HLT 1


### PR DESCRIPTION
### Description

Incorporates updates to the SBND trigger board (PTB) boardreader to enable exposure accounting for BNB and off-beam data, both zero-bias and light-triggered. Updates the way counters are incremented and filled relative to the previous version. No changes to the PTB data structures themselves.

### Testing details
- *Where it was tested*: tested in regular SBND shifter runs for the past ~10 days
- *Run number associated with test*: all SBND runs >17893
- Other information: Changes are exclusively to the PTB boardreader and thus should only affect SBND. Has been running stably in routine SBND runs for over a week.
