### PR TITLE
Handle Missing A2795's

### DIFF
--- a/sbndaq-artdaq/Generators/ICARUS/PhysCrateData_generator.cc
+++ b/sbndaq-artdaq/Generators/ICARUS/PhysCrateData_generator.cc
@@ -255,7 +255,7 @@ void icarus::PhysCrateData::InitializeHardware(){
   }
   catch (const cet::exception& e)
   {
-    TRACEN("PhysCrateData", TLVL_ERROR, "Error initializing creat %d: %s", CrateID_, e.what());
+    TRACEN("PhysCrateData", TLVL_ERROR, "Error initializing crate %d: %s", CrateID_, e.what());
     throw e;
   }
   this->nBoards_ = (uint16_t)(physCr->NBoards());

--- a/sbndaq-artdaq/Generators/ICARUS/PhysCrateData_generator.cc
+++ b/sbndaq-artdaq/Generators/ICARUS/PhysCrateData_generator.cc
@@ -249,7 +249,15 @@ void icarus::PhysCrateData::VetoOff(){
 
 void icarus::PhysCrateData::InitializeHardware(){
   physCr = std::make_unique<PhysCrate>();
-  physCr->initialize(pcieLinks_);
+  try
+  {
+    physCr->initialize(pcieLinks_, boardsPerLink_);
+  }
+  catch (const cet::exception& e)
+  {
+    TRACEN("PhysCrateData", TLVL_ERROR, "Error initializing creat %d: %s", CrateID_, e.what());
+    throw e;
+  }
   this->nBoards_ = (uint16_t)(physCr->NBoards());
   ForceReset();
   if(_compressionScheme != 0) SetCompressionBits(); // CompressionScheme is set up to mulitple compression schema, but currently there are only two

--- a/sbndaq-artdaq/Generators/ICARUS/PhysCrate_GeneratorBase.cc
+++ b/sbndaq-artdaq/Generators/ICARUS/PhysCrate_GeneratorBase.cc
@@ -53,6 +53,7 @@ void icarus::PhysCrate_GeneratorBase::Initialize(){
   }
   
   pcieLinks_ = ps_.get< std::vector<int> >("pcieLinks",std::vector<int>());
+  boardsPerLink_ = ps_.get< std::vector<unsigned int> >("boardsPerLink",std::vector<unsigned int>());
 
   least_data_block_bytes_ = (size_t)SamplesPerChannel_*(size_t)ChannelsPerBoard_*2+12+32;
 

--- a/sbndaq-artdaq/Generators/ICARUS/PhysCrate_GeneratorBase.hh
+++ b/sbndaq-artdaq/Generators/ICARUS/PhysCrate_GeneratorBase.hh
@@ -64,6 +64,7 @@ namespace icarus {
     statpack last_stat_pack_;
 
     std::vector<int> pcieLinks_;
+    std::vector<unsigned int> boardsPerLink_;
 
     size_t event_offset_;
     size_t packSize_zero_counter_;

--- a/sbndaq-artdaq/Generators/ICARUS/icarus-base/PhysCrate.cc
+++ b/sbndaq-artdaq/Generators/ICARUS/icarus-base/PhysCrate.cc
@@ -59,9 +59,10 @@ PhysCrate::initialize(std::vector<int> busVec, std::vector<unsigned int> boardsi
       
     }
     else{
+      int link = 0;
       for(int nBus : busVec){
 
-	for(unsigned int nBoardInCrate = 0; nBoardInCrate < boardsinCrateVec; ++nBoardInCrate)
+	for(unsigned int nBoardInCrate = 0; nBoardInCrate < boardsinCrateVec[link]; ++nBoardInCrate)
 	{        
 	  TRACEN("PhysCrate.cc", TLVL_INFO, "trying bus=%d,dev=%d",nBus,nBoardInCrate);
 	  
@@ -81,6 +82,7 @@ PhysCrate::initialize(std::vector<int> busVec, std::vector<unsigned int> boardsi
 	  }
 	}
 	nDev=0;
+	++link;
       }
     }
 

--- a/sbndaq-artdaq/Generators/ICARUS/icarus-base/PhysCrate.cc
+++ b/sbndaq-artdaq/Generators/ICARUS/icarus-base/PhysCrate.cc
@@ -66,9 +66,8 @@ PhysCrate::initialize(std::vector<int> busVec, std::vector<unsigned int> boardsi
 	{        
 	  TRACEN("PhysCrate.cc", TLVL_INFO, "trying bus=%d,dev=%d",nBus,nBoardInCrate);
 	  
-	  boards[nBoards]=new A2795Board(nDev,nBoardInCrate);
+	  boards[nBoards]=new A2795Board(nBoardInCrate,nBus);
           boardId = boards[nBoards]->boardId;
-	  nDev++;
 	  if (boardId>-1)
 	    { 
 	      TRACEN("PhysCrate.cc", TLVL_INFO, "PhysCrate::initialize(): Created board (%d, %d, %d, %d)",nBus,nBoardInCrate,nBoards,boardId);
@@ -81,7 +80,6 @@ PhysCrate::initialize(std::vector<int> busVec, std::vector<unsigned int> boardsi
               throw cet::exception("PhysCrate") << "Could not connect to board " << nBoardInCrate << " on link " << nBus;
 	  }
 	}
-	nDev=0;
 	++link;
       }
     }

--- a/sbndaq-artdaq/Generators/ICARUS/icarus-base/PhysCrate.cc
+++ b/sbndaq-artdaq/Generators/ICARUS/icarus-base/PhysCrate.cc
@@ -25,7 +25,7 @@ PhysCrate::~PhysCrate()
 #ifndef _simulate_
 // Initializes the crate detecting the boards
 void
-PhysCrate::initialize(std::vector<int> busVec) 
+PhysCrate::initialize(std::vector<int> busVec, std::vector<unsigned int> boardsinCrateVec) 
 {
    TRACEN("PhysCrate.cc",TLVL_INFO, "PhysCrate::initialize(): Initializing crate.");
 
@@ -37,7 +37,7 @@ PhysCrate::initialize(std::vector<int> busVec)
     
     nBoards=0;
     nDev=0;
-    if(busVec.size()==0){
+    if(busVec.size()==0 || boardsinCrateVec.size()==0){
       int nBus=0;
       do {
         do {        
@@ -61,20 +61,25 @@ PhysCrate::initialize(std::vector<int> busVec)
     else{
       for(int nBus : busVec){
 
-	do {        
-	  TRACEN("PhysCrate.cc", TLVL_INFO, "trying bus=%d,dev=%d",nBus,nDev);
+	for(unsigned int nBoardInCrate = 0; nBoardInCrate < boardsinCrateVec; ++nBoardInCrate)
+	{        
+	  TRACEN("PhysCrate.cc", TLVL_INFO, "trying bus=%d,dev=%d",nBus,nBoardInCrate);
 	  
-	  boards[nBoards]=new A2795Board(nDev,nBus);
+	  boards[nBoards]=new A2795Board(nDev,nBoardInCrate);
           boardId = boards[nBoards]->boardId;
 	  nDev++;
 	  if (boardId>-1)
 	    { 
-	      TRACEN("PhysCrate.cc", TLVL_INFO, "PhysCrate::initialize(): Created board (%d, %d, %d, %d)",nBus,nDev,nBoards,boardId);
+	      TRACEN("PhysCrate.cc", TLVL_INFO, "PhysCrate::initialize(): Created board (%d, %d, %d, %d)",nBus,nBoardInCrate,nBoards,boardId);
 	      
 	      nBoards++;
 	    }
-	  //else break;
-	} while (nDev<kMaxBoardsonLink );
+	  else
+	  {
+              TRACEN("PhysCrate.cc",TLVL_ERROR, "PhysCrate::initialize(): Could not connect to board on link %d, node %d", nBus, nBoardInCrate);
+              throw cet::exception("PhysCrate") << "Could not connect to board " << nBoardInCrate << " on link " << nBus;
+	  }
+	}
 	nDev=0;
       }
     }

--- a/sbndaq-artdaq/Generators/ICARUS/icarus-base/PhysCrate.h
+++ b/sbndaq-artdaq/Generators/ICARUS/icarus-base/PhysCrate.h
@@ -27,7 +27,7 @@ public:
     ~PhysCrate();
 
     void initialize( std::vector<int> busVec=std::vector<int>(),
-                     std::vector<unsigned int> boardsinCrateVec=)std::vector<unsigned int>();
+                     std::vector<unsigned int> boardsinCrateVec=std::vector<unsigned int>());
     void configure ( BoardConf conf );
     void configureTrig ( TrigConf conf );
     void waitData();

--- a/sbndaq-artdaq/Generators/ICARUS/icarus-base/PhysCrate.h
+++ b/sbndaq-artdaq/Generators/ICARUS/icarus-base/PhysCrate.h
@@ -26,7 +26,8 @@ public:
     PhysCrate();
     ~PhysCrate();
 
-    void initialize( std::vector<int> busVec=std::vector<int>());
+    void initialize( std::vector<int> busVec=std::vector<int>(),
+                     std::vector<unsigned int> boardsinCrateVec=)std::vector<unsigned int>();
     void configure ( BoardConf conf );
     void configureTrig ( TrigConf conf );
     void waitData();


### PR DESCRIPTION
We would like to throw errors if we cannot set up an A2795 board we expect to exist, however this is complicated by the way `PhysCrate` runs over the link. `PhysCrate` right now checks node on the link in a brute force manner with no concern for how many boards the crate should have. This means we cannot throw an error on a failed connection because we have some links which have fewer than the hard coded max of 5. A smarter way to handle this is to pass the number of boards expected on each link and then throw an error if we try to find a board and can't. This also requires adding a vector to the crate configuration, but since we should know the number of boards in each crate when starting the run it shouldn't be too onerous.
