### PR TITLE
CAENV1730: interrupts and A5818 support

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -1,105 +1,250 @@
 //
 //  CAENConfiguration.cc
 //
-//  Class to read and contain CAEN V1730SB configuration
-//   parameters
+//  Class to read, contain and print CAEN V1730SB
+//  configuration parameters.
 //
-//
+
 #define TRACE_NAME "CAENConfiguration"
+
 #include "artdaq/DAQdata/Globals.hh"
+#include "sbndaq-artdaq/Generators/Common/CAENConfiguration.hh"
+#include "sbndaq-artdaq/Generators/Common/CAENDecoder.hh"
+#include <iostream>
 
-#include "CAENConfiguration.hh"
+// Constructor reads fhicl paramaters
+// NOTE: do not put defaults on REQUIRED parameters
+// so that exception is thrown if missing from config
 
-// Constructor
-sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps):
-  link(0),
-  nBoards(0),
-  enableReadout(0),
-  boardId(0),
-  recordLength(0),
-  postPercent(0),
-  irqWaitTime(0),
-  allowTriggerOverlap(true),
-  dynamicRange(0),
-  ioLevel(0),
-  nChannels(0),
-  triggerPolarity(0),
-  extTrgMode(0),
-  swTrgMode(0),
-  acqMode(0),
-  debugLevel(0),
-  runSyncMode(0),
-  analogMode(0),
-  testPattern(0),
-  //ovthValue(0),
-  triggerLogic(0),
-  majorityLevel(0),
-  majorityCoincidenceWindow(0),
-  maxTemp(80),
-  temperatureCheckMask(0xFFFF),
-  aX818(3)
+sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps)
 {
-  link                 = ps.get<int>("link");
-  enableReadout        = ps.get<int>("enableReadout");
-  boardId              = ps.get<int>("board_id");
-  recordLength         = ps.get<int>("recordLength");
-  runSyncMode          = ps.get<int>("runSyncMode");
+
+  // optical COMET2 link number (range 0-7)
+  // this dependes on the aX818 cards/slots  
+  link = ps.get<int>("link");
+
+  // Boardreader fragment ID
+  fragmentId = ps.get<uint32_t>("fragment_id");
+
+  // Deprecated for artdaq (everything uses fragment id)
+  // but still used for error messages somewhere
+  boardId = ps.get<int>("board_id");
+
+  // board number along the optical link chain
+  // we have one board per link, so always 0  
+  boardChainNumber = ps.get<int>("boardChainNumber", 0);
+
+  // number of channels on the board
+  nChannels = ps.get<int>("nChannels", MAX_CHANNELS);
+
+  // selects type of VME bridge in use
+  // 3 for A3818, 5 for A5818
+  aX818 = ps.get<std::size_t>("AX818", 3);
+
+  // run ADC self-calibration during configuration
+  // suggestion is to keep it true
+  calibrateOnConfig = ps.get<bool>("CalibrateOnConfig");
+
+  // turn on or off automatic mid-run temperature correction
+  // known to cause baseline jumps, keep OFF (locked)
+  lockTempCalibration = ps.get<bool>("LockTempCalibration");
+
+  // manually write ADC calibration parameters
+  // If true, hardcoded values are written in the registers
+  // "its origin and purpose are still a total mistery", keep false.
+  writeCalibration = ps.get<bool>("WriteCalibration", false);
+
+  // sets the board acquisition mode 
+  // 0=Software Controlled, 1=Front Panel S_IN, 2=First trigger
+  acqMode = ps.get<int>("acqMode");
+
+  // sets the run synchronization mode
+  // currently: 0=CAEN_DGTZ_RUN_SYNC_Disabled 
+  runSyncMode = ps.get<int>("runSyncMode");
+
+  // sets the acqusition window width
+  // size of the recorded waveform buffer in samples
+  recordLength = ps.get<int>("recordLength");
+
+  // sets the post-trigger buffer fraction via CAEN_DGTZ function
+  // percent of waveform buffer after the trigger happens
+  postPercent = ps.get<int>("postPercent");
+
+  // sets the I/O level via CAEN_DGTZ function
+  // 0=NIM, 1=TTL
+  ioLevel = ps.get<int>("ioLevel");
+
+  // sets the input dynamic range
+  // writes to register 0x8028
+  // 0 = 2 Vpp (default), 1 = 0.5 Vpp
+  dynamicRange = ps.get<int>("dynamicRange");
+
+  // enable triangular test wave to the ADCs for debugging purposes
+  // 1 = writes 0b1000 to 0x8004 (CAEN_DGTZ_BROAD_CH_CONFIGBIT_SET_ADD)
+  // 0 = writes 0b1000 to 0x8008 (CAEN_DGTZ_BROAD_CH_CLEAR_CTRL_ADD)
+  // keep zero to leave it disabled
+  testPattern = ps.get<int>("testPattern");
+
+  // sets signal to output on the Analog Monitor Front Panel
+  // 0 = trigger majority, 1 = test, 2 = analog inspection
+  // 3 = buffer ocuppancy mode; 4 = voltage level mode
+  analogMode = ps.get<int>("analogMode");
+
+  // sets maximum number of events for each transfer
+  maxEventsPerTransfer = ps.get<uint32_t>("maxEventsPerTransfer", 1);
+
+  // boardreader poll buffer size (no longer circular!)
+  // this is the size in bytes
+  poolBufferSize = ps.get<std::size_t>("PoolBufferSize"); 
+
+  // sleep time between consecutive _GetNext() calls in us
+  // only in the case of no data in the pollbuffer
+  // also used in case of SW trigger mode
+  getNextSleep = ps.get<uint32_t>("GetNextSleep"); 
+
+  // unclear use in the code...?
+  // controls laggy GetNext metric sent to Grafana
+  // currently: 0.005*20 = 0.1 s 
+  // TODO: remove? rename?
+  getNextFragmentBunchSize  = ps.get<>("GetNextFragmentBunchSize");
+
+  // sets the external trigger input mode via CAEN_DGTZ function
+  // external trigger is tipically enabled for ACQ and TRG-OUT
+  // 0=DISABLED; 1=ACQ_ONLY; 2=TRGOUT_ONLY; 3=ACQ_AND_TRGOUT
+  extTrgMode = ps.get<int>("extTrgMode");
+
+  // sets the software trigger mode via CAEN_DGZT function
+  // software trigger is tipically disabled  
+  // 0=DISABLED; 1=ACQ_ONLY; 2=TRGOUT_ONLY; 3=ACQ_AND_TRGOUT
+  swTrgMode  = ps.get<int>("swTrgMode");
+
+  // sets the self trigger mode for all channels in the bitmask
+  // tipically disabled in favor of the external trigger 
+  // 0:DISABLED 1:ACQ_ONLY 2:TRGOUT_ONLY 3:ACQ_AND_TRGOUT
+  selfTrgMode = ps.get<uint32_t>("SelfTriggerMode"); 
+
+  // sets the bit mask to apply the self-trigger mode 
+  selfTrgMask = ps.get<uint32_t>("SelfTriggerMask"); 
+
+  // sends a software trigger inside each getData() calls
+  // this is used for debugging/test purpose whe sw trigger is on
+  // keep false for production running
+  swTrigger = ps.get<bool>("SWTrigger", false);
+
+  // allows overlapping triggers (buffers are merged)
+  // writes mask 0x0002 to register 0x8004 
   allowTriggerOverlap  = ps.get<bool>("allowTriggerOverlap");
-  dynamicRange         = ps.get<int>("dynamicRange");
-  ioLevel              = ps.get<int>("ioLevel");
-  nChannels            = ps.get<int>("nChannels");
-  extTrgMode           = ps.get<int>("extTrgMode");
-  swTrgMode            = ps.get<int>("swTrgMode");
-  acqMode              = ps.get<int>("acqMode");
-  triggerPolarity      = ps.get<int>("triggerPolarity");
-  triggerPulseWidth    = ps.get<uint8_t>("triggerPulseWidth");
-  debugLevel           = ps.get<int>("debugLevel");
-  postPercent          = ps.get<int>("postPercent");
-  irqWaitTime          = ps.get<int>("irqWaitTime");
-  readoutMode          = ps.get<int>("readoutMode");
-  analogMode           = ps.get<int>("analogMode");
-  testPattern          = ps.get<int>("testPattern");
- // ovthValue            = ps.get<int>("ovthValue");         
-  triggerLogic         = ps.get<int>("triggerLogic");  
-  majorityLevel        = ps.get<int>("majorityLevel"); 
+
+  // self trigger polarity bit for register 0x8000 (used by ICARUS)
+  // bit[6]=1 (negative, under threshold) or 
+  // bit[6]=0 (positive, over threshold)
+  selfTrgBit = ps.get<uint32_t>("SelfTrigBit");
+  
+  // Exclusive for SBND: keep this parameter = 0
+  // sets trigger polarity via CAEN_DGTZ library
+  // skipped by code for ICARUS
+  triggerPolarity = ps.get<int>("triggerPolarity");
+
+  // Exclusive for SBND: keep this parameter = 0
+  // majority level for self trigger mode
+  // skipped by the code in ICARUS
+  majorityLevel = ps.get<int>("majorityLevel"); 
+
+  // Exclusive for SBND: keep this parameter = 0
+  // majority coincident window for self trigger mode
+  // skipped by the code in ICARUS
   majorityCoincidenceWindow = ps.get<int>("majorityCoincidenceWindow"); 
-  maxTemp              = ps.get<uint32_t>("maxTempCelsius", 80);
+
+  // Exclusive for SBND: keep this parameter = 3
+  // self trigger logic setting
+  // skipped by the code in ICARUS
+  triggerLogic = ps.get<int>("triggerLogic");  
+
+  // LVDS output mode flag
+  // difference between ICARUS and SBND
+  // ICARUS=1, SBND=0
+  modeLVDS = ps.get<uint32_t>("ModeLVDS"); 
+
+  // Sets the TRIG-IN control
+  // 1=level, 0=edge
+  trigInLevel = ps.get<uint32_t>("TrigInLevel", 0);
+
+  // Exclusive for SBND, ICARUS keep to 20
+  // setting 0x1n70 but with the same parameter for all
+  // skipped in the code for ICARUS
+  triggerPulseWidth = ps.get<uint8_t>("triggerPulseWidth");
+
+  // Allow use of TriggerTimeTag (TTT) to form fragment timestamp
+  // exploit last full second of NTP time + TTT from board
+  useTimeTagForTimeStamp = ps.get<bool>("UseTimeTagForTimeStamp",true);
+  
+  // Exclusive for SBND
+  // different meaning to the timestamp, do no use for ICARUS!
+  useTimeTagShiftForTimeStamp = ps.get<bool>("UseTimeTagShiftForTimeStamp",false);
+
+  // adds optional offset to fragment timestamp in ns
+  timeOffsetNanoSec = ps.get<uint32_t>("TimeOffsetNanoSec", 0); 
+
+  // If enabled, motherboard clock is sent to TRG-OUT
+  // useful for testing CAENV1730 CLOCK synchronization
+  outputClk = ps.get<bool>("OutputClk", false); 
+
+  // If enabled, motherboard clock phase is sent to TRG-OUT
+  // useful for testing CAENV1730 CLOCK synchronization
+  outputClkPhase = ps.get<bool>("OutputClkPhase", false);
+
+  // Max ADC temperature before sending warnings
+  // From CAEN manual: V1730(S) shuts itself down at 70(85) Celsius
+  maxTemp = ps.get<uint32_t>("maxTempCelsius", 80);
+
+  // Mask saying which ADCs to perform the temperature check on
+  // needed to skip channels in one problematic board (S/N 164)
   temperatureCheckMask = ps.get<uint32_t>("temperatureCheckMask", 0xFFFF);
-  aX818                = ps.get<size_t>("AX818", 3);
+
+  // Timeout value waiting for an interrupt in ms
+  // set via CAEN_DGTZ_IRQWait
+  IRQTimeoutMS = ps.get<uint32_t>("IRQTimeoutMS",500);
 
   char tag[1024];
   channelEnableMask = 0;
 
   for ( int j=0; j<MAX_CHANNELS; j++){
+
+    // setting the channel enable mask
+    // this is both for readout and trigger features
+    // probably setting 0x810C appropriately behind the scenes 
+    sprintf(tag,"channelEnable%d", j);
+    channelEnable[j] = ps.get<bool>(tag);
+    if ( channelEnable[j] ) channelEnableMask |= ( 1 << j );
+
+    // absolute ADC threshold values for triggering
     sprintf(tag,"triggerThreshold%d", j);
     triggerThresholds[j] = ps.get<uint16_t>(tag);
+
+    // DC offset values for baseline setting
+    // Writing to registers 0x1n98
+    sprintf(tag,"channelPedestal%d", j);
+	  pedestal[j] = ps.get<int>(tag);
+
+    // LVDS output signal width in clock periods 
+    // Channel pulse width registers: 0x1n70
+    // e.g: 20 x 8ns = 160ns
+    sprintf(tag,"LVDSOutWidthC%d",j+1); //names go from 1 to 16
+    LVDSOutWidth[j] = ps.get<uint32_t>(tag);
+
   }
 
-  if ( enableReadout ){
-    for ( int j=0; j<MAX_CHANNELS; j++){
-      sprintf(tag,"channelEnable%d", j);
-      channelEnable[j] = ps.get<bool>(tag);
-      if ( channelEnable[j] )
-      {
-	channelEnableMask |= ( 1 << j );
-	sprintf(tag,"channelPedestal%d", j);
-	pedestal[j] = ps.get<int>(tag);
-      }
+  for ( int j=0; j<MAX_CHANNELS / 2; j++){
 
-      /*
-      sprintf(tag,"channelSelfTrgMode%d", j);
-      channelSelfTrgMode[j] = ps.get<bool>(tag);
-      if ( channelSelfTrgMode[j] )
-      {
-	channelEnableMask |= ( 1 << j );
-	sprintf(tag,"channelPedestal%d", j);
-	pedestal[j] = ps.get<int>(tag);
-      }
-      */
-    }
+    // Logic values for the LVDS pairs 
+    // Self trigger logic registers: 0x1n84   
+    // 01=only first in pair, 10=only second in pair, 00=AND, 11=OR
+    // bit[2] kept to 0 to allow custom output width
+    sprintf(tag,"LVDSLogicValueG%d",j+1); //names go from 1 to 8
+    LVDSLogicValue[j] = ps.get<uint32_t>(tag);
+
   }
 }
-
 
 void sbndaq::CAENConfiguration::print(std::ostream& os) 
 {
@@ -108,53 +253,81 @@ void sbndaq::CAENConfiguration::print(std::ostream& os)
 
 std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
 {
-  os << "CAEN Configuration" << std::endl;
-  os << "  Link                  " << e.link << std::endl;
-  os << "  nBoards               " << e.nBoards << std::endl;
-  os << "  EnableReadout         " << e.enableReadout << std::endl;
-  os << "  RecordLength          " << e.recordLength << std::endl;
-  os << "  AllowTriggerOverlap   " << e.allowTriggerOverlap << std::endl;
-  os << "  DynamicRange          " << e.dynamicRange << std::endl;
-  os << "  nChannels             " << e.nChannels << std::endl;
-  os << "  PostPercent           " << e.postPercent << "%" << std::endl;
-  os << "  IrqWaitTime           " << e.irqWaitTime << std::endl;
-  os << "  IOLevel (NIM or TTL)  " << e.ioLevel << " " 
-     << sbndaq::CAENDecoder::IOLevel((CAEN_DGTZ_IOLevel_t)e.ioLevel) << std::endl;
-  os << "  TriggerPolarity       " << e.triggerPolarity << " " 
-     << sbndaq::CAENDecoder::TriggerPolarity((CAEN_DGTZ_TriggerPolarity_t)e.triggerPolarity) << std::endl;
-  os << "  TriggerPulseWidth     " << e.triggerPulseWidth << std::endl;
-  os << "  ExtTrgMode            " << e.extTrgMode << " " 
-     << sbndaq::CAENDecoder::TriggerMode((CAEN_DGTZ_TriggerMode_t)e.extTrgMode) << std::endl;
-  os << "  SWTrgMode             " << e.swTrgMode << " " 
-     << sbndaq::CAENDecoder::TriggerMode((CAEN_DGTZ_TriggerMode_t)e.swTrgMode) << std::endl;
+  os << "CAEN Configuration: " << std::endl;
+  os << "Link                  " << e.link << std::endl;
+  os << "FragmentID            " << e.fragmentId << std::endl;
+  os << "BoardId               " << e.boardId << std::endl;
+  os << "BoardChainNumber      " << e.boardChainNumber << std::endl;
+  os << "nChannels             " << e.nChannels << std::endl;
+  os << "AX818                 " << e.aX818 << std::endl;
+  os << "CalibrateOnConfig     " << e.calibrateOnConfig << std::endl;
+  os << "LockTempCalibration   " << e.lockTempCalibration << std::endl;
+  os << "WriteCalibration      " << e.writeCalibration << std::endl;
+  os << "AcqMode               " << e.acqMode << " " 
+                                   << sbndaq::CAENDecoder::AcquisitionMode((CAEN_DGTZ_AcqMode_t)e.acqMode) 
+                                   << std::endl;
+  os << "RunSyncMode           " << e.runSyncMode << " " 
+                                   << sbndaq::CAENDecoder::RunSynchronizationMode((CAEN_DGTZ_RunSyncMode_t)e.runSyncMode) 
+                                   << std::endl;
+  os << "RecordLength          " << e.recordLength << " samples" << std::endl;
+  os << "PostPercent           " << e.postPercent << "%" << std::endl;
+  os << "IOLevel (NIM or TTL)  " << e.ioLevel << " "
+                                   << sbndaq::CAENDecoder::IOLevel((CAEN_DGTZ_IOLevel_t)e.ioLevel) 
+                                   << std::endl;
+  os << "DynamicRange          " << e.dynamicRange << std::endl;
+  os << "TestPattern           " << e.testPattern << std::endl;
+  os << "AnalogMode            " << e.analogMode << " " 
+                                   << sbndaq::CAENDecoder::AnalogMonOutput((CAEN_DGTZ_AnalogMonitorOutputMode_t)e.analogMode) 
+                                   << std::endl;
+  os << "MaxEventsPerTransfer  " << e.maxEventsPerTransfer << std::endl;
+  os << "PoolBufferSize        " << e.poolBufferSize << " bytes" << std::endl;
+  os << "GetNextSleep          " << e.getNextSleep << " us" << std::endl;
+  os << "GetNextFragmentBunchSize " << e.getNextFragmentBunchSize << std::endl;
+  os << "ExtTrgMode            " << e.extTrgMode << " " 
+                                   << sbndaq::CAENDecoder::TriggerMode((CAEN_DGTZ_TriggerMode_t)e.extTrgMode) 
+                                   << std::endl;
+  os << "SWTrgMode             " << e.swTrgMode << " " 
+                                   << sbndaq::CAENDecoder::TriggerMode((CAEN_DGTZ_TriggerMode_t)e.swTrgMode) 
+                                   << std::endl;
+  os << "SelfTrgMode           " << e.selfTrgMode << " " 
+                                   << sbndaq::CAENDecoder::TriggerMode((CAEN_DGTZ_TriggerMode_t)e.selfTrgMode) 
+                                   << std::endl;                                
+  os << "SelfTrgMask         0x" << std::hex << e.selfTrgMask << std::dec << " " << e.selfTrgMask << std::endl;
+  os << "SWTrigger             " << e.swTrigger << std::endl;
+  os << "AllowTriggerOverlap   " << e.allowTriggerOverlap << std::endl;
+  os << "selfTrgBit          0x" << std::hex << e.selfTrgBit << std::dec << " " << e.selfTrgBit << std::endl;
+  os << "TriggerPolarity       " << e.triggerPolarity << " " 
+                                   << sbndaq::CAENDecoder::TriggerPolarity((CAEN_DGTZ_TriggerPolarity_t)e.triggerPolarity) 
+                                   << std::endl;
+  os << "MajorityLevel         " << e.majorityLevel << std::endl;
+  os << "MajorityCoincidenceWindow " << e.majorityCoincidenceWindow << std::endl;
+  os << "TriggerLogic          " << e.triggerLogic << std::endl;
+  os << "ModeLVDS              " << e.modeLVDS << std::endl;
+  os << "TrigInLevel           " << e.trigInLevel << std::endl;
+  os << "TriggerPulseWidth     " << e.triggerPulseWidth << std::endl;
+  os << "UseTimeTagForTimeStamp " << e.useTimeTagForTimeStamp << std::endl;
+  os << "useTimeTagShiftForTimeStamp " << e.useTimeTagShiftForTimeStamp << std::endl;
+  os << "TimeOffsetNanoSec     " << e.timeOffsetNanoSec << " ns" << std::endl;
+  os << "OutputClk             " << e.outputClk << std::endl;
+  os << "OutputClkPhase        " << e.outputClkPhase << std::endl;
+  os << "MaxTempCelsius        " << e.maxTemp << "C" << std::endl;
+  os << "TemperatureCheckMask 0x" << std::hex << e.temperatureCheckMask << std::dec << std::endl;
+  os << "IRQTimeoutMS          " << e.IRQTimeoutMS << " ms" << std::endl;
+  os << "ChannelEnableMask   0x" << std::hex << e.channelEnableMask << std::dec << std::endl;
+
   for ( int j=0; j<sbndaq::CAENConfiguration::MAX_CHANNELS; j++)
-      os << "    Channel " << j << " Threshold " << e.triggerThresholds[j] << std::endl;
-  os << "  AcqMode               " << e.acqMode << " " 
-     << sbndaq::CAENDecoder::AcquisitionMode((CAEN_DGTZ_AcqMode_t)e.acqMode) << std::endl;
-  os << "  DebugLevel            " << e.debugLevel << std::endl;
-  os << "  ReadoutMode           " << e.readoutMode << " " 
-     << sbndaq::CAENDecoder::EnaDisMode((CAEN_DGTZ_EnaDis_t)e.readoutMode) << std::endl;
-  os << "  AnalogMode            " << e.analogMode << std::endl;
-  os << "  TestPattern           " << e.testPattern << std::endl;
- // os << "  OvthValue             " << e.ovthValue << std::endl;
-  os << "  TriggerLogic          " << e.triggerLogic << std::endl;
-  os << "  MajorityLevel         " << e.majorityLevel << std::endl;
-  os << "  MajorityCoincidenceWindow " << e.majorityCoincidenceWindow << std::endl;
-  os << "  MaxTempCelsius        " << e.maxTemp << std::endl;
-  os << "  TemperatureCheckMask  0x" << std::hex << e.temperatureCheckMask << std::dec << std::endl;
-  os << "  AX818                 " << e.aX818 << std::endl;
-  os << "  BoardId               " << e.boardId << 
-      "  EnableReadout " << e.enableReadout << std::endl;
-  if ( e.enableReadout )
   {
-    os << "    ChannelEnableMask   0x" << std::hex << e.channelEnableMask << std::dec << std::endl;
-    for ( int j=0; j<sbndaq::CAENConfiguration::MAX_CHANNELS; j++)
-    {
-      if ( e.channelEnable[j] )
-      {
-	os << "    Channel " << j << " Pedestal " << e.pedestal[j] << std::endl;
-      }
-    }
+    os << "Channel " << j << " EnableReadout " << e.channelEnable[j] 
+                          << " Threshold " << e.triggerThresholds[j] 
+                          << " Pedestal " << e.pedestal[j] 
+                          << " LVDSOutWidth " << e.LVDSOutWidth[j] 
+                          << std::endl;
   }
+
+  for ( int j=0; j<sbndaq::CAENConfiguration::MAX_CHANNELS / 2; j++)
+  {
+    os << "ChannelPair " << j << " LVDSLogicValue " << e.LVDSLogicValue[j] << std::endl;
+  }
+
   return(os);
 }

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -11,6 +11,8 @@
 #include "sbndaq-artdaq/Generators/Common/CAENConfiguration.hh"
 #include "sbndaq-artdaq/Generators/Common/CAENDecoder.hh"
 #include <iostream>
+#include <sstream>
+#include <string>
 
 // Constructor reads fhicl paramaters
 // NOTE: do not put defaults on REQUIRED parameters
@@ -259,6 +261,13 @@ void sbndaq::CAENConfiguration::print(std::ostream& os)
   os << *this;
 }
 
+std::string sbndaq::CAENConfiguration::to_string() const
+{
+  std::ostringstream os;
+  os << *this;
+  return os.str();
+}
+
 std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
 {
   os << "CAEN Configuration: " << std::endl;
@@ -312,7 +321,7 @@ std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
   os << "TriggerLogic          " << e.triggerLogic << std::endl;
   os << "ModeLVDS              " << e.modeLVDS << std::endl;
   os << "TrigInLevel           " << e.trigInLevel << std::endl;
-  os << "TriggerPulseWidth     " << e.triggerPulseWidth << std::endl;
+  os << "TriggerPulseWidth     " << int(e.triggerPulseWidth) << std::endl;
   os << "UseTimeTagForTimeStamp " << e.useTimeTagForTimeStamp << std::endl;
   os << "useTimeTagShiftForTimeStamp " << e.useTimeTagShiftForTimeStamp << std::endl;
   os << "TimeOffsetNanoSec     " << e.timeOffsetNanoSec << " ns" << std::endl;
@@ -320,7 +329,7 @@ std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
   os << "OutputClkPhase        " << e.outputClkPhase << std::endl;
   os << "MaxTempCelsius        " << e.maxTemp << "C" << std::endl;
   os << "TemperatureCheckMask 0x" << std::hex << e.temperatureCheckMask << std::dec << std::endl;
-  os << "InterruptEnable       " << e.interruptEnable << " " 
+  os << "InterruptEnable       " << int(e.interruptEnable) << " " 
                                  << sbndaq::CAENDecoder::EnaDisMode((CAEN_DGTZ_EnaDis_t)e.interruptEnable)
                                  << std::endl;
   os << "InterruptEventNumber  " << e.interruptEventNumber << std::endl;

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -201,6 +201,14 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps)
   // needed to skip channels in one problematic board (S/N 164)
   temperatureCheckMask = ps.get<uint32_t>("temperatureCheckMask", 0xFFFF);
 
+  // Enables optical link interrupts
+  // interrupt mode always CAEN_DGTZ_IRQ_MODE_RORA
+  // 0=CAEN_DGTZ_DISABLE, 1=CAEN_DGTZ_ENABLE
+  interruptEnable = ps.get<uint8_t>("InterruptEnable");
+
+  // Number of events needed to generate interrupt
+  interruptEventNumber = ps.get<uint16_t>("InterruptEventNumber",1);
+
   // Timeout value waiting for an interrupt in ms
   // set via CAEN_DGTZ_IRQWait
   IRQTimeoutMS = ps.get<uint32_t>("IRQTimeoutMS",500);
@@ -312,6 +320,10 @@ std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
   os << "OutputClkPhase        " << e.outputClkPhase << std::endl;
   os << "MaxTempCelsius        " << e.maxTemp << "C" << std::endl;
   os << "TemperatureCheckMask 0x" << std::hex << e.temperatureCheckMask << std::dec << std::endl;
+  os << "InterruptEnable       " << e.interruptEnable << " " 
+                                 << sbndaq::CAENDecoder::EnaDisMode((CAEN_DGTZ_EnaDis_t)e.interruptEnable)
+                                 << std::endl;
+  os << "InterruptEventNumber  " << e.interruptEventNumber << std::endl;
   os << "IRQTimeoutMS          " << e.IRQTimeoutMS << " ms" << std::endl;
   os << "ChannelEnableMask   0x" << std::hex << e.channelEnableMask << std::dec << std::endl;
 

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -106,7 +106,7 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps)
   // controls laggy GetNext metric sent to Grafana
   // currently: 0.005*20 = 0.1 s 
   // TODO: remove? rename?
