### PR TITLE
Feature/sbnd shifter v1 10 04

### DIFF
--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -568,7 +568,10 @@ bool sbnd::trigger::pmtSoftwareTriggerProducer::getGateTime(art::Handle<std::vec
       for(size_t word_i = 0; word_i < ctb_frag.NWords(); ++word_i){
         if(ctb_frag.Trigger(word_i)){
           auto wt = ctb_frag.Word(word_i)->word_type;
-          if (wt == 2 && ( ctb_frag.Trigger(word_i)->IsTrigger(26) || ctb_frag.Trigger(word_i)->IsTrigger(27) )){
+          bool gate_hlt = false;
+          if ((fStreamType == 2 ) && (ctb_frag.Trigger(word_i)->IsTrigger(26))) gate_hlt = true;
+          if ((fStreamType == 4 ) && (ctb_frag.Trigger(word_i)->IsTrigger(27))) gate_hlt = true;
+          if (wt == 2 && gate_hlt){            
             foundgate = true;
             gateTime = double((std::bitset<64>(ctb_frag.Trigger(word_i)->timestamp).to_ullong()*20)%(uint(1e9)) - fPTBDelay);
             if (fVerbose>=3) TLOG(TLVL_INFO) << "PTB gated FTRIG HLT timestamp: " << uint(gateTime) << " ns";

--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -182,7 +182,7 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::reconfigure(fhicl::ParameterSet 
   fStreamType         = p.get<uint8_t>("StreamType", 1); 
   // SPEC TDC ETT (or PTB gate HLT) [0] -> NTB (RawEventHeader) [1]
   fTimingType         = p.get<uint8_t>("TimingType", 0);
-  fAllowNTB           = p.get<bool>("AllowNTB", true);
+  fAllowNTB           = p.get<bool>("AllowNTB", false);
   fNTBDelay           = p.get<uint32_t>("NTBDelay", 365000); // units of ns
 
   fSPECTDCModuleLabel    = p.get<std::string>("SPECTDCModuleLabel", "daq");
@@ -204,7 +204,7 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::reconfigure(fhicl::ParameterSet 
 
   // most likely these will all be off...
   fIncludeExtensions  = p.get<bool>("IncludeExtensions",false);
-  fCalculateBaseline  = p.get<bool>("CalculateBaseline",false);
+  fCalculateBaseline  = p.get<bool>("CalculateBaseline",true);
   fCountPMTs          = p.get<bool>("CountPMTs",false);
   fCalculatePEMetrics = p.get<bool>("CalculatePEMetrics",false);
   fInputBaseline      = p.get<std::vector<float>>("InputBaseline",{14250,2.0});

--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -487,12 +487,12 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::produce(art::Event& e)
 
       flash_prelimPE = (flash_baseline-(*std::min_element(wvfm_sum.begin()+prelimStart,wvfm_sum.begin()+windowStartBin)))/fADCtoPE;
       flash_promptPE = (flash_baseline-(*std::min_element(wvfm_sum.begin()+windowStartBin,wvfm_sum.begin()+promptEnd)))/fADCtoPE;
-      flash_peakPE   = (flash_baseline-(*std::min_element(wvfm_sum.begin(),wvfm_sum.end())))/fADCtoPE;
       // auto flash_peak_it = std::min_element(wvfm_sum.begin(),wvfm_sum.end());
       // look at only the last 5000 samples of the waveform
       // important because our "chosen" ftrig may be an extended fragment
       auto flash_peak_it = std::min_element(wvfm_sum.end()-fWvfmLength,wvfm_sum.end());
       // time is referenced to the end of the waveform; this is correct assuming we grabbed the right fragment!  
+      flash_peakPE   = (flash_baseline-(*flash_peak_it))/fADCtoPE;
       flash_peaktime = (fWvfmLength*fWvfmPostPercent - (wvfm_sum.end() -  flash_peak_it))*ticks_to_us; // us
     }
     trig_metrics.nAboveThreshold = nAboveThreshold;

--- a/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
+++ b/sbndaq-artdaq/ArtModules/SBND/SoftwareTrigger/PMTMetricProducer_module.cc
@@ -246,6 +246,8 @@ void sbnd::trigger::pmtSoftwareTriggerProducer::produce(art::Event& e)
     for (const std::string &PTBInstanceLabel : fPTBInstanceLabels){
       art::Handle<std::vector<artdaq::Fragment>> ptbHandle;
       e.getByLabel(fPTBModuleLabel, PTBInstanceLabel, ptbHandle);
+      if(!ptbHandle.isValid() || ptbHandle->size() == 0)
+        continue;
       foundgate = getGateTime(ptbHandle, gateTime);
     }
   }

--- a/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
+++ b/sbndaq-artdaq/Generators/SBND/TriggerBoardReader_generator.cc
@@ -407,6 +407,7 @@ artdaq::Fragment* sbndaq::TriggerBoardReader::CreateFragment() {
 	numGates[0]++;
 	numGates[1]++;
 	numGates[4]++;
+	TRACE(TLVL_INFO, "Beam acceptance window (LLT 30) started at time: %lu", t->timestamp);
 	if (isVerbose) TRACE(TLVL_INFO, "LLT 30 occurred at timestamp: %lu and incrementing number of gates by 1 so numGates[0]: %d , numGates[1]: %d , numGates[4]: %d ", t->timestamp, numGates[0], numGates[1], numGates[4]); 
       }
       


### PR DESCRIPTION
### Description

Updates (including important bug fixes) to the SBND `pmtmetricproducer` module. Minor update to the SBND trigger board generator to record the time of all beam gates in the DAQ logs.

### Related Repository Branches

Intended to go along with a branch of the same name in `sbndaq_artdaq_core` that will be PR'd shortly.

### Testing details
- *Where it was tested*: SBN-ND
- *Run number associated with test*: initial tests in runs 18237 and up on Feb 12, further tests to be conducted on Feb 13
- Other information: Includes changes to SBND DAQ that are necessary for our final physics run setup