### PR TITLE
PMT Metrics/Software Trigger Updates

### DIFF
--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -210,7 +210,6 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::reconfigure(fhicl::ParameterSet 
 
 void sbnd::trigger::pmtSoftwareTriggerProducer::produce(art::Event& e)
 {
-  if (fVerbose==1) std::cout << "Processing Run: " << e.run() << ", Subrun: " <<  e.subRun() << ", Event: " << e.id().event() << std::endl;
   // object to store trigger metrics in
   std::unique_ptr<std::vector<sbnd::trigger::pmtSoftwareTrigger>> trig_metrics_v = std::make_unique<std::vector<sbnd::trigger::pmtSoftwareTrigger>>();
   sbnd::trigger::pmtSoftwareTrigger trig_metrics;
@@ -536,7 +535,6 @@ int8_t sbnd::trigger::pmtSoftwareTriggerProducer::getClosestFTrig(double refTime
     double diff = ftrig_v[i] - refTime;
     diff_v[i] = std::abs(diff);
 
-    std::cout << "FTrig: " << int(iftrig) << " ns, diff: " << int(diff) << " ns" << std::endl;
     if (std::abs(diff) < min_diff){
         min_idx = int8_t(i);
         min_diff = std::abs(diff);

--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -324,8 +324,8 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::produce(art::Event& e)
             for (size_t ii = 0; ii < contf.block_count(); ++ii){
               // find the absolute time difference between the fragment trigger time and the reference time stamp 
               auto len = getLength(*contf[ii].get());
-              if (len<fWvfmLength) continue;  // ignore extended triggers!!!
-              caen_ftrig_v.push_back(getTriggerTime(*contf[ii].get()));
+              if (len<fWvfmLength) caen_ftrig_v.push_back(-1e12);
+              else caen_ftrig_v.push_back(getTriggerTime(*contf[ii].get()));
             }
             auto min_idx = getClosestFTrig(refTimestamp, caen_ftrig_v);
             if (min_idx<0){

--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -270,12 +270,12 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::produce(art::Event& e)
       if (tdc_etrig!=1e9)
         refTimestamp = tdc_etrig - fSPECTDCDelay;
       else{
-        if (fVerbose>=2) TLOG(TLVL_INFO) << "No valid TDC timestamp found. Using NTB..." ;
+        if (fVerbose>=2) TLOG(TLVL_WARNING) << "No valid TDC timestamp found. Using NTB..." ;
         timing_type++;
       }
     }
     else{
-      if (fVerbose>=2) TLOG(TLVL_INFO) << "No valid TDC timestamp found. Using NTB..." ;
+      if (fVerbose>=2) TLOG(TLVL_WARNING) << "No valid TDC timestamp found. Using NTB..." ;
       timing_type++;
     }
   }

--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/pmtmetricproducer.fcl
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/pmtmetricproducer.fcl
@@ -1,25 +1,14 @@
 pmtmetricproducer: {
         module_type: "PMTMetricProducer"               
-        CAENInstanceLabels: [ "CAENV1730", "ContainerCAENV1730" ]
-        WindowLength: 0.5 #1.6     # beam window length after trigger time, default 1.6 us                                       
-     	  WvfmPostPercent:  0.8      # this should be a decimal! % of the wvfm contained in the 10 us window.
-                                   # having 1+9 -> 0.9. having 2+8 -> 0.8,
-                                   # IMPORTANT! this variable will determine where 0 is in our timing reference frame!
-                                   #
+        CAENInstanceLabels: [ "ContainerCAENV1730" ]
 
         # event trigger timing configuruables 
         ## priority system 
-        ## NTB (RawEventHeader) [0] -> SPEC TDC ETT [1] -> TIMING CAEN [2] -> PTB ETT [3]
-        ## if the first one is not available, it will go to the next one
-        NTBDelay: 367392 # NTB - FTRIG, ns 
+        StreamType: 1 # default value, needs to be changed for different streams!
         TimingType: 0
 
         # SPEC TDC Beam configuration
-        SPECTDCTimingChannel: 2 # 1 is bes, 2 is rwm, 4 is ett 
-        SPECTDCDelay: 2133 # spec tdc ftrig ts - caen ftrig ts
-
-        # CAEN 1730 configuration
-        ## the timing caen is 40968, so skip it
-        FragIDs: [40960,40961,40962,40963,40964,40965,40966,40967]
-     	Verbose: 1 # 0: no printout, 1: printout for each event, 2: printout for each fragment, 3: printout for each channel
+        SPECTDCTimingChannel: 4 # 1 is bes, 2 is rwm, 4 is ett 
+        SPECTDCDelay: 140
+        NTBDelay: 365000
     }


### PR DESCRIPTION
### Description

Adds many new features to the PMT metric producer/software trigger. 
- feature to be able to use extended triggers; important for when the gated FTRIG arrives as an extended trigger 
- add option to use different logic based on stream type; still needs work for +light streams but works for zero bias streams
- add option to ignore the NTB (raw header) timestamp; product will still be produced, just filled with dummy values 
- add option to specify a label for the output product. Useful if running the producer module offline

### Related Repository Branches

No other repos/branches. 

### Testing details
Tested in SBND runs17980-17982. 
Run regularly in shifter runs in SBND since run17983. 