-  getNextFragmentBunchSize  = ps.get<>("GetNextFragmentBunchSize");
+  getNextFragmentBunchSize = ps.get<uint32_t>("GetNextFragmentBunchSize");
 
   // sets the external trigger input mode via CAEN_DGTZ function
   // external trigger is tipically enabled for ACQ and TRG-OUT
@@ -116,7 +116,7 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps)
   // sets the software trigger mode via CAEN_DGZT function
   // software trigger is tipically disabled  
   // 0=DISABLED; 1=ACQ_ONLY; 2=TRGOUT_ONLY; 3=ACQ_AND_TRGOUT
-  swTrgMode  = ps.get<int>("swTrgMode");
+  swTrgMode = ps.get<int>("swTrgMode");
 
   // sets the self trigger mode for all channels in the bitmask
   // tipically disabled in favor of the external trigger 
@@ -133,7 +133,7 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps)
 
   // allows overlapping triggers (buffers are merged)
   // writes mask 0x0002 to register 0x8004 
-  allowTriggerOverlap  = ps.get<bool>("allowTriggerOverlap");
+  allowTriggerOverlap = ps.get<bool>("allowTriggerOverlap");
 
   // self trigger polarity bit for register 0x8000 (used by ICARUS)
   // bit[6]=1 (negative, under threshold) or 

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
@@ -8,6 +8,8 @@
 #include "fhiclcpp/ParameterSet.h"
 #include <iostream>
 #include <trace.h>
