### PR TITLE
PMTMetricsProducer +Light streams update

### DIFF
--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -568,7 +568,10 @@ bool sbnd::trigger::pmtSoftwareTriggerProducer::getGateTime(art::Handle<std::vec
       for(size_t word_i = 0; word_i < ctb_frag.NWords(); ++word_i){
         if(ctb_frag.Trigger(word_i)){
           auto wt = ctb_frag.Word(word_i)->word_type;
-          if (wt == 2 && ( ctb_frag.Trigger(word_i)->IsTrigger(26) || ctb_frag.Trigger(word_i)->IsTrigger(27) )){
+          bool gate_hlt = false;
+          if ((fStreamType == 2 ) && (ctb_frag.Trigger(word_i)->IsTrigger(26))) gate_hlt = true;
+          if ((fStreamType == 4 ) && (ctb_frag.Trigger(word_i)->IsTrigger(27))) gate_hlt = true;
+          if (wt == 2 && gate_hlt){            
             foundgate = true;
             gateTime = double((std::bitset<64>(ctb_frag.Trigger(word_i)->timestamp).to_ullong()*20)%(uint(1e9)) - fPTBDelay);
             if (fVerbose>=3) TLOG(TLVL_INFO) << "PTB gated FTRIG HLT timestamp: " << uint(gateTime) << " ns";

--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -182,7 +182,7 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::reconfigure(fhicl::ParameterSet 
   fStreamType         = p.get<uint8_t>("StreamType", 1); 
   // SPEC TDC ETT (or PTB gate HLT) [0] -> NTB (RawEventHeader) [1]
   fTimingType         = p.get<uint8_t>("TimingType", 0);
-  fAllowNTB           = p.get<bool>("AllowNTB", true);
+  fAllowNTB           = p.get<bool>("AllowNTB", false);
   fNTBDelay           = p.get<uint32_t>("NTBDelay", 365000); // units of ns
 
   fSPECTDCModuleLabel    = p.get<std::string>("SPECTDCModuleLabel", "daq");
@@ -204,7 +204,7 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::reconfigure(fhicl::ParameterSet 
 
   // most likely these will all be off...
   fIncludeExtensions  = p.get<bool>("IncludeExtensions",false);
-  fCalculateBaseline  = p.get<bool>("CalculateBaseline",false);
+  fCalculateBaseline  = p.get<bool>("CalculateBaseline",true);
   fCountPMTs          = p.get<bool>("CountPMTs",false);
   fCalculatePEMetrics = p.get<bool>("CalculatePEMetrics",false);
   fInputBaseline      = p.get<std::vector<float>>("InputBaseline",{14250,2.0});

--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -487,12 +487,12 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::produce(art::Event& e)
 
       flash_prelimPE = (flash_baseline-(*std::min_element(wvfm_sum.begin()+prelimStart,wvfm_sum.begin()+windowStartBin)))/fADCtoPE;
       flash_promptPE = (flash_baseline-(*std::min_element(wvfm_sum.begin()+windowStartBin,wvfm_sum.begin()+promptEnd)))/fADCtoPE;
-      flash_peakPE   = (flash_baseline-(*std::min_element(wvfm_sum.begin(),wvfm_sum.end())))/fADCtoPE;
       // auto flash_peak_it = std::min_element(wvfm_sum.begin(),wvfm_sum.end());
       // look at only the last 5000 samples of the waveform
       // important because our "chosen" ftrig may be an extended fragment
       auto flash_peak_it = std::min_element(wvfm_sum.end()-fWvfmLength,wvfm_sum.end());
       // time is referenced to the end of the waveform; this is correct assuming we grabbed the right fragment!  
+      flash_peakPE   = (flash_baseline-(*flash_peak_it))/fADCtoPE;
       flash_peaktime = (fWvfmLength*fWvfmPostPercent - (wvfm_sum.end() -  flash_peak_it))*ticks_to_us; // us
     }
     trig_metrics.nAboveThreshold = nAboveThreshold;

--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -246,6 +246,8 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::produce(art::Event& e)
     for (const std::string &PTBInstanceLabel : fPTBInstanceLabels){
       art::Handle<std::vector<artdaq::Fragment>> ptbHandle;
       e.getByLabel(fPTBModuleLabel, PTBInstanceLabel, ptbHandle);
+      if(!ptbHandle.isValid() || ptbHandle->size() == 0)
+        continue;
       foundgate = getGateTime(ptbHandle, gateTime);
     }
   }


### PR DESCRIPTION
### Description

Updates to PMT Metric Producer to fix logic for +light streams. Uses the PTB HLT 26/27 instead of SPEC TDC ETRIG as the reference timestamp for light streams. Checked the outputs using an offline analysis, and it looks consistent!

### Testing details
- *Where it was tested*: SBND 
- *Run number associated with test*: run18194
- Other information: run with config `opsFullTriggerMenuP2_ExtraMTCA5_AB-00001` during beam downtime