+#include <string>
+#include <sstream>
 
 namespace sbndaq
 {
@@ -28,6 +30,7 @@ namespace sbndaq
     
     /// Prints all configuration variables
     void print(std::ostream &os = std::cout);
+    std::string to_string() const;
 
     int link;                      ///> optical link number
     uint32_t fragmentId;           ///> fragment id
@@ -86,17 +89,5 @@ namespace sbndaq
 
 /// Define << operator for easy streaming
 std::ostream &operator<<(std::ostream &os, const sbndaq::CAENConfiguration &e);
-
-namespace
-{
-  template <>
-  inline TraceStreamer &TraceStreamer::
-  operator<<(const sbndaq::CAENConfiguration &r)
-  {
-    std::ostringstream s;
-    s << r;
-    return *this;
-  }
-}
 
 #endif

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
@@ -5,79 +5,96 @@
 #ifndef _CAENConfiguration_h
 #define _CAENConfiguration_h
 
-#include "CAENDecoder.hh"
 #include "fhiclcpp/ParameterSet.h"
 #include <iostream>
+#include <trace.h>
 
 namespace sbndaq
 {
-class CAENConfiguration
-{
-  public:
-  enum
+  class CAENConfiguration
   {
-    MAX_BOARDS = 8,
-    MAX_CHANNELS = 16
+  public:
+    enum
+    {
+      MAX_BOARDS = 8,
+      MAX_CHANNELS = 16
+    };
+
+    /// Constructor
+    CAENConfiguration(fhicl::ParameterSet const &ps);
+    
+    /// Virtual destructor
+    virtual ~CAENConfiguration() {}
+    
+    /// Prints all configuration variables
+    void print(std::ostream &os = std::cout);
+
+    int link;                      ///> optical link number
+    uint32_t fragmentId;           ///> fragment id
+    int boardId;                   ///> board id
+    int boardChainNumber;          ///> board optlink chain number 
+    int nChannels;                 ///> number of channels
+    std::size_t aX818;             ///> vme bridge card (A3818 or A5818)
+    bool calibrateOnConfig;        ///> force ADC calibration on config
+    bool lockTempCalibration;      ///> disable temperature self-calibration
+    bool writeCalibration;         ///> write manual ADC calibration parameters
+    int acqMode;                   ///> sets run acquisition mode
+    int runSyncMode;               ///> sets run synchronization mode
+    int recordLength;              ///> size of the recorded waveform buffer in samples
+    int postPercent;               ///> sets the post-trigger buffer fraction
+    int ioLevel;                   ///> sets i/o level
+    int dynamicRange;              ///> sets the input dynamic range
+    int testPattern;               ///> enable debugging test pattern
+    int analogMode;                ///> sets signal to output on the Analog Monitor Front Panel
+    uint32_t maxEventsPerTransfer; ///> max number of events for each transfer
+    std::size_t poolBufferSize;    ///> boardreader pool buffer size
+    uint32_t getNextSleep;         ///> sleep time between consecutive GetNext() calls
+    uint32_t getNextFragmentBunchSize; ///> unclear use in the code...?
+    int extTrgMode;                ///> sets the external trigger input mode
+    int swTrgMode;                 ///> sets the software trigger mode
+    uint32_t selfTrgMode;          ///> sets the self trigger mode
+    uint32_t selfTrgMask;          ///> sets the bit mask to apply the self-trigger mode 
+    bool swTrigger;                ///> sends a software trigger
+    bool allowTriggerOverlap;      ///> allows overlapping triggers
+    uint32_t selfTrgBit;           ///> self trigger polarity bit
+    int triggerPolarity;           ///> sets trigger polarity via CAEN_DGTZ library
+    int majorityLevel;             ///> majority level for self trigger mode
+    int majorityCoincidenceWindow; ///> majority coincident window for self trigger mode
+    int triggerLogic;              ///> self trigger logic setting
+    uint32_t modeLVDS;             ///> LVDS output mode
+    uint32_t trigInLevel;          ///> TRG_IN on level (1) or edge (0)
+    uint8_t triggerPulseWidth;     ///> LVDS output pulse width (all channels)
+    bool useTimeTagForTimeStamp;       ///> use TTT for fragment timestamp
+    bool useTimeTagShiftForTimeStamp;  ///> use TTT shift for fragment timestamp
+    uint32_t timeOffsetNanoSec;        ///> add time offset to fragment timestamp (optional)
+    bool outputClk;                    ///> output motherboard CLK to TRG-OUT
+    bool outputClkPhase;               ///> output motherboard CLK PHASE to TRG-OUT
+    uint32_t maxTemp;                  ///> max temperature before warnings are issued
+    uint32_t temperatureCheckMask;     ///> 8 bit mask saying which ADCs to perform the temperature check
+    uint32_t IRQTimeoutMS;             ///> timeout value waiting for an interrupt in ms
+    int channelEnable[MAX_CHANNELS];           ///> sets channel enable mask
+    uint32_t channelEnableMask;
+    int pedestal[MAX_CHANNELS];                ///> sets channel baseline pedestal
+    uint16_t triggerThresholds[MAX_CHANNELS];  ///> sets channel trigger threshold
+    uint32_t LVDSOutWidth[MAX_CHANNELS];       ///> sets channel LVDS output pulse width
+    uint32_t LVDSLogicValue[MAX_CHANNELS / 2]; ///> sets logic values for LVDS pairs
+
   };
-
-  virtual ~CAENConfiguration() {}
-  CAENConfiguration(fhicl::ParameterSet const & ps);
-
-    int  link;
-    int  nBoards;
-    int  enableReadout;
-    int  boardId;
-    int  recordLength;
-    int  postPercent;
-    int  eventsPerInterrupt;
-    int  irqWaitTime;
-    bool allowTriggerOverlap;
-    int  dynamicRange;
-    int  ioLevel;
-    int  nChannels;
-    int  triggerPolarity;
-    uint16_t triggerThresholds[MAX_CHANNELS];
-    uint8_t   triggerPulseWidth;
-    int  extTrgMode;
-    int  swTrgMode;
-    int  selfTrgMode;
-    int  acqMode;
-    int  debugLevel;
-    int  runSyncMode;
-    int  readoutMode;
-    int  analogMode;
-    int  testPattern;
-    int  pedestal[MAX_CHANNELS];
-    int  channelEnable[MAX_CHANNELS];
-    int  channelSelfTrgLogic[MAX_CHANNELS/2];
-    int  channelSelfTrgPulseType[MAX_CHANNELS/2];
-
-    uint32_t  channelEnableMask;
-    uint32_t  channelSelfTrgMask;
-  //  int  ovthValue;         
-    int  triggerLogic;  
-    int  majorityLevel; 
-    int  majorityCoincidenceWindow;
-    uint32_t  maxTemp;
-    uint32_t temperatureCheckMask; // 8 bit mask saying which ADCs to perforrm the temperature check
-
-    size_t aX818; // Are we using an A3818 card, an A5818 card, something else?
-
-    void print(std::ostream & os = std::cout);
-};
 }
 
-std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e);
+/// Define << operator for easy streaming
+std::ostream &operator<<(std::ostream &os, const sbndaq::CAENConfiguration &e);
 
-#include <trace.h>
-namespace {
-template <>
-inline TraceStreamer &TraceStreamer::
-operator<<(const sbndaq::CAENConfiguration &r) {
-  std::ostringstream s;
-  s << r;
-  return *this;
+namespace
+{
+  template <>
+  inline TraceStreamer &TraceStreamer::
+  operator<<(const sbndaq::CAENConfiguration &r)
+  {
+    std::ostringstream s;
+    s << r;
+    return *this;
+  }
 }
-} // namespace
 
 #endif

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.hh
@@ -71,6 +71,8 @@ namespace sbndaq
     bool outputClkPhase;               ///> output motherboard CLK PHASE to TRG-OUT
     uint32_t maxTemp;                  ///> max temperature before warnings are issued
     uint32_t temperatureCheckMask;     ///> 8 bit mask saying which ADCs to perform the temperature check
+    uint8_t interruptEnable;           ///> enable optical link interrupts
+    uint16_t interruptEventNumber;     ///> number of events needed to generate an interrupt
     uint32_t IRQTimeoutMS;             ///> timeout value waiting for an interrupt in ms
     int channelEnable[MAX_CHANNELS];           ///> sets channel enable mask
     uint32_t channelEnableMask;

--- a/sbndaq-artdaq/Generators/Common/CAENDecoder.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENDecoder.hh
@@ -4,7 +4,6 @@
 
 #include <atomic>
 #include <type_traits>
-//#include "messagefacility/MessageLogger/MessageLogger.h"
 #include <map>
 #include <string>
 #include <initializer_list>
@@ -33,36 +32,37 @@ class CAENDecoder
 
   const static std::string CAENError(CAEN_DGTZ_ErrorCode err)
   {
-    static const std::map<CAEN_DGTZ_ErrorCode, std::string> errors{{CAEN_DGTZ_Success, "CAEN_DGTZ_Success" },
-            { CAEN_DGTZ_CommError,                "CAEN_DGTZ_CommError" },
-            { CAEN_DGTZ_GenericError,             "CAEN_DGTZ_GenericError" },
-            { CAEN_DGTZ_InvalidParam,             "CAEN_DGTZ_InvalidParam" },
-            { CAEN_DGTZ_InvalidLinkType,          "CAEN_DGTZ_InvalidLinkType" },
-	    { CAEN_DGTZ_InvalidHandle,            "CAEN_DGTZ_InvalidHandle" },
-            { CAEN_DGTZ_MaxDevicesError,          "CAEN_DGTZ_MaxDevicesError" },
-            { CAEN_DGTZ_BadBoardType,             "CAEN_DGTZ_BadBoardType" },
-            { CAEN_DGTZ_BadInterruptLev,          "CAEN_DGTZ_BadInterruptLev" },
-            { CAEN_DGTZ_BadEventNumber,           "CAEN_DGTZ_BadEventNumber" },
-            { CAEN_DGTZ_ReadDeviceRegisterFail,   "CAEN_DGTZ_ReadDeviceRegisterFail" },
-            { CAEN_DGTZ_WriteDeviceRegisterFail,  "CAEN_DGTZ_WriteDeviceRegisterFail" },
-            { CAEN_DGTZ_InvalidChannelNumber,     "CAEN_DGTZ_InvalidChannelNumber" },
-            { CAEN_DGTZ_ChannelBusy,              "CAEN_DGTZ_ChannelBusy" },
-            { CAEN_DGTZ_FPIOModeInvalid,          "CAEN_DGTZ_FPIOModeInvalid" },
-            { CAEN_DGTZ_WrongAcqMode,             "CAEN_DGTZ_WrongAcqMode" },
-            { CAEN_DGTZ_FunctionNotAllowed,       "CAEN_DGTZ_FunctionNotAllowed" },
-            { CAEN_DGTZ_Timeout,                  "CAEN_DGTZ_Timeout" },
-            { CAEN_DGTZ_InvalidBuffer,            "CAEN_DGTZ_InvalidBuffer" },
-            { CAEN_DGTZ_EventNotFound,            "CAEN_DGTZ_EventNotFound" },
-            { CAEN_DGTZ_InvalidEvent,             "CAEN_DGTZ_InvalidEvent" },
-            { CAEN_DGTZ_OutOfMemory,              "CAEN_DGTZ_OutOfMemory" },
-            { CAEN_DGTZ_CalibrationError,         "CAEN_DGTZ_CalibrationError" },
-            { CAEN_DGTZ_DigitizerNotFound,        "CAEN_DGTZ_DigitizerNotFound" },
-            { CAEN_DGTZ_DigitizerAlreadyOpen,     "CAEN_DGTZ_DigitizerAlreadyOpen" },
-            { CAEN_DGTZ_DigitizerNotReady,        "CAEN_DGTZ_DigitizerNotReady" },
-            { CAEN_DGTZ_InterruptNotConfigured,   "CAEN_DGTZ_InterruptNotConfigured" },
-            { CAEN_DGTZ_DigitizerMemoryCorrupted, "CAEN_DGTZ_DigitizerMemoryCorrupted" },
-            { CAEN_DGTZ_DPPFirmwareNotSupported,  "CAEN_DGTZ_DPPFirmwareNotSupported" },
-            { CAEN_DGTZ_NotYetImplemented,        "CAEN_DGTZ_NotYetImplemented" }};
+    static const std::map<CAEN_DGTZ_ErrorCode, std::string> errors{
+      { CAEN_DGTZ_Success, "CAEN_DGTZ_Success" },
+      { CAEN_DGTZ_CommError,                "CAEN_DGTZ_CommError" },
+      { CAEN_DGTZ_GenericError,             "CAEN_DGTZ_GenericError" },
+      { CAEN_DGTZ_InvalidParam,             "CAEN_DGTZ_InvalidParam" },
+      { CAEN_DGTZ_InvalidLinkType,          "CAEN_DGTZ_InvalidLinkType" },
+      { CAEN_DGTZ_InvalidHandle,            "CAEN_DGTZ_InvalidHandle" },
+      { CAEN_DGTZ_MaxDevicesError,          "CAEN_DGTZ_MaxDevicesError" },
+      { CAEN_DGTZ_BadBoardType,             "CAEN_DGTZ_BadBoardType" },
+      { CAEN_DGTZ_BadInterruptLev,          "CAEN_DGTZ_BadInterruptLev" },
+      { CAEN_DGTZ_BadEventNumber,           "CAEN_DGTZ_BadEventNumber" },
+      { CAEN_DGTZ_ReadDeviceRegisterFail,   "CAEN_DGTZ_ReadDeviceRegisterFail" },
+      { CAEN_DGTZ_WriteDeviceRegisterFail,  "CAEN_DGTZ_WriteDeviceRegisterFail" },
+      { CAEN_DGTZ_InvalidChannelNumber,     "CAEN_DGTZ_InvalidChannelNumber" },
+      { CAEN_DGTZ_ChannelBusy,              "CAEN_DGTZ_ChannelBusy" },
+      { CAEN_DGTZ_FPIOModeInvalid,          "CAEN_DGTZ_FPIOModeInvalid" },
+      { CAEN_DGTZ_WrongAcqMode,             "CAEN_DGTZ_WrongAcqMode" },
+      { CAEN_DGTZ_FunctionNotAllowed,       "CAEN_DGTZ_FunctionNotAllowed" },
+      { CAEN_DGTZ_Timeout,                  "CAEN_DGTZ_Timeout" },
+      { CAEN_DGTZ_InvalidBuffer,            "CAEN_DGTZ_InvalidBuffer" },
+      { CAEN_DGTZ_EventNotFound,            "CAEN_DGTZ_EventNotFound" },
+      { CAEN_DGTZ_InvalidEvent,             "CAEN_DGTZ_InvalidEvent" },
+      { CAEN_DGTZ_OutOfMemory,              "CAEN_DGTZ_OutOfMemory" },
+      { CAEN_DGTZ_CalibrationError,         "CAEN_DGTZ_CalibrationError" },
+      { CAEN_DGTZ_DigitizerNotFound,        "CAEN_DGTZ_DigitizerNotFound" },
+      { CAEN_DGTZ_DigitizerAlreadyOpen,     "CAEN_DGTZ_DigitizerAlreadyOpen" },
+      { CAEN_DGTZ_DigitizerNotReady,        "CAEN_DGTZ_DigitizerNotReady" },
+      { CAEN_DGTZ_InterruptNotConfigured,   "CAEN_DGTZ_InterruptNotConfigured" },
+      { CAEN_DGTZ_DigitizerMemoryCorrupted, "CAEN_DGTZ_DigitizerMemoryCorrupted" },
+      { CAEN_DGTZ_DPPFirmwareNotSupported,  "CAEN_DGTZ_DPPFirmwareNotSupported" },
+      { CAEN_DGTZ_NotYetImplemented,        "CAEN_DGTZ_NotYetImplemented" }};
     auto it = errors.find (err);
     if (it == errors.end ()) return "CAEN_Unknown_error";
     return it->second;
@@ -72,11 +72,11 @@ class CAENDecoder
   const static std::string AnalogMonOutput(CAEN_DGTZ_AnalogMonitorOutputMode_t mode)
   {
     static const std::map<CAEN_DGTZ_AnalogMonitorOutputMode_t, std::string> table{
-       { CAEN_DGTZ_AM_TRIGGER_MAJORITY, "CAEN_DGTZ_AM_TRIGGER_MAJORITY" },
-       { CAEN_DGTZ_AM_TEST, "CAEN_DGTZ_AM_TEST" },
-       { CAEN_DGTZ_AM_ANALOG_INSPECTION, "CAEN_DGTZ_AM_ANALOG_INSPECTION" },
-       { CAEN_DGTZ_AM_BUFFER_OCCUPANCY, "CAEN_DGTZ_AM_BUFFER_OCCUPANCY" },
-       { CAEN_DGTZ_AM_VOLTAGE_LEVEL, "CAEN_DGTZ_AM_VOLTAGE_LEVEL" }};
+      { CAEN_DGTZ_AM_TRIGGER_MAJORITY, "CAEN_DGTZ_AM_TRIGGER_MAJORITY" },
+      { CAEN_DGTZ_AM_TEST, "CAEN_DGTZ_AM_TEST" },
+      { CAEN_DGTZ_AM_ANALOG_INSPECTION, "CAEN_DGTZ_AM_ANALOG_INSPECTION" },
+      { CAEN_DGTZ_AM_BUFFER_OCCUPANCY, "CAEN_DGTZ_AM_BUFFER_OCCUPANCY" },
+      { CAEN_DGTZ_AM_VOLTAGE_LEVEL, "CAEN_DGTZ_AM_VOLTAGE_LEVEL" }};
     auto it = table.find (mode);
     if (it == table.end ()) return "CAEN_Unknown";
     return it->second;
@@ -85,9 +85,9 @@ class CAENDecoder
   const static std::string ZeroSuppressionMode(CAEN_DGTZ_ZS_Mode_t mode)
   {
     static const std::map<CAEN_DGTZ_ZS_Mode_t, std::string> table{{CAEN_DGTZ_ZS_NO, "CAEN_DGTZ_ZS_NO" },
-       { CAEN_DGTZ_ZS_NO,  "CAEN_DGTZ_ZS_INT" },
-       { CAEN_DGTZ_ZS_INT, "CAEN_DGTZ_ZS_ZLE" },
-       { CAEN_DGTZ_ZS_AMP, "CAEN_DGTZ_ZS_AMP" }};
+      { CAEN_DGTZ_ZS_NO,  "CAEN_DGTZ_ZS_INT" },
+      { CAEN_DGTZ_ZS_INT, "CAEN_DGTZ_ZS_ZLE" },
+      { CAEN_DGTZ_ZS_AMP, "CAEN_DGTZ_ZS_AMP" }};
     auto it = table.find (mode);
     if (it == table.end ()) return "CAEN_Unknown";
     return it->second;
@@ -97,8 +97,8 @@ class CAENDecoder
   const static std::string AcquisitionMode(CAEN_DGTZ_AcqMode_t mode)
   {
     static const std::map<CAEN_DGTZ_AcqMode_t, std::string> table{
-       { CAEN_DGTZ_SW_CONTROLLED, "CAEN_DGTZ_SW_CONTROLLED" },
-       { CAEN_DGTZ_S_IN_CONTROLLED, "CAEN_DGTZ_S_IN_CONTROLLED" }};
+      { CAEN_DGTZ_SW_CONTROLLED, "CAEN_DGTZ_SW_CONTROLLED" },
+      { CAEN_DGTZ_S_IN_CONTROLLED, "CAEN_DGTZ_S_IN_CONTROLLED" }};
     auto it = table.find (mode);
     if (it == table.end ()) return "CAEN_Unknown";
     return it->second;
@@ -107,10 +107,10 @@ class CAENDecoder
   const static std::string OutputSignalMode(CAEN_DGTZ_OutputSignalMode_t mode)
   {
     static const std::map<CAEN_DGTZ_OutputSignalMode_t, std::string> table{
-        { CAEN_DGTZ_TRIGGER, "CAEN_DGTZ_TRIGGER" },
-	{ CAEN_DGTZ_FASTTRG_ALL, "CAEN_DGTZ_FASTTRG_ALL" },
-	{ CAEN_DGTZ_FASTTRG_ACCEPTED, "CAEN_DGTZ_FASTTRG_ACCEPTED" },
-        { CAEN_DGTZ_BUSY, "CAEN_DGTZ_BUSY" }};
+      { CAEN_DGTZ_TRIGGER, "CAEN_DGTZ_TRIGGER" },
+      { CAEN_DGTZ_FASTTRG_ALL, "CAEN_DGTZ_FASTTRG_ALL" },
+      { CAEN_DGTZ_FASTTRG_ACCEPTED, "CAEN_DGTZ_FASTTRG_ACCEPTED" },
+      { CAEN_DGTZ_BUSY, "CAEN_DGTZ_BUSY" }};
     auto it = table.find (mode);
     if (it == table.end ()) return "CAEN_Unknown";
     return it->second;
@@ -119,11 +119,11 @@ class CAENDecoder
   const static std::string RunSynchronizationMode(CAEN_DGTZ_RunSyncMode_t mode)
   {
     static const std::map<CAEN_DGTZ_RunSyncMode_t, std::string> table{
-        { CAEN_DGTZ_RUN_SYNC_Disabled, "CAEN_DGTZ_RUN_SYNC_Disabled" },
-	{ CAEN_DGTZ_RUN_SYNC_TrgOutTrgInDaisyChain, "CAEN_DGTZ_RUN_SYNC_TrgOutTrgInDaisyChain" },
-	{ CAEN_DGTZ_RUN_SYNC_TrgOutSinDaisyChain, "CAEN_DGTZ_RUN_SYNC_TrgOutSinDaisyChain" },
-	{ CAEN_DGTZ_RUN_SYNC_SinFanout, "CAEN_DGTZ_RUN_SYNC_SinFanout" },
-       { CAEN_DGTZ_RUN_SYNC_GpioGpioDaisyChain, "CAEN_DGTZ_RUN_SYNC_GpioGpioDaisyChain" }};
+      { CAEN_DGTZ_RUN_SYNC_Disabled, "CAEN_DGTZ_RUN_SYNC_Disabled" },
+      { CAEN_DGTZ_RUN_SYNC_TrgOutTrgInDaisyChain, "CAEN_DGTZ_RUN_SYNC_TrgOutTrgInDaisyChain" },
+      { CAEN_DGTZ_RUN_SYNC_TrgOutSinDaisyChain, "CAEN_DGTZ_RUN_SYNC_TrgOutSinDaisyChain" },
+      { CAEN_DGTZ_RUN_SYNC_SinFanout, "CAEN_DGTZ_RUN_SYNC_SinFanout" },
+      { CAEN_DGTZ_RUN_SYNC_GpioGpioDaisyChain, "CAEN_DGTZ_RUN_SYNC_GpioGpioDaisyChain" }};
     auto it = table.find (mode);
     if (it == table.end ()) return "CAEN_Unknown";
     return it->second;
@@ -164,8 +164,8 @@ class CAENDecoder
   const static std::string IRQMode(CAEN_DGTZ_IRQMode_t mode)
   {
     static const std::map<CAEN_DGTZ_IRQMode_t, std::string> table{
-       { CAEN_DGTZ_IRQ_MODE_ROAK, "CAEN_DGTZ_IRQ_MODE_ROAK" },
-       { CAEN_DGTZ_IRQ_MODE_RORA, "CAEN_DGTZ_IRQ_MODE_RORA" }};
+      { CAEN_DGTZ_IRQ_MODE_ROAK, "CAEN_DGTZ_IRQ_MODE_ROAK" },
+      { CAEN_DGTZ_IRQ_MODE_RORA, "CAEN_DGTZ_IRQ_MODE_RORA" }};
     auto it = table.find (mode);
     if (it == table.end ()) return "CAEN_Unknown";
     return it->second;
@@ -174,8 +174,8 @@ class CAENDecoder
   const static std::string IOLevel(CAEN_DGTZ_IOLevel_t mode)
   {
     static const std::map<CAEN_DGTZ_IOLevel_t, std::string> table{
-       { CAEN_DGTZ_IOLevel_NIM, "CAEN_DGTZ_IOLevel_NIM" },
-       { CAEN_DGTZ_IOLevel_TTL, "CAEN_DGTZ_IOLevel_TTL" }};
+      { CAEN_DGTZ_IOLevel_NIM, "CAEN_DGTZ_IOLevel_NIM" },
+      { CAEN_DGTZ_IOLevel_TTL, "CAEN_DGTZ_IOLevel_TTL" }};
     auto it = table.find (mode);
     if (it == table.end ()) return "CAEN_Unknown";
     return it->second;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -44,9 +44,6 @@ namespace sbndaq
     bool readSingleWindowDataBlock();
     bool readWindowDataBlocks();
 	
-    bool readCombinedWindowFragments(artdaq::FragmentPtrs &);
-    void configureInterrupts();
-
     typedef enum 
     { 
       CONFIG_READ_ADDR     = 0x8000,
@@ -197,6 +194,7 @@ namespace sbndaq
     void GetSWInfo();
     void Configure();
 
+    void ConfigureInterrupts();
     void ConfigureRecordFormat();    
     void ConfigureDataBuffer();
     void ConfigureTrigger();

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -11,8 +11,9 @@
 #include "artdaq/Generators/CommandableFragmentGenerator.hh"
 #include "sbndaq-artdaq-core/Overlays/Common/CAENV1730Fragment.hh"
 
-#include "sbndaq-artdaq/Generators/Common/CAENDigitizer.h"
-#include "sbndaq-artdaq/Generators/Common/CAENDigitizerType.h"
+#include "CAENDigitizer.h"
+#include "CAENDigitizerType.h"
+
 #include "sbndaq-artdaq/Generators/Common/CAENConfiguration.hh"
 #include "sbndaq-artdaq/Generators/Common/PoolBuffer.hh"
 #include "sbndaq-artdaq/Generators/Common/workerThread.hh"

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -9,16 +9,13 @@
 #include "fhiclcpp/fwd.h"
 #include "artdaq-core/Data/Fragment.hh"
 #include "artdaq/Generators/CommandableFragmentGenerator.hh"
-
-#include "CAENDigitizer.h"
-#include "CAENDigitizerType.h"
 #include "sbndaq-artdaq-core/Overlays/Common/CAENV1730Fragment.hh"
 
-#include "CAENConfiguration.hh"
-
-//#include "CircularBuffer.hh"
-#include "PoolBuffer.hh"
-#include "workerThread.hh"
+#include "sbndaq-artdaq/Generators/Common/CAENDigitizer.h"
+#include "sbndaq-artdaq/Generators/Common/CAENDigitizerType.h"
+#include "sbndaq-artdaq/Generators/Common/CAENConfiguration.hh"
+#include "sbndaq-artdaq/Generators/Common/PoolBuffer.hh"
+#include "sbndaq-artdaq/Generators/Common/workerThread.hh"
 
 #include <string>
 #include <unordered_map>
@@ -47,8 +44,6 @@ namespace sbndaq
     bool readWindowDataBlocks();
 	
     bool readCombinedWindowFragments(artdaq::FragmentPtrs &);
-		
-    void loadConfiguration(fhicl::ParameterSet const& ps);
     void configureInterrupts();
 
     typedef enum 
@@ -66,8 +61,6 @@ namespace sbndaq
     //char*                 fBuffer;
     uint32_t              fBufferSize;
     //uint32_t              fCircularBufferSize;
-    CAEN_DGTZ_AcqMode_t   fAcqMode;	// initialized in the constructor
-
 
     typedef enum {
       TEST_PATTERN_S=3
@@ -181,65 +174,7 @@ namespace sbndaq
     {
       V1730_UNPHYSICAL_TEMPERATURE = 200  // degC
     };
-
-    //fhicl parameters
-    int fVerbosity;
-    int fBoardChainNumber;
-    uint8_t  fInterruptEnable;
-    uint32_t fIRQTimeoutMS;
-    uint32_t fGetNextSleep;
-    uint32_t fGetNextFragmentBunchSize;
-    uint32_t fMaxEventsPerTransfer;
-    bool     fSWTrigger;
-    uint32_t fSelfTriggerMode;
-    uint32_t fSelfTriggerMask;
-    uint32_t fModeLVDS;
-    uint32_t fTrigOutDelay;
-    uint32_t fTrigInLevel;
-    bool     fCombineReadoutWindows;
-    bool     fCalibrateOnConfig;
-    bool     fLockTempCalibration;
-    bool     fWriteCalibration;
-    uint32_t fFragmentID;
-    bool fOutputClk;
-    bool fOutputClkPhase;
-
-    bool fUseTimeTagForTimeStamp;
-    bool fUseTimeTagShiftForTimeStamp;
-    uint32_t fTimeOffsetNanoSec;
-
-    // Animesh & Aiwu add fhicl parameters - LVDS logic
-    uint32_t fLVDSLogicValueG1;
-    uint32_t fLVDSLogicValueG2;
-    uint32_t fLVDSLogicValueG3;
-    uint32_t fLVDSLogicValueG4;
-    uint32_t fLVDSLogicValueG5;
-    uint32_t fLVDSLogicValueG6;
-    uint32_t fLVDSLogicValueG7;
-    uint32_t fLVDSLogicValueG8;
-    // Animesh & Aiwu add end
-    // Animesh & Aiwu add fhicl parameters - LVDS output pulse width
-    uint32_t fLVDSOutWidthC1;
-    uint32_t fLVDSOutWidthC2;
-    uint32_t fLVDSOutWidthC3;
-    uint32_t fLVDSOutWidthC4;
-    uint32_t fLVDSOutWidthC5;
-    uint32_t fLVDSOutWidthC6;
-    uint32_t fLVDSOutWidthC7;
-    uint32_t fLVDSOutWidthC8;
-    uint32_t fLVDSOutWidthC9;
-    uint32_t fLVDSOutWidthC10;
-    uint32_t fLVDSOutWidthC11;
-    uint32_t fLVDSOutWidthC12;
-    uint32_t fLVDSOutWidthC13;
-    uint32_t fLVDSOutWidthC14;
-    uint32_t fLVDSOutWidthC15;
-    uint32_t fLVDSOutWidthC16;
-    // Animesh & Aiwu add end
-    //Animesh & Aiwu add - self trigger polarity
-    uint32_t fSelfTrigBit;
-    //Animesh & Aiwu add end
-
+ 
     //internals
     size_t   fNChannels;
     uint32_t fBoardID;
@@ -281,7 +216,6 @@ namespace sbndaq
     bool GetData();
     share::WorkerThreadUPtr GetData_thread_;
     sbndaq::PoolBuffer fPoolBuffer; 		
-    size_t fCircularBufferSize;
     std::unique_ptr<uint16_t[]> fBuffer;
 
     std::unordered_map<uint32_t,artdaq::Fragment::timestamp_t> fTimestampMap;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -118,13 +118,12 @@ void sbndaq::CAENV1730Readout::configureInterrupts()
   CAEN_DGTZ_IRQMode_t mode ,modeOut ;
   CAEN_DGTZ_ErrorCode retcode;
 
-  uint8_t fInterruptEnable = 0;
   interruptLevel  = 1; // Fixed for CONET
   statusId        = 1;
-  eventNumber     = 1;
+  eventNumber     = fCAEN.interruptEventNumber;
   mode            = CAEN_DGTZ_IRQ_MODE_RORA;
 
-  if(fInterruptEnable>0) // Enable interrupts
+  if(fCAEN.interruptEnable>0) // Enable interrupts
   {
     state           = CAEN_DGTZ_ENABLE;
   }

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -33,7 +33,7 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   TLOG_ARB(TCONFIG,TRACE_NAME) << "CAENV1730Readout()" << TLOG_ENDL;
 
   // print-out all configuration parameters
-  TLOG(TINFO) << fCAEN;
+  TLOG(TINFO) << fCAEN.to_string();
   
   last_rcvd_rwcounter=0x0;
   last_sent_seqid=0x1;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -118,9 +118,9 @@ void sbndaq::CAENV1730Readout::ConfigureInterrupts()
   CAEN_DGTZ_IRQMode_t mode, modeOut;
   CAEN_DGTZ_ErrorCode retcode;
 
-  interruptLevel  = 1; // For CONET, level shoudl be kept to 1
+  interruptLevel  = 1; // For CONET, level should be kept to 1
   statusId        = 0; // For CONET, statusId is meaningless
-  mode            = CAEN_DGTZ_IRQ_MODE_RORA; // RORA = Release on Register Access
+  mode            = CAEN_DGTZ_IRQ_MODE_RORA; // For CONET, only RORA = Release on Register Access
   eventNumber     = fCAEN.interruptEventNumber; // Number of recorded events to generate interrupts
 
   if(fCAEN.interruptEnable>0) // Enable interrupts
@@ -132,11 +132,12 @@ void sbndaq::CAENV1730Readout::ConfigureInterrupts()
     state           = CAEN_DGTZ_DISABLE;
   }
 
-  TLOG(TINFO) << "Configuring Interrupts state=" << sbndaq::CAENDecoder::EnaDisMode((CAEN_DGTZ_EnaDis_t)state)
-             << ", mode=" << sbndaq::CAENDecoder::IRQMode((CAEN_DGTZ_IRQMode_t)mode) 
-             << ", interruptLevel=" << uint32_t{interruptLevel} 
-             << ", statusId=" << uint32_t{statusId}
-             << ", eventNumber="<< uint32_t{eventNumber};
+  TLOG(TINFO) << "Configuring Interrupts state=" << uint32_t{state} << " ("
+	      << sbndaq::CAENDecoder::EnaDisMode((CAEN_DGTZ_EnaDis_t)state) << ")"
+              << ", mode=" << uint32_t{mode} << " (" << sbndaq::CAENDecoder::IRQMode((CAEN_DGTZ_IRQMode_t)mode) << ")" 
+              << ", interruptLevel=" << uint32_t{interruptLevel} 
+              << ", statusId=" << uint32_t{statusId}
+              << ", eventNumber="<< uint16_t{eventNumber};
 
   retcode = CAEN_DGTZ_SetInterruptConfig(fHandle,
 					 state,
@@ -154,39 +155,31 @@ void sbndaq::CAENV1730Readout::ConfigureInterrupts()
 					  &modeOut);
   CAENDecoder::checkError(retcode,"GetInterruptConfig",fBoardID);
 
+  // check returned value for inconsistencies
+  // skip statusId, interruptLevel, mode: these are meaningless for optical links
+  // what matters is state and eventNumber
+
   if (state != stateOut)
   {
     TLOG_WARNING("CAENV1730Readout") << "Interrupt State was not setup properly, state write/read="
-                                     << int32_t{state} << "/" << int32_t{stateOut};
+                                     << uint32_t{state} << "/" << uint32_t{stateOut};
   }
   if (eventNumber != eventNumberOut)
   {
-    TLOG_WARNING("CAENV1730Readout") << "Interrupt State was not setup properly, eventNumber write/read="
+    TLOG_WARNING("CAENV1730Readout") << "Interrupt eventNumber was not setup properly, eventNumber write/read="
                                      << uint32_t{eventNumber} << "/" << uint32_t{eventNumberOut};
-  }
-  if (statusId != statusIdOut)
-  {
-    TLOG_WARNING("CAENV1730Readout") << "Interrupt StatusID was not setup properly, statusId write/read="
-                                     << uint32_t{statusId} << "/" << uint32_t{statusIdOut};
-  }
-  if (interruptLevel != interruptLevelOut)
-  {
-    TLOG_WARNING("CAENV1730Readout") << "Interrupt State was not setup properly, interruptLevel write/read="
-                                     << uint32_t{interruptLevel} << "/" << uint32_t{interruptLevelOut};
-  }
-  if (mode != modeOut)
-  {
-    TLOG_WARNING("CAENV1730Readout") << "Interrupt State was not setup properly, mode write/read="
-                                     << int32_t{mode}<< "/" << int32_t{modeOut};
   }
 
   // Checking READOUT_CONTROL register after interrupts config
+  // this is the actual check to make sure they were configured correctly
+  // expected value is 0x18 or 0b11000
   uint32_t addr = READOUT_CONTROL;
   uint32_t value = 0;
   retcode = CAEN_DGTZ_ReadRegister(fHandle,addr,&value);
-  TLOG(TCONFIG) << "CAEN_DGTZ_ReadRegister of READOUT_CONTROL addr=" << std::hex << addr 
-                << ", returned value=" << std::hex << value 
-                << " (" << std::bitset<32>(value) << ")"; 
+  sbndaq::CAENDecoder::checkError(retcode,"READOUT_CONTROL",fBoardID);
+  TLOG(TINFO) << "Checking READOUT_CONTROL register addr=0x" << std::hex << addr 
+              << " returns value=0x" << std::hex << value 
+              << " (0b" << std::bitset<10>(value) << ")"; 
               
 }
 
@@ -224,7 +217,7 @@ void sbndaq::CAENV1730Readout::Configure()
   sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fBoardID);
   
   ConfigureAcquisition();
-  configureInterrupts();
+  ConfigureInterrupts();
 
   if (fCAEN.calibrateOnConfig)     { RunADCCalibration();  }
 

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -3,38 +3,37 @@
 //
 
 #define TRACE_NAME "CAENV1730Readout"
-#include "artdaq/DAQdata/Globals.hh"
 
+#include "artdaq/DAQdata/Globals.hh"
 #include "artdaq/Generators/GeneratorMacros.hh"
+#include "sbndaq-artdaq-core/Overlays/FragmentType.hh"
 #include "sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh"
+#include "sbndaq-artdaq/Generators/Common/CAENDecoder.hh"
 
 #include <iostream>
 #include <sstream>
 #include <time.h>
 #include <unistd.h>
-
 #include <algorithm>
-#include "CAENDecoder.hh"
-#include "sbndaq-artdaq-core/Overlays/FragmentType.hh"
 
 #include "boost/date_time/microsec_time_clock.hpp"
 #include "boost/date_time/posix_time/posix_time.hpp"
 
 using namespace sbndaq;
 
-// constructor of the CAENV1730Readout. It wants the param set 
-// which means the fhicl paramters in CAENV1730Readout.hh
+// Constructor of the CAENV1730Readout.
+// All configuration parameters are loaded and stored in CAENConfiguration.
+// Connection is opened, board is reset and Configure() is called.
 
 sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   CommandableFragmentGenerator(ps),
   fCAEN(ps),
-  fAcqMode(CAEN_DGTZ_SW_CONTROLLED)
 {
-  uint32_t data;
 
   TLOG_ARB(TCONFIG,TRACE_NAME) << "CAENV1730Readout()" << TLOG_ENDL;
-  TLOG(TCONFIG) << fCAEN;
-  loadConfiguration(ps);
+
+  // print-out all configuration parameters
+  TLOG(TINFO) << fCAEN;
   
   last_rcvd_rwcounter=0x0;
   last_sent_seqid=0x1;
@@ -50,7 +49,7 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
 		<< fNChannels;
 
   retcode = CAEN_DGTZ_OpenDigitizer(CAEN_DGTZ_OpticalLink, fCAEN.link, 
-				    fBoardChainNumber, 0, &fHandle);
+				    fCAEN.boardChainNumber, 0, &fHandle);
 
   fOK=true;
 
@@ -61,7 +60,7 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
     fHandle = -1;
     fOK = false;
     TLOG(TLVL_ERROR) << ": Fatal error configuring CAEN board at " << 
-      fCAEN.link << ", " << fBoardChainNumber;
+      fCAEN.link << ", " << fCAEN.boardChainNumber;
     TLOG(TLVL_ERROR) << "Terminating process";
     abort();
   }
@@ -75,6 +74,7 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   sleep(1);
   Configure();
 
+  uint32_t data;
   retcode = CAEN_DGTZ_ReadRegister(fHandle,FP_TRG_OUT_CONTROL,&data);
   TLOG(TLVL_INFO) << "FP_TRG_OUT_CONTROL Reg:0x" << std::hex << FP_TRG_OUT_CONTROL << 
     "=0x" << data;
@@ -90,7 +90,7 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   {
     CAEN_DGTZ_CloseDigitizer(fHandle);
     TLOG(TLVL_ERROR) << ": Fatal error configuring CAEN board at " << 
-      fCAEN.link << ", " << fBoardChainNumber;
+      fCAEN.link << ", " << fCAEN.boardChainNumber;
     TLOG(TLVL_ERROR) << "Terminating process";
     abort();
   }
@@ -118,6 +118,7 @@ void sbndaq::CAENV1730Readout::configureInterrupts()
   CAEN_DGTZ_IRQMode_t mode ,modeOut ;
   CAEN_DGTZ_ErrorCode retcode;
 
+  uint8_t fInterruptEnable = 0;
   interruptLevel  = 1; // Fixed for CONET
   statusId        = 1;
   eventNumber     = 1;
@@ -202,142 +203,6 @@ void sbndaq::CAENV1730Readout::configureInterrupts()
 
 }
 
-void sbndaq::CAENV1730Readout::loadConfiguration(fhicl::ParameterSet const& ps)
-{
-  // initialize the fhicl parameters (see CAENV1730Readout.hh)
-  // the obj ps has a member method that gets the private members
-  // fVerbosity, etc.. are priv memb in CAENV1730Readout.hh
-  //
-  // wes, 16Jan2018: disabling default parameters
-  ///
-  fFragmentID = ps.get<uint32_t>("fragment_id");
-  TLOG(TINFO)<< "fFragmentID=" << fFragmentID;
-
-  fVerbosity = ps.get<int>("Verbosity");
-  TLOG(TINFO) << "Verbosity=" << fVerbosity;
-
-  fBoardChainNumber = ps.get<int>("BoardChainNumber"); //0
-  TLOG(TINFO)<<"BoardChainNumber=" << fBoardChainNumber;
-
-  fInterruptEnable = ps.get<uint8_t>("InterruptEnable",0); 
-  TLOG(TINFO) << "InterruptEnable=" << fInterruptEnable;
-
-  fIRQTimeoutMS = ps.get<uint32_t>("IRQTimeoutMS",500);
-  TLOG(TINFO) << "IRQTimeoutMS=" << fIRQTimeoutMS;
-
-  fSWTrigger = ps.get<bool>("SWTrigger"); //false
-  TLOG(TINFO)<<"SWTrigger=" << fSWTrigger ;
-
-  fModeLVDS = ps.get<uint32_t>("ModeLVDS"); // LVDS output mode
-  TLOG(TINFO)<<"ModeLVDS=" << fModeLVDS;
-
-  fTrigInLevel  = ps.get<uint32_t>("TrigInLevel",0); // TRG_IN on level (1) or edge (0)
-  TLOG(TINFO)<<"TrigInLevel=" << fTrigInLevel;
-
-  fSelfTriggerMode = ps.get<uint32_t>("SelfTriggerMode"); 
-  TLOG(TINFO)<<"SelfTriggerMode=" << fSelfTriggerMode;
-
-  fSelfTriggerMask = ps.get<uint32_t>("SelfTriggerMask"); 
-  TLOG(TINFO)<<"SelfTriggerMask=" << std::hex << fSelfTriggerMask << std::dec;
-
-  fGetNextSleep = ps.get<uint32_t>("GetNextSleep"); //1000000
-  TLOG(TINFO) << "GetNextSleep=" << fGetNextSleep;
-
-  fCircularBufferSize = ps.get<uint32_t>("CircularBufferSize"); //1000000
-  TLOG(TINFO) << "CircularBufferSize=" << fCircularBufferSize;
-
-  // force ADC calibration on config
-  fCalibrateOnConfig = ps.get<bool>("CalibrateOnConfig");
-  TLOG(TINFO) <<"CalibrateOnConfig=" << fCalibrateOnConfig;
-
-  // disable temperature calibration
-  fLockTempCalibration = ps.get<bool>("LockTempCalibration");
-  TLOG(TINFO) <<"LockTempCalibration=" << fLockTempCalibration;
-
-  // read/write ADC calibration parameters
-  fWriteCalibration = ps.get<bool>("AdcCalibration");
-  TLOG(TINFO) <<"WriteCalibration=" << fWriteCalibration;
-
-  fGetNextFragmentBunchSize  = ps.get<uint32_t>("GetNextFragmentBunchSize");
-  TLOG(TINFO) <<"fGetNextFragmentBunchSize=" << fGetNextFragmentBunchSize;
-
-  fMaxEventsPerTransfer = ps.get<uint32_t>("maxEventsPerTransfer",1);
-  TLOG(TINFO) <<"fMaxEventsPerTransfer=" << fMaxEventsPerTransfer;
-
-  //Animesh & Aiwu add - for LVDS logic settings
-  fLVDSLogicValueG1 = ps.get<uint32_t>("LVDSLogicValueG1"); // LVDS logic value for G1
-  TLOG(TINFO)<<"LVDSLogicValueG1=" << fLVDSLogicValueG1;
-  fLVDSLogicValueG2 = ps.get<uint32_t>("LVDSLogicValueG2"); // LVDS logic value for G2
-  TLOG(TINFO)<<"LVDSLogicValueG2=" << fLVDSLogicValueG2;
-  fLVDSLogicValueG3 = ps.get<uint32_t>("LVDSLogicValueG3"); // LVDS logic value for G3
-  TLOG(TINFO)<<"LVDSLogicValueG3=" << fLVDSLogicValueG3;
-  fLVDSLogicValueG4 = ps.get<uint32_t>("LVDSLogicValueG4"); // LVDS logic value for G4
-  TLOG(TINFO)<<"LVDSLogicValueG4=" << fLVDSLogicValueG4;
-  fLVDSLogicValueG5 = ps.get<uint32_t>("LVDSLogicValueG5"); // LVDS logic value for G5
-  TLOG(TINFO)<<"LVDSLogicValueG5=" << fLVDSLogicValueG5;
-  fLVDSLogicValueG6 = ps.get<uint32_t>("LVDSLogicValueG6"); // LVDS logic value for G6
-  TLOG(TINFO)<<"LVDSLogicValueG6=" << fLVDSLogicValueG6;
-  fLVDSLogicValueG7 = ps.get<uint32_t>("LVDSLogicValueG7"); // LVDS logic value for G7
-  TLOG(TINFO)<<"LVDSLogicValueG7=" << fLVDSLogicValueG7;
-  fLVDSLogicValueG8 = ps.get<uint32_t>("LVDSLogicValueG8"); // LVDS logic value for G8
-  TLOG(TINFO)<<"LVDSLogicValueG8=" << fLVDSLogicValueG8;
-  //Animesh & Aiwu add end
-
-  //Animesh & Aiwu add - for LVDS output width
-  fLVDSOutWidthC1 = ps.get<uint32_t>("LVDSOutWidthC1"); // LVDS output width Ch1
-  TLOG(TINFO)<<"LVDSOutWidthC1=" << fLVDSOutWidthC1;
-  fLVDSOutWidthC2 = ps.get<uint32_t>("LVDSOutWidthC2"); // LVDS output width Ch2
-  TLOG(TINFO)<<"LVDSOutWidthC2=" << fLVDSOutWidthC2;
-  fLVDSOutWidthC3 = ps.get<uint32_t>("LVDSOutWidthC3"); // LVDS output width Ch3
-  TLOG(TINFO)<<"LVDSOutWidthC3=" << fLVDSOutWidthC3;
-  fLVDSOutWidthC4 = ps.get<uint32_t>("LVDSOutWidthC4"); // LVDS output width Ch4
-  TLOG(TINFO)<<"LVDSOutWidthC4=" << fLVDSOutWidthC4;
-  fLVDSOutWidthC5 = ps.get<uint32_t>("LVDSOutWidthC5"); // LVDS output width Ch5
-  TLOG(TINFO)<<"LVDSOutWidthC5=" << fLVDSOutWidthC5;
-  fLVDSOutWidthC6 = ps.get<uint32_t>("LVDSOutWidthC6"); // LVDS output width Ch6
-  TLOG(TINFO)<<"LVDSOutWidthC6=" << fLVDSOutWidthC6;
-  fLVDSOutWidthC7 = ps.get<uint32_t>("LVDSOutWidthC7"); // LVDS output width Ch7
-  TLOG(TINFO)<<"LVDSOutWidthC7=" << fLVDSOutWidthC7;
-  fLVDSOutWidthC8 = ps.get<uint32_t>("LVDSOutWidthC8"); // LVDS output width Ch8
-  TLOG(TINFO)<<"LVDSOutWidthC8=" << fLVDSOutWidthC8;
-  fLVDSOutWidthC9 = ps.get<uint32_t>("LVDSOutWidthC9"); // LVDS output width Ch9
-  TLOG(TINFO)<<"LVDSOutWidthC9=" << fLVDSOutWidthC9;
-  fLVDSOutWidthC10 = ps.get<uint32_t>("LVDSOutWidthC10"); // LVDS output width Ch10
-  TLOG(TINFO)<<"LVDSOutWidthC10=" << fLVDSOutWidthC10;
-  fLVDSOutWidthC11 = ps.get<uint32_t>("LVDSOutWidthC11"); // LVDS output width Ch11
-  TLOG(TINFO)<<"LVDSOutWidthC11=" << fLVDSOutWidthC11;
-  fLVDSOutWidthC12 = ps.get<uint32_t>("LVDSOutWidthC12"); // LVDS output width Ch12
-  TLOG(TINFO)<<"LVDSOutWidthC12=" << fLVDSOutWidthC12;
-  fLVDSOutWidthC13 = ps.get<uint32_t>("LVDSOutWidthC13"); // LVDS output width Ch13
-  TLOG(TINFO)<<"LVDSOutWidthC13=" << fLVDSOutWidthC13;
-  fLVDSOutWidthC14 = ps.get<uint32_t>("LVDSOutWidthC14"); // LVDS output width Ch14
-  TLOG(TINFO)<<"LVDSOutWidthC14=" << fLVDSOutWidthC14;
-  fLVDSOutWidthC15 = ps.get<uint32_t>("LVDSOutWidthC15"); // LVDS output width Ch15
-  TLOG(TINFO)<<"LVDSOutWidthC15=" << fLVDSOutWidthC15;
-  fLVDSOutWidthC16 = ps.get<uint32_t>("LVDSOutWidthC16"); // LVDS output width Ch16
-  TLOG(TINFO)<<"LVDSOutWidthC16=" << fLVDSOutWidthC16;
-  //Animesh & Aiwu add end
-
-  //Animesh & Aiwu add - self trigger polarity
-  fSelfTrigBit = ps.get<uint32_t>("SelfTrigBit"); // LVDS output width Ch16
-  TLOG(TINFO)<<"SelfTrigBit=" << fSelfTrigBit;
-
-  fUseTimeTagForTimeStamp = ps.get<bool>("UseTimeTagForTimeStamp",true);
-  TLOG(TINFO) <<"fUseTimeTagForTimeStamp=" << fUseTimeTagForTimeStamp;
-  
-  fUseTimeTagShiftForTimeStamp = ps.get<bool>("UseTimeTagShiftForTimeStamp",false);
-  TLOG(TINFO) <<"fUseTimeTagShiftForTimeStamp=" << fUseTimeTagShiftForTimeStamp;
-
-  fTimeOffsetNanoSec = ps.get<uint32_t>("TimeOffsetNanoSec",0); //0ms by default
-  TLOG(TINFO) <<"fTimeOffsetNanoSec=" << fTimeOffsetNanoSec;
-
-  fOutputClk = ps.get<bool>("OutputClk", 0); // To output Motherboard CLK to TRG-OUT, default 0
-  TLOG(TINFO)<<"OutputClk=" << fOutputClk;
-
-  fOutputClkPhase = ps.get<bool>("OutputClkPhase", 0); // To output Motherboard CLK PHASE to TRG-OUT, default 0
-  TLOG(TINFO)<<"OutputClkPhase=" << fOutputClkPhase;
-}
-
 void sbndaq::CAENV1730Readout::Configure()
 {
   TLOG_ARB(TCONFIG,TRACE_NAME) << "Configure()" << TLOG_ENDL;
@@ -376,10 +241,10 @@ void sbndaq::CAENV1730Readout::Configure()
   ConfigureAcquisition();
   configureInterrupts();
 
-  if (fCalibrateOnConfig)     { RunADCCalibration();  }
+  if (fCAEN.calibrateOnConfig)     { RunADCCalibration();  }
 
   // Does lock bit clear on V1730 reset?   If not, always call this routine
-  if (fLockTempCalibration )  
+  if (fCAEN.lockTempCalibration )  
   { 
     for ( uint32_t ch=0; ch<CAENConfiguration::MAX_CHANNELS; ch++)
     {
@@ -389,7 +254,7 @@ void sbndaq::CAENV1730Readout::Configure()
 
   // Calibration added by Animesh
   uint8_t fCalParams;
-  if (fWriteCalibration)  
+  if (fCAEN.writeCalibration)  
     { 
       
       for ( uint32_t ch=0; ch<CAENConfiguration::MAX_CHANNELS; ch++)
@@ -629,13 +494,13 @@ void sbndaq::CAENV1730Readout::Write_ADC_CalParams_V1730(int handle, int ch, uin
   CAEN_DGTZ_ErrorCode retcod = CAEN_DGTZ_Success;
 
   retcod = CAEN_DGTZ_SetChannelSelfTrigger(fHandle,
-					   (CAEN_DGTZ_TriggerMode_t)fSelfTriggerMode,
-					   fSelfTriggerMask);
+					   (CAEN_DGTZ_TriggerMode_t)fCAEN.selfTrgMode,
+					   fCAEN.selfTrgMask);
   sbndaq::CAENDecoder::checkError(retcod,"SetChannelSelfTriggerMode",fBoardID);
   
 
-  // GVS: the following configuration parameters are for SBND. fModeLVDS must be
-  if(fModeLVDS==0){ 
+  // GVS: the following configuration parameters are for SBND. fCAEN.modeLVDS must be
+  if(fCAEN.modeLVDS==0){ 
   
      uint32_t data, data2, bitpair, readBack, aux, aux2;
   
@@ -643,7 +508,7 @@ void sbndaq::CAENV1730Readout::Write_ADC_CalParams_V1730(int handle, int ch, uin
      for(uint32_t chn=0; chn<fNChannels; ++chn){
          retcod = CAEN_DGTZ_GetChannelSelfTrigger(fHandle, chn, (CAEN_DGTZ_TriggerMode_t *)&readBack);
          sbndaq::CAENDecoder::checkError(retcod,"GetChannelSelfTriggerMode",fBoardID);
-         CheckReadback("ChannelSelfTriggerMode", fBoardID, fSelfTriggerMode, readBack, chn);
+         CheckReadback("ChannelSelfTriggerMode", fBoardID, fCAEN.selfTrgMode, readBack, chn);
 
     
         // GVS: inserted triggerLogic for each PAIR of channels.
@@ -694,7 +559,7 @@ void sbndaq::CAENV1730Readout::Write_ADC_CalParams_V1730(int handle, int ch, uin
 void sbndaq::CAENV1730Readout::ConfigureClkToTrgOut()
 {
   /* Check to output ONLY CLK OR CLK PHASE */
-  if ( fOutputClk && fOutputClkPhase ){
+  if ( fCAEN.outputClk && fCAEN.outputClkPhase ){
     TLOG(TLVL_ERROR) << "Error configuring output clock: Cannot output clock and its phase at the same time." << std::endl;
     abort();
   } 
@@ -708,8 +573,8 @@ void sbndaq::CAENV1730Readout::ConfigureClkToTrgOut()
 
   uint32_t value16 = 0x1; 
   uint32_t value18 = 0x0;
-  if (fOutputClk) value18 = 0x1;
-  if (fOutputClkPhase) value18 = 0x2;
+  if (fCAEN.outputClk) value18 = 0x1;
+  if (fCAEN.outputClkPhase) value18 = 0x2;
   data |= ((value16 & 0x3)<<16) + ((value18 &0x3)<<18);
 
   retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_IO_CONTROL, data);
@@ -729,7 +594,7 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
   sbndaq::CAENDecoder::checkError(retcod,"ReadFPOutputConfig",fBoardID);
 
   // Construct mode mask
-  data = fModeLVDS | (fModeLVDS << 4) | (fModeLVDS << 8) | (fModeLVDS << 12);
+  data = fCAEN.modeLVDS | (fCAEN.modeLVDS << 4) | (fCAEN.modeLVDS << 8) | (fCAEN.modeLVDS << 12);
   TLOG(TINFO) << "ModelLVDS: 0x" << 
       std::hex << data << std::dec;
   retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_CONTROL, data);
@@ -741,7 +606,7 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
   CheckReadback("LVDSOutputConfig", fBoardID, data, readBack);
 
   // If TRIGGER mode, send them out TRG-OUT NIM
-  if ( fModeLVDS == LVDS_TRIGGER )
+  if ( fCAEN.modeLVDS == LVDS_TRIGGER )
   {
     retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_TRG_OUT_CONTROL, &data);
     sbndaq::CAENDecoder::checkError(retcod,"ReadTRGOutputConfig",fBoardID);
@@ -771,7 +636,7 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
     ioMode &= ~(LVDS_IO | DISABLE_TRG_OUT_LEMO);
   }
 
-  if ( fTrigInLevel )
+  if ( fCAEN.trigInLevel )
   {
     ioMode |= TRG_IN_LEVEL;
   }
@@ -791,14 +656,14 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
   CheckReadback("FPOutputConfig", fBoardID, ioMode, readBack);
 
   //Animesh & Aiwu add - to set/read registers for LVDS logic values setting
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G1, fLVDSLogicValueG1);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G2, fLVDSLogicValueG2);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G3, fLVDSLogicValueG3);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G4, fLVDSLogicValueG4);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G5, fLVDSLogicValueG5);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G6, fLVDSLogicValueG6);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G7, fLVDSLogicValueG7);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G8, fLVDSLogicValueG8);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G1, fCAEN.LVDSLogicValue[0]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G2, fCAEN.LVDSLogicValue[1]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G3, fCAEN.LVDSLogicValue[2]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G4, fCAEN.LVDSLogicValue[3]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G5, fCAEN.LVDSLogicValue[4]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G6, fCAEN.LVDSLogicValue[5]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G7, fCAEN.LVDSLogicValue[6]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G8, fCAEN.LVDSLogicValue[7]);
 
   retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G1, &readBack);
   TLOG(TINFO) << "LVDS Logic for G1: 0x" << std::hex << readBack << std::dec;
@@ -819,22 +684,22 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
   //Animesh & Aiwu add ends
 
   //Animesh & Aiwu add - to set/read registers for LVDS output width values setting
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch1, fLVDSOutWidthC1);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch2, fLVDSOutWidthC2);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch3, fLVDSOutWidthC3);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch4, fLVDSOutWidthC4);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch5, fLVDSOutWidthC5);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch6, fLVDSOutWidthC6);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch7, fLVDSOutWidthC7);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch8, fLVDSOutWidthC8);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch9, fLVDSOutWidthC9);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch10, fLVDSOutWidthC10);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch11, fLVDSOutWidthC11);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch12, fLVDSOutWidthC12);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch13, fLVDSOutWidthC13);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch14, fLVDSOutWidthC14);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch15, fLVDSOutWidthC15);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch16, fLVDSOutWidthC16);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch1, fCAEN.LVDSOutWidth[0]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch2, fCAEN.LVDSOutWidth[1]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch3, fCAEN.LVDSOutWidth[2]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch4, fCAEN.LVDSOutWidth[3]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch5, fCAEN.LVDSOutWidth[4]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch6, fCAEN.LVDSOutWidth[5]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch7, fCAEN.LVDSOutWidth[6]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch8, fCAEN.LVDSOutWidth[7]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch9, fCAEN.LVDSOutWidth[8]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch10, fCAEN.LVDSOutWidth[9]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch11, fCAEN.LVDSOutWidth[10]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch12, fCAEN.LVDSOutWidth[11]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch13, fCAEN.LVDSOutWidth[12]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch14, fCAEN.LVDSOutWidth[13]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch15, fCAEN.LVDSOutWidth[14]);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch16, fCAEN.LVDSOutWidth[15]);
   
   retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch1, &readBack);
   TLOG(TINFO) << "LVDS  Logic output width for Ch1: 0x" << std::hex << readBack << std::dec;
@@ -871,7 +736,7 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
   //Animesh & Aiwu add ends
 
   //Animesh & Aiwu add - test self trigger polarity
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, CONFIG_READ_ADDR, fSelfTrigBit);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, CONFIG_READ_ADDR, fCAEN.selfTrgBit);
   retcod = CAEN_DGTZ_ReadRegister(fHandle, CONFIG_READ_ADDR, &readBack);
   TLOG(TINFO) << "Address 0x8000, values inside: 0x" << std::hex << readBack << std::dec;
   //Animesh & Aiwu end
@@ -973,7 +838,7 @@ void sbndaq::CAENV1730Readout::ConfigureDataBuffer()
 
   CAEN_DGTZ_ErrorCode retcode;
 
-  retcode = CAEN_DGTZ_SetMaxNumEventsBLT(fHandle,fMaxEventsPerTransfer);
+  retcode = CAEN_DGTZ_SetMaxNumEventsBLT(fHandle,fCAEN.maxEventsPerTransfer);
   sbndaq::CAENDecoder::checkError(retcode,"SetMaxNumEventsBLT",fBoardID);
 
   //we do this shenanigans so we can get the BufferSize. We then allocate our own...
@@ -988,8 +853,8 @@ void sbndaq::CAENV1730Readout::ConfigureDataBuffer()
   retcode = CAEN_DGTZ_FreeReadoutBuffer(&myBuffer);
   sbndaq::CAENDecoder::checkError(retcode,"FreeReadoutBuffer",fBoardID);
 
-  TLOG_ARB(TSTART,TRACE_NAME) << "Configuring Circular Buffer of size " << fCircularBufferSize << TLOG_ENDL;
-  fPoolBuffer.allocate(fBufferSize,fCircularBufferSize,true);
+  TLOG_ARB(TSTART,TRACE_NAME) << "Configuring Circular Buffer of size " << fCAEN.poolBufferSize << TLOG_ENDL;
+  fPoolBuffer.allocate(fBufferSize,fCAEN.poolBufferSize,true);
   fPoolBuffer.debugInfo();
 
   std::lock_guard<std::mutex> lock(fTimestampMapMutex);
@@ -1027,8 +892,8 @@ void sbndaq::CAENV1730Readout::ConfigureTrigger()
     retcode = CAEN_DGTZ_GetChannelTriggerThreshold(fHandle,ch,&readback);
     CheckReadback("SetChannelTriggerThreshold",fBoardID,fCAEN.triggerThresholds[ch],readback);
 
-    //GVS: the following configuration parameters are for SBND. fModeLVDS must be 0
-      if(fModeLVDS==0){
+    //GVS: the following configuration parameters are for SBND. fCAEN.modeLVDS must be 0
+      if(fCAEN.modeLVDS==0){
       TLOG_ARB(TCONFIG,TRACE_NAME) << "Set Trigger Polarity " << fCAEN.triggerPolarity << " to channel: " << ch << TLOG_ENDL;
       retcode = CAEN_DGTZ_SetTriggerPolarity(fHandle, ch,(CAEN_DGTZ_TriggerPolarity_t)(fCAEN.triggerPolarity));
       sbndaq::CAENDecoder::checkError(retcode,"SetTriggerPolarity",fBoardID);
@@ -1054,10 +919,10 @@ void sbndaq::CAENV1730Readout::ConfigureTrigger()
   }
 
   // for ICARUS
-  if(fModeLVDS!=0){ ConfigureLVDS();  }
+  if(fCAEN.modeLVDS!=0){ ConfigureLVDS();  }
 	
   // for clock synchronization studies
-  if( fOutputClk || fOutputClkPhase ){ ConfigureClkToTrgOut(); } 
+  if( fCAEN.outputClk || fCAEN.outputClkPhase ){ ConfigureClkToTrgOut(); } 
 
   ConfigureSelfTriggerMode();
 
@@ -1190,9 +1055,7 @@ bool sbndaq::CAENV1730Readout::WaitForTrigger()
 void sbndaq::CAENV1730Readout::start()
 {
 
-  if(fVerbosity>0)
-    TLOG_INFO("CAENV1730Readout") << "start()" << TLOG_ENDL;
-  TLOG_ARB(TSTART,TRACE_NAME) << "start()" << TLOG_ENDL;
+  TLOG_INFO("CAENV1730Readout") << "start()" << TLOG_ENDL;
   
   ConfigureDataBuffer();
   total_data_size = 0;
@@ -1212,7 +1075,7 @@ void sbndaq::CAENV1730Readout::start()
 
   // Animesh add ADC registers here
 
-  if (fWriteCalibration)  
+  if (fCAEN.writeCalibration)  
     { 
       for ( uint32_t ch=0; ch<CAENConfiguration::MAX_CHANNELS; ++ch)
         {
@@ -1260,15 +1123,15 @@ void sbndaq::CAENV1730Readout::start()
   //  uint32_t readBack;
   //Animesh & Aiwu add - to set/read registers for LVDS logic values setting
 
-  if(fModeLVDS!=0){
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G1, fLVDSLogicValueG1);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G2, fLVDSLogicValueG2);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G3, fLVDSLogicValueG3);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G4, fLVDSLogicValueG4);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G5, fLVDSLogicValueG5);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G6, fLVDSLogicValueG6);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G7, fLVDSLogicValueG7);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G8, fLVDSLogicValueG8);
+  if(fCAEN.modeLVDS!=0){
+    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G1, fCAEN.LVDSLogicValue[0]);
+    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G2, fCAEN.LVDSLogicValue[1]);
+    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G3, fCAEN.LVDSLogicValue[2]);
+    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G4, fCAEN.LVDSLogicValue[3]);
+    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G5, fCAEN.LVDSLogicValue[4]);
+    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G6, fCAEN.LVDSLogicValue[5]);
+    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G7, fCAEN.LVDSLogicValue[6]);
+    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G8, fCAEN.LVDSLogicValue[7]);
     
     
     retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G1, &readBack);
@@ -1305,9 +1168,7 @@ void sbndaq::CAENV1730Readout::start()
 
 void sbndaq::CAENV1730Readout::stop()
 {
-  if(fVerbosity>0)
-    TLOG_INFO("CAENV1730Readout") << "stop()" << TLOG_ENDL;
-  TLOG_ARB(TSTOP,TRACE_NAME) << "stop()" << TLOG_ENDL;
+  TLOG_INFO("CAENV1730Readout") << "stop()" << TLOG_ENDL;
 
   GetData_thread_->stop();
 
@@ -1422,7 +1283,7 @@ bool sbndaq::CAENV1730Readout::GetData() {
   CAEN_DGTZ_ErrorCode retcod;
 
   if(fSWTrigger) {
-    usleep(fGetNextSleep);
+    usleep(fCAEN.getNextSleep);
     TLOG(TGETDATA) << "Sending SW trigger..." << TLOG_ENDL;
     retcod = CAEN_DGTZ_SendSWtrigger(fHandle);
     TLOG(TGETDATA) << "CAEN_DGTZ_SendSWtrigger returned " << int{retcod};
@@ -1438,17 +1299,17 @@ bool sbndaq::CAENV1730Readout::GetData() {
 bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 
   if(fail_GetNext) {
-    TLOG(TLVL_ERROR) << "(FragID=" << fFragmentID << ")"
+    TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
 		     << "Not calling CAEN_DGTZ_ReadData due a previous critical error...";
     ::usleep(50000);
     return false;
   }
 
-  TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"    
+  TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"    
 		 << "Begin.";
 
   //wait for one event, then interrupt
-  CAEN_DGTZ_ErrorCode retcode = CAEN_DGTZ_IRQWait(fHandle, fIRQTimeoutMS);
+  CAEN_DGTZ_ErrorCode retcode = CAEN_DGTZ_IRQWait(fHandle, fCAEN.IRQTimeoutMS);
 
   //if we have a timeout condition, return
   if (retcode == CAEN_DGTZ_Timeout) {
@@ -1456,7 +1317,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     //end of this poll
     fTimePollEnd = boost::posix_time::microsec_clock::universal_time();
     
-    TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		   << "Exiting after a timeout. Poll time was " 
 		   << (fTimePollEnd - fTimePollBegin).total_milliseconds() << " ms.";
     
@@ -1467,7 +1328,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     return true;
   }
 
-  TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
+  TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		 << "No timeout. TimePollBegin=" 
 		 << fTimePollBegin << " TimePollEnd=" << fTimePollEnd;
 
@@ -1477,11 +1338,11 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
   //gianluca won't let me do a do while
   //we want to do ReadData until there is no more data to read
 
-  TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
+  TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		 << "Start while loop read. " << read_data_size; 
   while(read_data_size!=0){
 
-    TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		   << "Last read data size was " << read_data_size; 
 
     //reset read_data_size to 0, just in case
@@ -1490,13 +1351,13 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     //get a block of data from the PoolBuffer. Hopefully doesn't take very long.
     auto block =  fPoolBuffer.takeFreeBlock();
     if(!block) {
-      TLOG(TLVL_ERROR) << "(FragID=" << fFragmentID << ")"
+      TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
 		       << "PoolBuffer is empty; last received trigger eventCounter=" <<last_rcvd_rwcounter;
-      TLOG(TLVL_ERROR) << "(FragID=" << fFragmentID << ")"
+      TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
 		       << "PoolBuffer status: freeBlockCount=" << fPoolBuffer.freeBlockCount()
-                       << "(FragID=" << fFragmentID << ")"
+                       << "(FragID=" << fCAEN.fragmentId << ")"
 		       <<", activeBlockCount=" << fPoolBuffer.activeBlockCount();
-      TLOG(TLVL_ERROR) << "(FragID=" << fFragmentID << ")"
+      TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
 		       << "Critical error; aborting boardreader process....";				
 
       fail_GetNext = true;
@@ -1504,12 +1365,12 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
       std::this_thread::yield();
       return false;
     }
-    TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		   << "Got a free DataBlock from PoolBuffer";
 
 
     //call ReadData
-    TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		   << "Calling ReadData(fHandle="<<fHandle<< ",bufp=" << (void*)block->begin
                    << ",&block.size="<<(void*)&(block->size) << ")";
 
@@ -1526,7 +1387,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     block->verify_redzone();
     block->data_size= read_data_size;
 
-    TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		   << "This read data size was " << read_data_size; 
 
     //check to make sure no errors on readout.
@@ -1538,14 +1399,14 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     }
 
     fTimePollEnd = boost::posix_time::microsec_clock::universal_time();
-    TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		   << "CAEN_DGTZ_ReadData complete with returned data size " << block->data_size
                    << " retcod=" << int{retcode};
 
 
     const auto header = reinterpret_cast<CAENV1730EventHeader const *>(block->begin);
     
-    TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		   
 		   << ": PMT_EVENT_COUNTER=" << header->eventCounter
 		   << ", PMT_EVENT_SIZE=" << header->eventSize
@@ -1553,7 +1414,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 
     const size_t header_event_size = sizeof(uint32_t)* header->eventSize; 
     if(block->data_size != header_event_size ) {
-      TLOG(TLVL_ERROR) << "(FragID=" << fFragmentID << ")"
+      TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
 		       <<"Wrong event size; returned="
                        << block->data_size << ", header=" << header_event_size
 		       << ". PMT_EVENT_COUNTER=" << header->eventCounter
@@ -1575,7 +1436,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     fTTT=0;
     fTTT_ns = -1;
 
-    if(fUseTimeTagForTimeStamp){
+    if(fCAEN.useTimeTagForTimeStamp){
       fTTT = uint32_t{header->triggerTimeTag}; // 
       fTTT_ns = fTTT*8;
       
@@ -1584,9 +1445,9 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
       fTS = fMeanPollTime - fMeanPollTimeNS + fTTT_ns
 	+ (fTTT_ns - (long)fMeanPollTimeNS < -500000000) * 1000000000
 	- (fTTT_ns - (long)fMeanPollTimeNS >  500000000) * 1000000000
-	- fTimeOffsetNanoSec;
+	- fCAEN.timeOffsetNanoSec;
     }
-    else if(fUseTimeTagShiftForTimeStamp){
+    else if(fCAEN.useTimeTagShiftForTimeStamp){
       fTTT = uint32_t{header->triggerTimeTag}; // 
       // TTT is 8 ticks/ns, record length is 2 ticks/ns. See CAEN V1730 manuals for details
       fTTT_ns = (fTTT*8.0) - (((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0)); //in 1 ns
@@ -1596,10 +1457,10 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
       fTS = fMeanPollTime - fMeanPollTimeNS + fTTT_ns
 	+ (fTTT_ns - (long)fMeanPollTimeNS < -500000000) * 1000000000
 	- (fTTT_ns - (long)fMeanPollTimeNS >  500000000) * 1000000000
-	- fTimeOffsetNanoSec;
+	- fCAEN.timeOffsetNanoSec;
     }
     else{
-      fTS = fTimeDiffPollEnd.total_nanoseconds() - fTimeOffsetNanoSec;;
+      fTS = fTimeDiffPollEnd.total_nanoseconds() - fCAEN.timeOffsetNanoSec;
     }
 
     //put lock in local scope
@@ -1609,17 +1470,17 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     }
 
     //print out timestamping info
-    TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
-		   << "TIMESTAMP " << fFragmentID 
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
+		   << "TIMESTAMP " << fCAEN.fragmentId 
 		   << ": Poll begin/end/mean/ns = " << fTimeDiffPollBegin.total_nanoseconds()
 		   << "/" << fTimeDiffPollEnd.total_nanoseconds() 
 		   << "/" << fMeanPollTime
 		   << "/" << fMeanPollTimeNS;
-    TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
-		   << "TIMESTAMP " << fFragmentID 
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
+		   << "TIMESTAMP " << fCAEN.fragmentId 
 		   << ": TTT/TTT_ns/TS_ns = " << fTTT << "/" << fTTT_ns << "/" << fTS;
-    TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
-		   << "TIMESTAMP " << fFragmentID 
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
+		   << "TIMESTAMP " << fCAEN.fragmentId 
 		   << ": Timestamp for event " << header->eventCounter << " = " << fTS;
 
 
@@ -1627,7 +1488,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     //if the run is long, it can overflow --> do not throw errors in that case
     auto readoutwindow_trigger_counter_gap= uint32_t{header->eventCounter} - last_rcvd_rwcounter;
     if( readoutwindow_trigger_counter_gap > 1u && last_rcvd_rwcounter < max_rwcounter ){
-      TLOG (TLVL_DEBUG) << "(FragID=" << fFragmentID << ")"
+      TLOG (TLVL_DEBUG) << "(FragID=" << fCAEN.fragmentId << ")"
 			<< "Missing triggers; previous trigger eventCounter / gap  = " << last_rcvd_rwcounter << " / "
 			<< readoutwindow_trigger_counter_gap <<", freeBlockCount=" <<fPoolBuffer.freeBlockCount() 
 			<< ", activeBlockCount=" <<fPoolBuffer.activeBlockCount() << ", fullyDrainedCount=" << fPoolBuffer.fullyDrainedCount();
@@ -1637,13 +1498,13 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     //return active block
     fPoolBuffer.returnActiveBlock(block);
     
-    TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		   << "CAEN_DGTZ_ReadData returned DataBlock header.eventCounter=" 
 		   << header->eventCounter << ", header.eventSize=" << header_event_size;
 
   }//end while read_data_size is not zero
 
-  TLOG(TGETDATA) << "(FragID=" << fFragmentID << ")"
+  TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		 << "n_reads=" << n_reads; 
   
   //update the polling time for the next poll
@@ -1668,15 +1529,15 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 
   std::chrono::duration<double> delta = std::chrono::steady_clock::now()-start;
 
-  if (delta.count() >0.005*fGetNextFragmentBunchSize) {
+  if (delta.count() >0.005*fCAEN.getNextFragmentBunchSize) {
      metricMan->sendMetric("Laggy getNext",1,"count",11,artdaq::MetricMode::Accumulate);
      TLOG (TLVL_DEBUG) << "Time spent outside of getNext_() " << delta.count()*1000 << " ms. Last seen fragment sequenceID=" << last_sent_seqid;
    }
 
   if(fPoolBuffer.activeBlockCount() == 0){
     TLOG(TGETNEXT) << "PoolBuffer has no data.  Laast last seen fragment sequenceID=" << last_sent_seqid
-                   << "; Sleep for " << fGetNextSleep << " us and return.";
-    ::usleep(fGetNextSleep);
+                   << "; Sleep for " << fCAEN.getNextSleep << " us and return.";
+    ::usleep(fCAEN.getNextSleep);
     start= std::chrono::steady_clock::now();
     return true;
   }
@@ -1696,7 +1557,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
   while(fPoolBuffer.activeBlockCount()){
 
     start= std::chrono::steady_clock::now();
-    auto fragment_uptr=artdaq::Fragment::FragmentBytes(fragment_datasize_bytes,fEvCounter,fFragmentID,sbndaq::detail::FragmentType::CAENV1730,metadata);
+    auto fragment_uptr=artdaq::Fragment::FragmentBytes(fragment_datasize_bytes,fEvCounter,fCAEN.fragmentId,sbndaq::detail::FragmentType::CAENV1730,metadata);
 
 
     using sbndaq::PoolBuffer;
@@ -1759,7 +1620,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
       TLOG(TLVL_ERROR) << " TIMESTAMP FOR SEQID " << readoutwindow_sequence_id << " EVCOUNTER " << readoutwindow_event_counter << " not found in fTimestampMap!"
 		       << " Will generate new one now...";
 
-      if(fUseTimeTagForTimeStamp){
+      if(fCAEN.useTimeTagForTimeStamp){
 	const auto TTT = uint32_t {header->triggerTimeTag};
 	
 	using namespace boost::gregorian;
@@ -1775,7 +1636,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 	
 	ts_frag = (t_truetriggertime*8); //in 1ns ticks
       }
-      else if(fUseTimeTagShiftForTimeStamp){
+      else if(fCAEN.useTimeTagShiftForTimeStamp){
 	const auto TTT = uint32_t {header->triggerTimeTag};
 	
 	using namespace boost::gregorian;
@@ -1800,7 +1661,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 	ptime time_t_epoch(date(1970,1,1));
 	time_duration diff = t_now - time_t_epoch;
 	
-	ts_frag = diff.total_nanoseconds() - fTimeOffsetNanoSec;;
+	ts_frag = diff.total_nanoseconds() - fCAEN.timeOffsetNanoSec;
       }
     }
 
@@ -1832,7 +1693,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
     // throw errors if gap > 1 or order is not correct
     auto readoutwindow_sequence_id_gap= readoutwindow_sequence_id - last_sent_seqid;
 
-    TLOG(TMAKEFRAG)<<"Created fragment " << fFragmentID << " sequenceID " << readoutwindow_sequence_id << " for event " << readoutwindow_event_counter
+    TLOG(TMAKEFRAG)<<"Created fragment " << fCAEN.fragmentId << " sequenceID " << readoutwindow_sequence_id << " for event " << readoutwindow_event_counter
                    << " triggerTimeTag " << header->triggerTimeTag << " ts=" << ts_frag;
     
     if( readoutwindow_sequence_id_gap > 1u ){

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -109,19 +109,19 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   fTimeEpoch = boost::posix_time::ptime(boost::gregorian::date(1970,1,1));
 }
 
-void sbndaq::CAENV1730Readout::configureInterrupts() 
+void sbndaq::CAENV1730Readout::ConfigureInterrupts() 
 {
-  CAEN_DGTZ_EnaDis_t  state ,stateOut ;
-  uint8_t             interruptLevel ,interruptLevelOut ;
-  uint32_t            statusId ,statusIdOut ;
-  uint16_t            eventNumber   ,eventNumberOut ;
-  CAEN_DGTZ_IRQMode_t mode ,modeOut ;
+  CAEN_DGTZ_EnaDis_t  state, stateOut;
+  uint8_t             interruptLevel, interruptLevelOut;
+  uint32_t            statusId, statusIdOut;
+  uint16_t            eventNumber, eventNumberOut;
+  CAEN_DGTZ_IRQMode_t mode, modeOut;
   CAEN_DGTZ_ErrorCode retcode;
 
-  interruptLevel  = 1; // Fixed for CONET
-  statusId        = 1;
-  eventNumber     = fCAEN.interruptEventNumber;
-  mode            = CAEN_DGTZ_IRQ_MODE_RORA;
+  interruptLevel  = 1; // For CONET, level shoudl be kept to 1
+  statusId        = 0; // For CONET, statusId is meaningless
+  mode            = CAEN_DGTZ_IRQ_MODE_RORA; // RORA = Release on Register Access
+  eventNumber     = fCAEN.interruptEventNumber; // Number of recorded events to generate interrupts
 
   if(fCAEN.interruptEnable>0) // Enable interrupts
   {
@@ -132,10 +132,11 @@ void sbndaq::CAENV1730Readout::configureInterrupts()
     state           = CAEN_DGTZ_DISABLE;
   }
 
-  TLOG(TLVL_INFO)  << "Configuring Interrupts state=" << uint32_t{ stateOut} << 
-    ", interruptLevel=" << uint32_t{interruptLevelOut} 
-    << ", statusId=" << uint32_t{statusIdOut} << ", eventNumber=" <<
-    uint32_t{eventNumberOut}<<", mode="<< int32_t{modeOut};
+  TLOG(TINFO) << "Configuring Interrupts state=" << sbndaq::CAENDecoder::EnaDisMode((CAEN_DGTZ_EnaDis_t)state)
+             << ", mode=" << sbndaq::CAENDecoder::IRQMode((CAEN_DGTZ_IRQMode_t)mode) 
+             << ", interruptLevel=" << uint32_t{interruptLevel} 
+             << ", statusId=" << uint32_t{statusId}
+             << ", eventNumber="<< uint32_t{eventNumber};
 
   retcode = CAEN_DGTZ_SetInterruptConfig(fHandle,
 					 state,
@@ -145,7 +146,7 @@ void sbndaq::CAENV1730Readout::configureInterrupts()
 					 mode);
   CAENDecoder::checkError(retcode,"SetInterruptConfig",fBoardID);
 
-  retcode = CAEN_DGTZ_GetInterruptConfig (fHandle, 
+  retcode = CAEN_DGTZ_GetInterruptConfig(fHandle, 
 					  &stateOut, 
 					  &interruptLevelOut, 
 					  &statusIdOut, 
@@ -156,50 +157,37 @@ void sbndaq::CAENV1730Readout::configureInterrupts()
   if (state != stateOut)
   {
     TLOG_WARNING("CAENV1730Readout") << "Interrupt State was not setup properly, state write/read="
-                                     << int32_t{ state} <<"/"<< int32_t{ stateOut};
+                                     << int32_t{state} << "/" << int32_t{stateOut};
   }
   if (eventNumber != eventNumberOut)
   {
-    TLOG_WARNING("CAENV1730Readout")
-      << "Interrupt State was not setup properly, eventNumber write/read="
-      << uint32_t {eventNumber} <<"/"<< uint32_t {eventNumberOut};
+    TLOG_WARNING("CAENV1730Readout") << "Interrupt State was not setup properly, eventNumber write/read="
+                                     << uint32_t{eventNumber} << "/" << uint32_t{eventNumberOut};
   }
   if (statusId != statusIdOut)
   {
-    TLOG_WARNING("CAENV1730Readout")
-      << "Interrupt StatusID was not setup properly, eventNumber write/read="
-      << uint32_t {statusId} <<"/"<< uint32_t {statusIdOut};
+    TLOG_WARNING("CAENV1730Readout") << "Interrupt StatusID was not setup properly, statusId write/read="
+                                     << uint32_t{statusId} << "/" << uint32_t{statusIdOut};
   }
-  // Mode and InterruptLevel are only defined on VME, not CONET
-  // if (interruptLevel != interruptLevelOut)
-  // {
-  //   TLOG_WARNING("CAENV1730Readout") << "Interrupt State was not setup properly, interruptLevel write/read="
-  //                                    << uint32_t{interruptLevel}<< "/" << uint32_t{interruptLevelOut};
-  // }
-  // if (mode != modeOut)
-  // {
-  //   TLOG_WARNING("CAENV1730Readout")
-  //     << "Interrupt State was not setup properly, mode write/read="
-  //     << int32_t { mode }<< "/"<<int32_t { modeOut };
-  // }
+  if (interruptLevel != interruptLevelOut)
+  {
+    TLOG_WARNING("CAENV1730Readout") << "Interrupt State was not setup properly, interruptLevel write/read="
+                                     << uint32_t{interruptLevel} << "/" << uint32_t{interruptLevelOut};
+  }
+  if (mode != modeOut)
+  {
+    TLOG_WARNING("CAENV1730Readout") << "Interrupt State was not setup properly, mode write/read="
+                                     << int32_t{mode}<< "/" << int32_t{modeOut};
+  }
 
-
-  uint32_t bitmask = (uint32_t)(0x1FF);
-  uint32_t data = (uint32_t)(0x9); //RORA,irq link enabled,vme baseaddress relocation disabled,VME Bus error enabled,level 1
+  // Checking READOUT_CONTROL register after interrupts config
   uint32_t addr = READOUT_CONTROL;
   uint32_t value = 0;
   retcode = CAEN_DGTZ_ReadRegister(fHandle,addr,&value);
-  TLOG(TCONFIG) << "CAEN_DGTZ_ReadRegister prior to overwrite of addr=" << std::hex << addr << ", returned value=" << std::bitset<32>(value) ; 
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "Setting I/O control register 0x811C " << TLOG_ENDL;
-  retcode = sbndaq::CAENV1730Readout::WriteRegisterBitmask(fHandle,addr,data,bitmask);
-  sbndaq::CAENDecoder::checkError(retcode,"SetIOControl",fBoardID);
-  retcode = CAEN_DGTZ_ReadRegister(fHandle,addr,&value);
-
-  TLOG(TCONFIG) << "CAEN_DGTZ_ReadRegister addr=" << std::hex << addr << 
-    " and bitmask=" << std::bitset<32>(bitmask)
-                << ", returned value=" << std::bitset<32>(value); 
-
+  TLOG(TCONFIG) << "CAEN_DGTZ_ReadRegister of READOUT_CONTROL addr=" << std::hex << addr 
+                << ", returned value=" << std::hex << value 
+                << " (" << std::bitset<32>(value) << ")"; 
+              
 }
 
 void sbndaq::CAENV1730Readout::Configure()
@@ -1305,8 +1293,15 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
   TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"    
 		 << "Begin.";
 
+  // (re)-arm interrupt before waiting for one
+  CAEN_DGTZ_ErrorCode retcode = CAEN_DGTZ_RearmInterrupt(fHandle);
+  if(retcode < 0){
+    TLOG(TLVL_WARNING) << "(FragID=" << fCAEN.fragmentId << ")"
+                       << " RearmInterrupt() failed: " << retcode;
+  } 
+
   //wait for one event, then interrupt
-  CAEN_DGTZ_ErrorCode retcode = CAEN_DGTZ_IRQWait(fHandle, fCAEN.IRQTimeoutMS);
+  retcode = CAEN_DGTZ_IRQWait(fHandle, fCAEN.IRQTimeoutMS);
 
   //if we have a timeout condition, return
   if (retcode == CAEN_DGTZ_Timeout) {

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -27,7 +27,7 @@ using namespace sbndaq;
 
 sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   CommandableFragmentGenerator(ps),
-  fCAEN(ps),
+  fCAEN(ps)
 {
 
   TLOG_ARB(TCONFIG,TRACE_NAME) << "CAENV1730Readout()" << TLOG_ENDL;
@@ -232,12 +232,10 @@ void sbndaq::CAENV1730Readout::Configure()
   ConfigureRecordFormat();
   ConfigureTrigger();
 
-  if(fAcqMode==CAEN_DGTZ_SW_CONTROLLED){
-    TLOG_ARB(TCONFIG,TRACE_NAME) << "Stop Acquisition" << TLOG_ENDL;
-    retcode = CAEN_DGTZ_SWStopAcquisition(fHandle);
-    sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fBoardID);
-  }
-
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "Stop Acquisition" << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SWStopAcquisition(fHandle);
+  sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fBoardID);
+  
   ConfigureAcquisition();
   configureInterrupts();
 
@@ -1282,7 +1280,7 @@ bool sbndaq::CAENV1730Readout::GetData() {
 
   CAEN_DGTZ_ErrorCode retcod;
 
-  if(fSWTrigger) {
+  if(fCAEN.swTrigger) {
     usleep(fCAEN.getNextSleep);
     TLOG(TGETDATA) << "Sending SW trigger..." << TLOG_ENDL;
     retcod = CAEN_DGTZ_SendSWtrigger(fHandle);


### PR DESCRIPTION
### Description

This PR addresses the way interrupts are being configured in the CAENV1730 boardreader. These changes are informed by recent communication via CAEN (ticket TT160334) and the need for compatibility with the new A5818 cards.
**This code is based off #185 and should be merged on top or after it.**

Historically, we always had troubles with configuring interrupts.
When the code was initially developed, the `CAEN_DGTZ_SetInterruptConfig()` function was bugged. The solution that was found was to skip it by setting`InterruptEnable=0` in `pmt_standard.fcl` and performing the actual configuration by manually writing into the READOUT_CONTROL register `0xEF00` the value `0x9`.  Eventually, the function was fixed in `CAENDigitizer` version `2.17.1` but our code was not changed. The situation was also complicated by the fact that several interrupt options are available only for VME communication and are instead  meaningless for optical link connections (`statusId`, `interruptLevel`, `mode`). This has been the reason for the frequent interrupt-related warnings seen during the board configuration step.

Recently, while testing the V1730 readout with A5818, we noticed that interrupts were not being generated by the board and `CAEN_DGTZ_IRQWait()` was timing out constantly. CAEN confirmed the problem and suggested to add a call to `CAEN_DGTZ_RearmInterrupt()` right before the GetData() loop. 

Initially, the function returned error code -27 (`CAEN_DGTZ_InterruptNotConfigured`). While investigating, I discovered this was because we were manually writing the value `0x9` (`0b01001`) to register `0xEF00` to configure the interrupts. Once I switched to using `CAEN_DGTZ_SetInterruptConfig()` to enable interrupts, everything worked as expected. However, `CAEN_DGTZ_SetInterruptConfig()` writes `0x18` (`0b11000`) to  `0xEF00`. Discussing with CAEN, the bits that are set differently are actually related to VME communication, which does not apply in our case. Therefore, there is effectively no difference between `0x9` and `0x18` for our specific setup. Moreover, they recommend using `CAEN_DGTZ_SetInterruptConfig()` for simplicity and to make it easier for them to track our configuration settings.

Regarding `CAEN_DGTZ_RearmInterrupt()`, CAEN informed us that their developers decided to adopt this approach as the standard implementation for interrupt handling, as it aligns with the correct behavior defined by the VME standard. They concluded that this behavior is consistent with the specification and should not be considered an issue. Therefore, the interrupt still needs to be manually rearmed each time.

As a result, I updated the code in the following way:

- I removed the manual writing of value `0x9` to register `0xEF00`, so that interrupts are enabled only through the `CAEN_DGTZ_SetInterruptConfig()` function by setting `InterruptEnable=1` in `pmt_standard.fcl`;
- I removed the warnings that were triggered by checking options that are meaningless for optical link interrupts, such as the `statusId`, `interruptLevel` and `mode` (only RORA="Release on Register Access" is available);
- I added `CAEN_DGTZ_RearmInterrupt()` right before `CAEN_DGTZ_IRQWait()` so that the interrupts are rearmed every time we start looking for new data.

During my tests, I didn't find any issues or differences with the new interrupt setup. The addition of the rearm function also doesn't seem to affect in a negative way the boards still using the A3818 cards, so I feel confident in proposing this as a change for all boards.

### Testing details
- ICARUS: Tested with runs 13348-13352 (ECL#[291668](https://dbweb9.fnal.gov:8443/ECL/sbnfd/E/show?e=291668))
- SBND: Needs testing