### PR TITLE
CAENV1730: final code clean-up

### DIFF
--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -164,7 +164,7 @@ sbndaq::CAENConfiguration::CAENConfiguration(fhicl::ParameterSet const & ps)
 
   // LVDS output mode flag
   // difference between ICARUS and SBND
-  // ICARUS=1, SBND=0
+  // ICARUS=1 (LVDS_TRIGGER), SBND=0
   modeLVDS = ps.get<uint32_t>("ModeLVDS"); 
 
   // Sets the TRIG-IN control

--- a/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENConfiguration.cc
@@ -312,7 +312,7 @@ std::ostream& operator<<(std::ostream& os, const sbndaq::CAENConfiguration& e)
   os << "SelfTrgMask         0x" << std::hex << e.selfTrgMask << std::dec << " " << e.selfTrgMask << std::endl;
   os << "SWTrigger             " << e.swTrigger << std::endl;
   os << "AllowTriggerOverlap   " << e.allowTriggerOverlap << std::endl;
-  os << "selfTrgBit          0x" << std::hex << e.selfTrgBit << std::dec << " " << e.selfTrgBit << std::endl;
+  os << "selfTrgBit            " << " " << e.selfTrgBit << std::endl;
   os << "TriggerPolarity       " << e.triggerPolarity << " " 
                                    << sbndaq::CAENDecoder::TriggerPolarity((CAEN_DGTZ_TriggerPolarity_t)e.triggerPolarity) 
                                    << std::endl;

--- a/sbndaq-artdaq/Generators/Common/CAENDecoder.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENDecoder.cc
@@ -13,56 +13,36 @@
 #include <sstream>
 #include <ctime>
 
-// Following function is not thread safe
 
-const char * sbndaq::CAENDecoder::zeit(char delimiter)
-{
-  time_t t;
-  struct tm * hora;
-  static char heure[20];
-  char format[20];
-
-  sprintf(format,"%%Y.%%m.%%d-%%H%c%%M%c%%S", delimiter, delimiter);
-  std::time(&t);
-  hora = std::localtime(&t);
-  std::strftime(heure,sizeof(heure),format,hora);
-  return((char *)heure);
-}
-
-
-void sbndaq::CAENDecoder::commError(CAENComm_ErrorCode retcod,
-			    const std::string label)
+void sbndaq::CAENDecoder::commError(CAENComm_ErrorCode retcod, const std::string label, const int fragID)
 {
   if ( retcod != CAENComm_Success)
   {
     char buffer[256];
     CAENComm_DecodeError(retcod,buffer);
-    TLOG_ERROR("CAENDecoder") << zeit() << " " << label 
+    TLOG_ERROR("CAENDecoder") << "(fragID=" << fragID << ") " << label 
 			      << " error: " << buffer << TLOG_ENDL;
   }
 }
 
-void sbndaq::CAENDecoder::vmeError(CVErrorCodes      retcod,
-			   const std::string label)
+void sbndaq::CAENDecoder::vmeError(CVErrorCodes retcod, const std::string label, const int fragID)
 {
   if ( retcod != cvSuccess )
   {
     char buffer[256];
     CAENComm_DecodeError(retcod,buffer);
-    TLOG_ERROR("CAENDecoder") << zeit() << " " << label 
+    TLOG_ERROR("CAENDecoder") << "(fragID=" << fragID << ") " << label 
 			      << " error: " << buffer << TLOG_ENDL;
   }
 }
 
-void sbndaq::CAENDecoder::checkError(CAEN_DGTZ_ErrorCode err, 
-			     const std::string label,
-			     int boardId)
+void sbndaq::CAENDecoder::checkError(CAEN_DGTZ_ErrorCode err, const std::string label, const int fragID)
 {
   if ( err != CAEN_DGTZ_Success )
   {
     std::stringstream text;
-    sbndaq::CAENException e(err, label,boardId);
-    TLOG_ERROR("CAENDecoder") << zeit() << " " << e.what() << " ["<< err << "]" << TLOG_ENDL;
+    sbndaq::CAENException e(err, label, fragID);
+    TLOG_ERROR("CAENDecoder") << e.what() << " [" << err << "]" << TLOG_ENDL;
     throw(e);
   }
 }

--- a/sbndaq-artdaq/Generators/Common/CAENDecoder.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENDecoder.hh
@@ -21,14 +21,12 @@ class CAENDecoder
 {
  public:
 
-  const static char * zeit(char delimiter = ':');
-  static void commError(CAENComm_ErrorCode retcod, 
-			      const std::string label);
-  static void vmeError(CVErrorCodes retcod, 
-		       const std::string label);
-  static void checkError(CAEN_DGTZ_ErrorCode err, 
-			       const std::string label,
-			       int boardId=-1);
+  // convert CAENComm error code to readable format
+  static void commError(CAENComm_ErrorCode retcod, const std::string label, const int fragID=-1);
+  // convert CAENVME error code to readable format
+  static void vmeError(CVErrorCodes retcod, const std::string label, const int fragID=-1);
+  // convert CAENDGTZ error code to readbale format
+  static void checkError(CAEN_DGTZ_ErrorCode err, const std::string label, const int fragId=-1);
 
   const static std::string CAENError(CAEN_DGTZ_ErrorCode err)
   {

--- a/sbndaq-artdaq/Generators/Common/CAENException.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENException.cc
@@ -8,10 +8,10 @@
 
 sbndaq::CAENException::CAENException(CAEN_DGTZ_ErrorCode error_, 
 				      std::string label_,
-				      int boardId_):
+				      int fragID_):
   error(error_),
   label(label_),
-  boardId(boardId_)
+  fragID(fragID_)
 {
 }
 
@@ -23,12 +23,14 @@ std::string sbndaq::CAENException::what()
 }
 
 void sbndaq::CAENException::print(std::ostream & os) 
-{ os << *this;}
+{ 
+  os << *this;
+}
 
 std::ostream& operator<<(std::ostream& s, const sbndaq::CAENException& e)
 {
+  if ( e.fragID >= 0 ) { s << "(fragID=" << e.fragID << ") ";}
   s << "ERROR: " << e.label << " " << sbndaq::CAENDecoder::CAENError(e.error);
-  if ( e.boardId >= 0 ) { s << " BoardId " << e.boardId ;}
   s << std::endl;
   return(s);
 }

--- a/sbndaq-artdaq/Generators/Common/CAENException.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENException.hh
@@ -16,13 +16,12 @@ class CAENException: public std::exception
 
   CAEN_DGTZ_ErrorCode error; 
   std::string label;
-  int boardId;
+  int fragID;
 
-  CAENException(CAEN_DGTZ_ErrorCode error_, 
-		std::string label_,
-		int boardId_);
+  CAENException(CAEN_DGTZ_ErrorCode error_, std::string label_, int fragID_);
 
   void print(std::ostream & os = std::cout);
+  
   using std::exception::what;
   std::string what();// override;
 };

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -71,17 +71,12 @@ namespace sbndaq
 
     // run ADC self-calibration 
     void RunADCCalibration();
-    // read channel ADC calibration parameters
-    void Read_ADC_CalParams_V1730(int handle, int ch, uint8_t *CalParams);
-    // write channel ADC calibration parameters
-    void Write_ADC_CalParams_V1730(int handle, int ch, uint8_t *CalParams);
     // lock ADC temperature self-calibration
     void SetLockTempCalibration(bool onOff, uint32_t ch);
 
     // support function for register read/write operations
     CAEN_DGTZ_ErrorCode WriteSPIRegister(int handle, uint32_t ch, uint32_t address, uint8_t value);
     CAEN_DGTZ_ErrorCode ReadSPIRegister(int handle, uint32_t ch, uint32_t address, uint8_t *value);
-    CAEN_DGTZ_ErrorCode	WriteRegisterBitmask(int32_t handle, uint32_t address, uint32_t data, uint32_t bitmask); 
 
     // check readback value from register
     void CheckReadback(std::string,int,uint32_t,uint32_t,int channelID=-1);
@@ -90,7 +85,6 @@ namespace sbndaq
     CAENConfiguration     fCAEN;	    // initialized in the constructor
     CAEN_DGTZ_BoardInfo_t fBoardInfo; // board S/N, firmware relase
     size_t   fNChannels; // number of channels
-    uint32_t fBoardID;   // board ID
     int fHandle;         // access handle
     bool fail_GetNext; // tracks GetNext_ failure
 
@@ -132,100 +126,42 @@ namespace sbndaq
     // hardware status check
     uint32_t ch_temps[CAENConfiguration::MAX_CHANNELS];
     uint32_t ch_status[CAENConfiguration::MAX_CHANNELS];
-
-    typedef enum {
-      TEST_PATTERN_S=3
-    } TEST_PATTERN_t;
     
     typedef enum {
-      BOARD_CONFIG_READ  = 0x8000, // board configuration register
-      BOARD_CONFIG_SET   = 0x8004,
-      BOARD_CONFIG_CLEAR = 0x8008,
-
+      BOARD_CONFIG_READ  = 0x8000, // board configuration read register
+      BOARD_CONFIG_SET   = 0x8004, // board configuration set register
+      BOARD_CONFIG_CLEAR = 0x8008, // board configuration clear register
       FP_TRG_OUT_CONTROL = 0x8110, // front panel TRG-OUT control
       FP_IO_CONTROL      = 0x811C, // front panel I/O control
       FP_LVDS_CONTROL    = 0x81A0, // front panel LVDS control
       ACQ_CONTROL        = 0x8100, // acquisition control register
       READOUT_CONTROL    = 0xEF00, // readout control
-
       GLB_TRG_MASK       = 0x810C, // global trigger mask
       CH_ENABLE_MASK     = 0x8120, // channel enable mask
-
-      DYNAMIC_RANGE      = 0x8028,
-      TRG_OUT_WIDTH      = 0x8070,
-      TRG_OUT_WIDTH_CH   = 0x1070,
-      SLF_TRG_LG_CH      = 0x1084,
-      SLF_TRG_LG_GLB     = 0x8084,
-    
-      // Animesh & Aiwu add registers for the LVDS logic
-      FP_LVDS_Logic_G1   = 0x1084,
-      FP_LVDS_Logic_G2   = 0x1284,
-      FP_LVDS_Logic_G3   = 0x1484,
-      FP_LVDS_Logic_G4   = 0x1684,
-      FP_LVDS_Logic_G5   = 0x1884,
-      FP_LVDS_Logic_G6   = 0x1A84,
-      FP_LVDS_Logic_G7   = 0x1C84,
-      FP_LVDS_Logic_G8   = 0x1E84,
-      // Animesh & Aiwu add end
-      // Animesh & Aiwu add registers for the LVDS output width
-      FP_LVDS_OutWidth_Ch1   = 0x1070,
-      FP_LVDS_OutWidth_Ch2   = 0x1170,
-      FP_LVDS_OutWidth_Ch3   = 0x1270,
-      FP_LVDS_OutWidth_Ch4   = 0x1370,
-      FP_LVDS_OutWidth_Ch5   = 0x1470,
-      FP_LVDS_OutWidth_Ch6   = 0x1570,
-      FP_LVDS_OutWidth_Ch7   = 0x1670,
-      FP_LVDS_OutWidth_Ch8   = 0x1770,
-      FP_LVDS_OutWidth_Ch9   = 0x1870,
-      FP_LVDS_OutWidth_Ch10   = 0x1970,
-      FP_LVDS_OutWidth_Ch11   = 0x1A70,
-      FP_LVDS_OutWidth_Ch12   = 0x1B70,
-      FP_LVDS_OutWidth_Ch13   = 0x1C70,
-      FP_LVDS_OutWidth_Ch14   = 0x1D70,
-      FP_LVDS_OutWidth_Ch15   = 0x1E70,
-      FP_LVDS_OutWidth_Ch16   = 0x1F70,
-      // Animesh & Aiwu add - check DPP algorithm feature
-      DPP_Alo_Feature_Ch1 = 0x1080,
-      DPP_Alo_Feature_Ch2 = 0x1180,
-      Baseline_Ch1 = 0x1098,
-      Baseline_Ch2 = 0x1198,
-      Baseline_Ch3 = 0x1298,
-      Baseline_Ch4 = 0x1398,
-      Baseline_Ch5 = 0x1498,
-      Baseline_Ch6 = 0x1598,
-      Baseline_Ch7 = 0x1698,
-      Baseline_Ch8 = 0x1798,
-      Baseline_Ch9 = 0x1898,
-      Baseline_Ch10 = 0x1998,
-      Baseline_Ch11 = 0x1A98,
-      Baseline_Ch12 = 0x1B98,
-      Baseline_Ch13 = 0x1C98,
-      Baseline_Ch14 = 0x1D98,
-      Baseline_Ch15 = 0x1E98,
-      Baseline_Ch16 = 0x1F98,
-      // want to send a software trigger
-      // SWTriggerValue = 0x8108
-      // Animesh & Aiwu add end
+      DYNAMIC_RANGE      = 0x8028, // dynamic range control 
+      TRG_OUT_WIDTH_CH   = 0x1070, // channel n LVDS pulse width
+                                   // 0x1n70 for n=0,..,F
+      SLF_TRG_LG_CH      = 0x1084, // couple n self-trigger logic
+                                   // 0x1n84 for n=0,2,4,6,8,A,C,E
+      ANALOG_MON_MODE    = 0x8144, // analog monitor output mode
     } ADDRESS_t;
 
     typedef enum 
     {
-      TRIGGER_OVERLAP_MASK = 0x0002
-      ENABLE_LVDS_TRIGGER  = 0x20000000,
-      ENABLE_EXT_TRIGGER   = 0x40000000,
-      ENABLE_NEW_LVDS      = 0x100,
-      ENABLE_TRG_OUT       = 0xFF,
-      TRG_IN_LEVEL         = 0x400,
-      TRIGGER_LOGIC        = 0x1F00,
-      DISABLE_TRG_OUT_LEMO = 0x2,
-      LVDS_IO              = 0x3C,
-      LVDS_BUSY            = 0,
-      LVDS_TRIGGER         = 1,
-      LVDS_nBUSY_nVETO     = 2,
-      LVDS_LEGACY          = 3
+      TRIGGER_OVERLAP_MASK = 0x0002, // bitmask for trigger overlap
+      SLF_TRG_BIT_MASK     = 0x40,   // bitmask for self-trigger polarity
+      ENABLE_NEW_LVDS      = 0x100,  // bitmask to enable "new" LVDS features
+      TRG_IN_LEVEL         = 0x400,  // bitmask to configure TRG-IN as level/edge
+      DISABLE_TRG_OUT_LEMO = 0x2,    // bitmask to disable TRG-OUT LEMO output
+      LVDS_IO              = 0x3C,   // bitmask for LVDS I/O pins
+      LVDS_BUSY            = 0, // LVDS output is BUSY status
+      LVDS_TRIGGER         = 1, // LVDS output is TRIGGER (ICARUS mode)
+      LVDS_nBUSY_nVETO     = 2, // LVDS output is nBUSY/nVETO
+      LVDS_LEGACY          = 3  // legacy LVDS behavior
     } IO_MASK_t;
 
-    enum {
+    enum 
+    {
       TERROR    = TLVL_ERROR,
       TWARNING  = TLVL_WARNING,
       TINFO     = TLVL_INFO,
@@ -244,6 +180,10 @@ namespace sbndaq
     {
       V1730_UNPHYSICAL_TEMPERATURE = 200  // degC
     };
+
+    typedef enum {
+      TEST_PATTERN_S=3
+    } TEST_PATTERN_t;
 
   };
 }

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -29,21 +29,112 @@ namespace sbndaq
 
   public:
 
+    // constructor: initialize and configure
     explicit CAENV1730Readout(fhicl::ParameterSet const& ps);
+    // destructor: freeing the buffer
     virtual ~CAENV1730Readout();
 
+    // getNext_ builds fragments from buffer
     bool getNext_(artdaq::FragmentPtrs & output) override;
+    // poll hardware status 
     bool checkHWStatus_() override;
+    // called at START transition
     void start() override;
+    // called at STOP transition
     void stop() override;
     void stopNoMutex() override { stop(); }
-    //void init();
 
   private:
+
+    // support function for getNext_ loop
     bool readSingleWindowFragments(artdaq::FragmentPtrs &);
-    bool readSingleWindowDataBlock();
+    // waits for interrupt, puts data into buffer
+    bool GetData();
+    // support function for GetData loop
     bool readWindowDataBlocks();
+
+    // support function for configuration
+    // called from constructor
+    void Configure();
+    void ConfigureInterrupts();
+    void ConfigureRecordFormat();    
+    void ConfigureDataBuffer();
+    void ConfigureTrigger();
+    void ConfigureReadout();
+    void ConfigureAcquisition();
+    void ConfigureLVDS();
+    void ConfigureSelfTriggerMode();
+    void ConfigureClkToTrgOut();
 	
+    // print board + CAEN software info
+    void GetSWInfo();
+
+    // run ADC self-calibration 
+    void RunADCCalibration();
+    // read channel ADC calibration parameters
+    void Read_ADC_CalParams_V1730(int handle, int ch, uint8_t *CalParams);
+    // write channel ADC calibration parameters
+    void Write_ADC_CalParams_V1730(int handle, int ch, uint8_t *CalParams);
+    // lock ADC temperature self-calibration
+    void SetLockTempCalibration(bool onOff, uint32_t ch);
+
+    // support function for register read/write operations
+    CAEN_DGTZ_ErrorCode WriteSPIRegister(int handle, uint32_t ch, uint32_t address, uint8_t value);
+    CAEN_DGTZ_ErrorCode ReadSPIRegister(int handle, uint32_t ch, uint32_t address, uint8_t *value);
+    CAEN_DGTZ_ErrorCode	WriteRegisterBitmask(int32_t handle, uint32_t address, uint32_t data, uint32_t bitmask); 
+
+    // check readback value from register
+    void CheckReadback(std::string,int,uint32_t,uint32_t,int channelID=-1);
+
+    //CAEN pieces
+    CAENConfiguration     fCAEN;	    // initialized in the constructor
+    CAEN_DGTZ_BoardInfo_t fBoardInfo; // board S/N, firmware relase
+    size_t   fNChannels; // number of channels
+    uint32_t fBoardID;   // board ID
+    int fHandle;         // access handle
+    bool fOK; // tracks initialization failure
+    bool fail_GetNext; // tracks GetNext_ failure
+
+    // PoolBuffer implementation
+    sbndaq::PoolBuffer fPoolBuffer;  		
+    std::unique_ptr<uint16_t[]> fBuffer; 
+    uint32_t fBufferSize;
+
+    // GetData worker thread
+    share::WorkerThreadUPtr GetData_thread_;
+
+    //internals in getting the data
+    boost::posix_time::ptime fTimePollEnd,fTimePollBegin;
+    boost::posix_time::ptime fTimeEpoch;
+    boost::posix_time::time_duration fTimeDiffPollBegin, fTimeDiffPollEnd;
+
+    // map fragmen sequence ID to timestamp
+    std::unordered_map<uint32_t,artdaq::Fragment::timestamp_t> fTimestampMap;
+    mutable std::mutex fTimestampMapMutex;
+
+    // fragment timestamping
+    artdaq::Fragment::timestamp_t fTS; 
+    uint64_t fMeanPollTime;
+    uint64_t fMeanPollTimeNS;
+    uint32_t fTTT;
+    long fTTT_ns;
+
+    // set to zero at the beginning
+    uint32_t fEvCounter; 
+    //count overflows of fEvCounter
+    uint32_t fOverflowCounter; 
+    // max event number internal to the V1730 board
+    const uint32_t max_rwcounter = 0xFFFFFF;  //24-bit
+
+    uint32_t last_rcvd_rwcounter;
+    uint32_t last_sent_seqid;
+    uint32_t last_sent_ts;
+
+    // hardware status check
+    uint32_t ch_temps[CAENConfiguration::MAX_CHANNELS];
+    uint32_t ch_status[CAENConfiguration::MAX_CHANNELS];
+
+
     typedef enum 
     { 
       CONFIG_READ_ADDR     = 0x8000,
@@ -52,26 +143,10 @@ namespace sbndaq
       TRIGGER_OVERLAP_MASK = 0x0002
     } REGISTERS_t;
 
-    //CAEN pieces
-    CAENConfiguration     fCAEN;	// initialized in the constructor
-    int                   fHandle;
-    CAEN_DGTZ_BoardInfo_t fBoardInfo;
-    uint32_t              fBufferSize;
-
     typedef enum {
       TEST_PATTERN_S=3
     } TEST_PATTERN_t;
     
-    typedef enum {
-      BOARD_READY  = 0x0100,
-      PLL_STATUS   = 0x0080,
-      PLL_BYPASS   = 0x0040,
-      CLOCK_SOURCE = 0x0020,
-      EVENT_FULL   = 0x0010,
-      EVENT_READY  = 0x0008,
-      RUN_ENABLED  = 0x0004
-    } ACQ_STATUS_MASK_t;
-
     typedef enum {
       DYNAMIC_RANGE      = 0x8028,
       TRG_OUT_WIDTH      = 0x8070,
@@ -170,71 +245,8 @@ namespace sbndaq
     {
       V1730_UNPHYSICAL_TEMPERATURE = 200  // degC
     };
- 
-    //internals
-    size_t   fNChannels;
-    uint32_t fBoardID;
-    bool     fOK;
-    bool     fail_GetNext;
-    uint32_t fEvCounter; // set to zero at the beginning
-    uint32_t fOverflowCounter; //count overflows of fEvCounter
-    uint32_t last_rcvd_rwcounter;
-    uint32_t last_sent_seqid;
-    const uint32_t max_rwcounter = 0xFFFFFF; //24-bit
-    uint32_t last_sent_ts;
-    uint32_t total_data_size;
-    //uint32_t event_size;	
-    uint32_t n_readout_windows;
-    uint32_t ch_temps[CAENConfiguration::MAX_CHANNELS];
-    uint32_t ch_status[CAENConfiguration::MAX_CHANNELS];
-    
-    //functions
-    void GetSWInfo();
-    void Configure();
 
-    void ConfigureInterrupts();
-    void ConfigureRecordFormat();    
-    void ConfigureDataBuffer();
-    void ConfigureTrigger();
-    void ConfigureReadout();
-    void ConfigureAcquisition();
-    void ConfigureLVDS();
-    void ConfigureSelfTriggerMode();
-    void ConfigureClkToTrgOut();
-    void RunADCCalibration();
-    void SetLockTempCalibration(bool onOff, uint32_t ch);
-    CAEN_DGTZ_ErrorCode WriteSPIRegister(int handle, uint32_t ch, uint32_t address, uint8_t value);
-    CAEN_DGTZ_ErrorCode ReadSPIRegister(int handle, uint32_t ch, uint32_t address, uint8_t *value);
-    void Read_ADC_CalParams_V1730(int handle, int ch, uint8_t *CalParams);
-    void Write_ADC_CalParams_V1730(int handle, int ch, uint8_t *CalParams);
-
-    bool WaitForTrigger();
-    bool GetData();
-    share::WorkerThreadUPtr GetData_thread_;
-    sbndaq::PoolBuffer fPoolBuffer; 		
-    std::unique_ptr<uint16_t[]> fBuffer;
-
-    std::unordered_map<uint32_t,artdaq::Fragment::timestamp_t> fTimestampMap;
-    mutable std::mutex fTimestampMapMutex;
-
-    //internals in getting the data
-    boost::posix_time::ptime fTimePollEnd,fTimePollBegin;
-    boost::posix_time::ptime fTimeEpoch;
-    boost::posix_time::time_duration fTimeDiffPollBegin,fTimeDiffPollEnd;
-    
-    artdaq::Fragment::timestamp_t fTS;
-    uint64_t fMeanPollTime;
-    uint64_t fMeanPollTimeNS;
-    uint32_t fTTT;
-    long fTTT_ns;
-
-    void CheckReadback(std::string,int,uint32_t,uint32_t,int channelID=-1);
-
-    CAEN_DGTZ_ErrorCode	WriteRegisterBitmask(int32_t handle, uint32_t address,
-					     uint32_t data, uint32_t bitmask); 
-    
   };
-
 }
 
 #endif

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -92,7 +92,6 @@ namespace sbndaq
     size_t   fNChannels; // number of channels
     uint32_t fBoardID;   // board ID
     int fHandle;         // access handle
-    bool fOK; // tracks initialization failure
     bool fail_GetNext; // tracks GetNext_ failure
 
     // PoolBuffer implementation
@@ -134,31 +133,30 @@ namespace sbndaq
     uint32_t ch_temps[CAENConfiguration::MAX_CHANNELS];
     uint32_t ch_status[CAENConfiguration::MAX_CHANNELS];
 
-
-    typedef enum 
-    { 
-      CONFIG_READ_ADDR     = 0x8000,
-      CONFIG_SET_ADDR      = 0x8004,
-      CONFIG_CLEAR_ADDR    = 0x8008,
-      TRIGGER_OVERLAP_MASK = 0x0002
-    } REGISTERS_t;
-
     typedef enum {
       TEST_PATTERN_S=3
     } TEST_PATTERN_t;
     
     typedef enum {
+      BOARD_CONFIG_READ  = 0x8000, // board configuration register
+      BOARD_CONFIG_SET   = 0x8004,
+      BOARD_CONFIG_CLEAR = 0x8008,
+
+      FP_TRG_OUT_CONTROL = 0x8110, // front panel TRG-OUT control
+      FP_IO_CONTROL      = 0x811C, // front panel I/O control
+      FP_LVDS_CONTROL    = 0x81A0, // front panel LVDS control
+      ACQ_CONTROL        = 0x8100, // acquisition control register
+      READOUT_CONTROL    = 0xEF00, // readout control
+
+      GLB_TRG_MASK       = 0x810C, // global trigger mask
+      CH_ENABLE_MASK     = 0x8120, // channel enable mask
+
       DYNAMIC_RANGE      = 0x8028,
       TRG_OUT_WIDTH      = 0x8070,
       TRG_OUT_WIDTH_CH   = 0x1070,
       SLF_TRG_LG_CH      = 0x1084,
       SLF_TRG_LG_GLB     = 0x8084,
-      GLB_TRG_MASK       = 0x810C,
-      ACQ_CONTROL        = 0x8100,
-      FP_TRG_OUT_CONTROL = 0x8110,
-      FP_IO_CONTROL      = 0x811C,
-      FP_LVDS_CONTROL    = 0x81A0,
-      READOUT_CONTROL    = 0xEF00,
+    
       // Animesh & Aiwu add registers for the LVDS logic
       FP_LVDS_Logic_G1   = 0x1084,
       FP_LVDS_Logic_G2   = 0x1284,
@@ -212,6 +210,7 @@ namespace sbndaq
 
     typedef enum 
     {
+      TRIGGER_OVERLAP_MASK = 0x0002
       ENABLE_LVDS_TRIGGER  = 0x20000000,
       ENABLE_EXT_TRIGGER   = 0x40000000,
       ENABLE_NEW_LVDS      = 0x100,

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -56,9 +56,7 @@ namespace sbndaq
     CAENConfiguration     fCAEN;	// initialized in the constructor
     int                   fHandle;
     CAEN_DGTZ_BoardInfo_t fBoardInfo;
-    //char*                 fBuffer;
     uint32_t              fBufferSize;
-    //uint32_t              fCircularBufferSize;
 
     typedef enum {
       TEST_PATTERN_S=3
@@ -209,7 +207,6 @@ namespace sbndaq
     CAEN_DGTZ_ErrorCode ReadSPIRegister(int handle, uint32_t ch, uint32_t address, uint8_t *value);
     void Read_ADC_CalParams_V1730(int handle, int ch, uint8_t *CalParams);
     void Write_ADC_CalParams_V1730(int handle, int ch, uint8_t *CalParams);
-    void ReadChannelBusyStatus(int handle, uint32_t ch, uint32_t& status);
 
     bool WaitForTrigger();
     bool GetData();

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout.hh
@@ -112,15 +112,18 @@ namespace sbndaq
     uint32_t fTTT;
     long fTTT_ns;
 
-    // set to zero at the beginning
-    uint32_t fEvCounter; 
-    //count overflows of fEvCounter
-    uint32_t fOverflowCounter; 
     // max event number internal to the V1730 board
-    const uint32_t max_rwcounter = 0xFFFFFF;  //24-bit
+    static constexpr uint32_t EVENT_COUNTER_MASK = 0xFFFFFFu; // 24-bit
+    // last event counter seen in GetData() thread
+    uint32_t last_rcv_event_counter;
 
-    uint32_t last_rcvd_rwcounter;
-    uint32_t last_sent_seqid;
+    // count overflows of V1730 event counter
+    uint32_t fOverflowCounter; 
+    // last fragment event counter sent
+    uint32_t last_sent_event_counter;
+    // last fragment sequence id sent
+    uint64_t last_sent_seqid;
+    // last fragment timestamps sent
     uint32_t last_sent_ts;
 
     // hardware status check

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -36,9 +36,6 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   // print-out all configuration parameters
   TLOG(TINFO) << fCAEN.to_string();
   
-  last_rcvd_rwcounter=0x0;
-  last_sent_seqid=0x1;
-  last_sent_ts=0;
   CAEN_DGTZ_ErrorCode retcode;
 
   fail_GetNext=false;
@@ -851,9 +848,11 @@ void sbndaq::CAENV1730Readout::start()
     sbndaq::CAENDecoder::checkError(retcode,"SWStartAcquisition",fCAEN.fragmentId);
   }
   
-  last_sent_seqid = 0;
-  fEvCounter=0;
   fOverflowCounter=0;
+  last_rcv_event_counter=0x0;
+  last_sent_event_counter=0x0;
+  last_sent_seqid =0x0;
+  last_sent_ts=0x0;
 
   // Manual calibration added by Animesh - DELETE?
   // "its origin and purpose is still a total mistery"
@@ -982,7 +981,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 
     if(!block) {
       TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
-                       << "PoolBuffer is empty; last received trigger eventCounter=" <<last_rcvd_rwcounter;
+                       << "PoolBuffer is empty; last received trigger eventCounter=" << last_rcv_event_counter;
       TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
                        << "PoolBuffer status: freeBlockCount=" << fPoolBuffer.freeBlockCount()
                        << "(FragID=" << fCAEN.fragmentId << ")"
@@ -1124,16 +1123,22 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 		   << "TIMESTAMP " << fCAEN.fragmentId 
 		   << ": Timestamp for event " << header->eventCounter << " = " << fTS;
 
-    //check trigger event counter gaps: this is a 24-bit counter in the CAEN board
-    //if the run is long, it can overflow --> do not throw errors in that case
-    auto readoutwindow_trigger_counter_gap= uint32_t{header->eventCounter} - last_rcvd_rwcounter;
-    if( readoutwindow_trigger_counter_gap > 1u && last_rcvd_rwcounter < max_rwcounter ){
+    // check trigger event counter gaps: this is a 24-bit counter in the CAEN board
+    // compute gap: look only at first 24bits to handle possible overflows
+    uint32_t current_event_counter = uint32_t{header->eventCounter};
+    uint32_t gap  = (current_event_counter - last_rcv_event_counter) & EVENT_COUNTER_MASK;
+
+    if(gap > 1u)
+    {
       TLOG (TLVL_WARNING) << "(FragID=" << fCAEN.fragmentId << ")"
-			<< "Missing triggers; previous trigger eventCounter / gap  = " << last_rcvd_rwcounter << " / "
-			<< readoutwindow_trigger_counter_gap <<", freeBlockCount=" <<fPoolBuffer.freeBlockCount() 
-			<< ", activeBlockCount=" <<fPoolBuffer.activeBlockCount() << ", fullyDrainedCount=" << fPoolBuffer.fullyDrainedCount();
+        << " Missing triggers; current trigger eventCounter=" << current_event_counter
+        << ", previous trigger eventCounter / gap  = " << last_rcv_event_counter << " / " << gap 
+        << ", freeBlockCount=" <<fPoolBuffer.freeBlockCount() 
+        << ", activeBlockCount=" <<fPoolBuffer.activeBlockCount() 
+        << ", fullyDrainedCount=" << fPoolBuffer.fullyDrainedCount();
     }    
-    last_rcvd_rwcounter = uint32_t{header->eventCounter};
+    // update
+    last_rcv_event_counter = current_event_counter;
     
     //return active block
     fPoolBuffer.returnActiveBlock(block);
@@ -1217,7 +1222,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 
     // create an artdaq::Fragment buffer to receive the data
     // set some identifiers as required 
-    auto fragment_uptr=artdaq::Fragment::FragmentBytes(fragment_datasize_bytes,fEvCounter,fCAEN.fragmentId,sbndaq::detail::FragmentType::CAENV1730,metadata);
+    auto fragment_uptr=artdaq::Fragment::FragmentBytes(fragment_datasize_bytes,last_sent_seqid,fCAEN.fragmentId,sbndaq::detail::FragmentType::CAENV1730,metadata);
 
     // create a data range that points into the fragment
     // now poolbuffer "knows" where it needs to write the payload
@@ -1234,31 +1239,42 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
    
     // get eventCounter, which is the key to get the correct timestamp from the map
     // for longer runs it can overflow (24 bit) --> play safe and don't use it as sequence id
+    uint32_t current_event_counter = uint32_t {header->eventCounter};
+
+    // detect overflow: 
+    // 1. current counter smaller than previous one
+    // 2. difference is large (larger then 0.9 overflow...)
+    if (current_event_counter < last_sent_event_counter && 
+       (last_sent_event_counter - current_event_counter) > (EVENT_COUNTER_MASK * 9 / 10)) 
+    {
+      ++fOverflowCounter;
+    }
+
     // build sequence id keeping track of overflows (avoids repeated seqIDs in the same run)
-    const auto readoutwindow_event_counter = uint32_t {header->eventCounter};
-    uint64_t readoutwindow_sequence_id = uint64_t{readoutwindow_event_counter + fOverflowCounter*(max_rwcounter+1u)};
+    // of course 64 bit can still overflow, but much more unlikely
+    uint64_t current_sequence_id = uint64_t{current_event_counter} + uint64_t{fOverflowCounter} * (uint64_t{EVENT_COUNTER_MASK} + 1u);
     
-    // sets this new event counter as sequence_id for the fragment
-    fragment_uptr->setSequenceID(readoutwindow_sequence_id);
+    // update the sequence_id for the fragment
+    fragment_uptr->setSequenceID(current_sequence_id);
 
     // now look up the timestamp from the map
     size_t ts_count=0;
     {
       std::lock_guard<std::mutex> lock(fTimestampMapMutex);
-      ts_count = fTimestampMap.count(readoutwindow_event_counter);
+      ts_count = fTimestampMap.count(current_event_counter);
     }
 
     // if no timestamp is found, retry 3 times -- sleeping in between 
     int ts_loop=0;
     while(ts_loop<3 && ts_count==0)
     {
-      TLOG(TLVL_WARNING) << " TIMESTAMP FOR SEQID " << readoutwindow_sequence_id << " EVCOUNTER " << readoutwindow_event_counter << " not found in fTimestampMap!"
+      TLOG(TLVL_WARNING) << " TIMESTAMP FOR SEQID " << current_sequence_id << " EVCOUNTER " << current_event_counter << " not found in fTimestampMap!"
 			 << " Will sleep for 200 ms and try again. Times tried = " << ts_loop;
       ::usleep(200000);
       ts_loop++;
       {
 	      std::lock_guard<std::mutex> lock(fTimestampMapMutex);
-	      ts_count = fTimestampMap.count(readoutwindow_event_counter);
+	      ts_count = fTimestampMap.count(current_event_counter);
       }
     }
 
@@ -1281,8 +1297,8 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
     if(ts_count>0)
     {
       std::lock_guard<std::mutex> lock(fTimestampMapMutex);      
-      ts_frag = fTimestampMap.at(readoutwindow_event_counter);
-      fTimestampMap.erase(readoutwindow_event_counter);
+      ts_frag = fTimestampMap.at(rcurrent_event_counter);
+      fTimestampMap.erase(current_event_counter);
     }
     // if no timestamp is found (weird..)
     // generate a new timestamp based on the current time
@@ -1290,7 +1306,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
     // no "polling" correction being applied here
     else
     {
-      TLOG(TLVL_ERROR) << " TIMESTAMP FOR SEQID " << readoutwindow_sequence_id << " EVCOUNTER " << readoutwindow_event_counter << " not found in fTimestampMap!"
+      TLOG(TLVL_ERROR) << " TIMESTAMP FOR SEQID " << current_sequence_id << " EVCOUNTER " << current_event_counter << " not found in fTimestampMap!"
 		       << " Will generate new one now...";
 
       if(fCAEN.useTimeTagForTimeStamp)
@@ -1370,44 +1386,39 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
     // finally, set the timestamp to the fragment 
     fragment_uptr->setTimestamp( ts_frag );
 
-    // check for possible gaps in the sequence IDs: compare current one with last sent
-    // throw errors if gap > 1 or order is not correct
-    auto readoutwindow_sequence_id_gap= readoutwindow_sequence_id - last_sent_seqid;
-
-    TLOG(TMAKEFRAG) << "Created fragment " << fCAEN.fragmentId << " sequenceID " << readoutwindow_sequence_id << " for event " << readoutwindow_event_counter
+    TLOG(TMAKEFRAG) << "Created fragment " << fCAEN.fragmentId << " sequenceID " << current_sequence_id << " for event " << current_event_counter
                     << " triggerTimeTag " << header->triggerTimeTag << " ts=" << ts_frag;
     
+    // check for possible gaps in the sequence IDs: compare current one with last sent
+    // throw errors if gap > 1 or order is not correct
+    // no handling of possible 64 bit overflow -- FIX?
+    uint64_t sequence_id_gap = current_sequence_id - last_sent_seqid;
+
     // look for gaps in the sequence_id
-    if( readoutwindow_sequence_id_gap > 1u )
+    if( sequence_id_gap > 1u )
     {
-      if ( last_sent_seqid > 0 )
-      {
-	      TLOG (TLVL_DEBUG) << "Missing data; previous fragment sequenceID / gap  = " << last_sent_seqid << " / " << readoutwindow_sequence_id_gap;
-	      metricMan->sendMetric("Missing Fragments", uint64_t{readoutwindow_sequence_id_gap}, "frags", 11, artdaq::MetricMode::Accumulate);
-      }
+      TLOG (TLVL_WARNING) << "Missing data; current fragment sequenceID=" << current_sequence_id;
+         << ", previous fragment sequenceID / gap  = " << last_sent_seqid << " / " << sequence_id_gap;
+      metricMan->sendMetric("Missing Fragments", uint64_t{sequence_id_gap}, "frags", 11, artdaq::MetricMode::Accumulate);
     }
 
     // look for bad ordering
-    if( readoutwindow_sequence_id < last_sent_seqid )
+    if( current_sequence_id < last_sent_seqid )
     {
-	    TLOG(TLVL_ERROR) << "SequenceIDs processed out of order!! " << readoutwindow_sequence_id << " < " << last_sent_seqid << TLOG_ENDL;
+      TLOG(TLVL_ERROR) << "SequenceIDs processed out of order!! " << current_sequence_id << " < " << last_sent_seqid << TLOG_ENDL;
     }
     if( last_sent_ts > ts_frag)
     {
-	    TLOG(TLVL_ERROR) << "Timestamps out of order!! Last event later than current one." << ts_frag << " < " << last_sent_ts << TLOG_ENDL;
+      TLOG(TLVL_ERROR) << "Timestamps out of order!! Last event later than current one." << ts_frag << " < " << last_sent_ts << TLOG_ENDL;
     }
 
     // finally push the fragments to the eventbuilders
     // clear and them move in the fragments vector
     fragments.emplace_back(nullptr);
     std::swap(fragments.back(),fragment_uptr);
-   
-    // keep track of CAEN event counter overflows
-    // this is important to avoid repeating sequenceIDs
-    if( readoutwindow_event_counter == max_rwcounter ) fOverflowCounter++;
-    fEvCounter++;
-
-    last_sent_seqid = readoutwindow_sequence_id;
+ 
+    last_sent_event_counter = current_event_counter;
+    last_sent_seqid = current_sequence_id;
     last_sent_ts = ts_frag;
 
     // keep track of how much time it took

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -440,7 +440,7 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
 
   // set/read registers for LVDS logic values setting
   // values are set in pairs (8 groups)
-  for (int gr = 0; gr < fNChannels/2; ++gr) 
+  for (size_t gr = 0; gr < 8; ++gr) 
   {
     // 0x1n84 with n = 0,2,4,6,..,E
     uint32_t regAddr = SLF_TRG_LG_CH + (gr * 0x200); 
@@ -451,13 +451,13 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
     retcod = CAEN_DGTZ_WriteRegister(fHandle, regAddr, fCAEN.LVDSLogicValue[gr]);
     sbndaq::CAENDecoder::checkError(retcod, "WriteLVDSLogicValue", fCAEN.fragmentId);
     retcod = CAEN_DGTZ_ReadRegister(fHandle, regAddr, &readBack);
-    sbndaq::CAENDecoder::checkError(retcod,"ReadLVDSLogicValue", fCAEN.fragID);
+    sbndaq::CAENDecoder::checkError(retcod,"ReadLVDSLogicValue", fCAEN.fragmentId);
     CheckReadback("LVDSLogicValue", fCAEN.fragmentId, fCAEN.LVDSLogicValue[gr], readBack, gr);
   }
 
   // set/read registers for LVDS output width values setting
   // values are set per channel
-  for (int ch = 0; ch < fNChannels; ++ch) 
+  for (size_t ch = 0; ch < fNChannels; ++ch) 
   {
     // 0x1n70 with n = 0,1,2,3,..,F
     uint32_t regAddr = TRG_OUT_WIDTH_CH + (ch * 0x100); 
@@ -468,8 +468,8 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
     retcod = CAEN_DGTZ_WriteRegister(fHandle, regAddr, fCAEN.LVDSOutWidth[ch]);
     sbndaq::CAENDecoder::checkError(retcod, "WriteLVDSOutWidth", fCAEN.fragmentId);
     retcod = CAEN_DGTZ_ReadRegister(fHandle, regAddr, &readBack);
-    sbndaq::CAENDecoder::checkError(retcod,"ReadLVDSOutWidth", fCAEN.fragID);
-    CheckReadback("LVDSOutWidth", fCAEN.fragmentId, CAEN.LVDSOutWidth[ch], readBack, ch);
+    sbndaq::CAENDecoder::checkError(retcod,"ReadLVDSOutWidth", fCAEN.fragmentId);
+    CheckReadback("LVDSOutWidth", fCAEN.fragmentId, fCAEN.LVDSOutWidth[ch], readBack, ch);
   }
 
   // set self-trigger polarity
@@ -477,7 +477,7 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
   uint32_t addr = (fCAEN.selfTrgBit)
     ? BOARD_CONFIG_SET    // writing a 1 to a bit sets that bit
     : BOARD_CONFIG_CLEAR; // writing a 1 to a bit clears that bit
-  retcode = CAEN_DGTZ_WriteRegister(fHandle, addr, SLF_TRG_BIT_MASK);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, addr, SLF_TRG_BIT_MASK);
   sbndaq::CAENDecoder::checkError(retcod, "WriteSelfTrigBit", fCAEN.fragmentId);
 }
 
@@ -524,7 +524,7 @@ void sbndaq::CAENV1730Readout::ConfigureSelfTriggerMode()
   retcod = CAEN_DGTZ_SetChannelSelfTrigger(fHandle,
 					   (CAEN_DGTZ_TriggerMode_t)fCAEN.selfTrgMode,
 					   fCAEN.selfTrgMask);
-  sbndaq::CAENDecoder::checkError(retcod,"SetChannelSelfTriggerMode",fCAEN.fragmentID);
+  sbndaq::CAENDecoder::checkError(retcod,"SetChannelSelfTriggerMode",fCAEN.fragmentId);
   
   // GVS: the following configuration parameters are for SBND. 
   // fCAEN.modeLVDS must be 0
@@ -536,8 +536,8 @@ void sbndaq::CAENV1730Readout::ConfigureSelfTriggerMode()
     for(uint32_t chn=0; chn<fNChannels; ++chn)
     {
       retcod = CAEN_DGTZ_GetChannelSelfTrigger(fHandle, chn, (CAEN_DGTZ_TriggerMode_t *)&readBack);
-      sbndaq::CAENDecoder::checkError(retcod,"GetChannelSelfTriggerMode",fCAEN.fragmentID);
-      CheckReadback("ChannelSelfTriggerMode", fCAEN.fragmentID, fCAEN.selfTrgMode, readBack, chn);
+      sbndaq::CAENDecoder::checkError(retcod,"GetChannelSelfTriggerMode",fCAEN.fragmentId);
+      CheckReadback("ChannelSelfTriggerMode", fCAEN.fragmentId, fCAEN.selfTrgMode, readBack, chn);
 
       // GVS: inserted triggerLogic for each PAIR of channels.
       if(chn%2==0)
@@ -550,11 +550,11 @@ void sbndaq::CAENV1730Readout::ConfigureSelfTriggerMode()
         retcod = CAEN_DGTZ_WriteRegister(fHandle,SLF_TRG_LG_CH+(chn<<8),
                  (fCAEN.triggerLogic & 0x3)/* + ((fCAEN.ovthValue & 0x1) <<2)*/);
 
-        sbndaq::CAENDecoder::checkError(retcod,"SelfTriggerPulseType",fCAEN.fragmentID);
+        sbndaq::CAENDecoder::checkError(retcod,"SelfTriggerPulseType",fCAEN.fragmentId);
         retcod = CAEN_DGTZ_ReadRegister(fHandle,SLF_TRG_LG_CH+(chn<<8),&aux2);
       
         TLOG_ARB(TCONFIG,TRACE_NAME) << "Self-trigger logic to channel " << chn << " new value " << std::hex << aux2 << std::dec;
-        CheckReadback("SelfTriggerPulseType", fCAEN.fragmentID, aux2, (fCAEN.triggerLogic & 0x3) /*+ ((fCAEN.ovthValue & 0x1) <<2)*/,chn);
+        CheckReadback("SelfTriggerPulseType", fCAEN.fragmentId, aux2, (fCAEN.triggerLogic & 0x3) /*+ ((fCAEN.ovthValue & 0x1) <<2)*/,chn);
       }
     }
   
@@ -573,18 +573,18 @@ void sbndaq::CAENV1730Readout::ConfigureSelfTriggerMode()
 				   
     retcod = CAEN_DGTZ_WriteRegister(fHandle,GLB_TRG_MASK, data);
 
-    sbndaq::CAENDecoder::checkError(retcod,"SetMajCoincWindow",fCAEN.fragmentID);
+    sbndaq::CAENDecoder::checkError(retcod,"SetMajCoincWindow",fCAEN.fragmentId);
     retcod = CAEN_DGTZ_ReadRegister(fHandle,GLB_TRG_MASK,&data2);
       
     TLOG_ARB(TCONFIG,TRACE_NAME) << "Global Trigger Mask address 0x810C, new value: 0x" << std::hex << data2 << std::dec;
-    CheckReadback("SetMajCoincWindow", fCAEN.fragmentID, data, data2);
+    CheckReadback("SetMajCoincWindow", fCAEN.fragmentId, data, data2);
   }
 }
 
 // ------------------------------------------------------------------------
 // ------------------------------------------------------------------------
 
-oid sbndaq::CAENV1730Readout::ConfigureAcquisition()
+void sbndaq::CAENV1730Readout::ConfigureAcquisition()
 {
   TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureAcquisition()" << TLOG_ENDL;
 

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1297,7 +1297,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
     if(ts_count>0)
     {
       std::lock_guard<std::mutex> lock(fTimestampMapMutex);      
-      ts_frag = fTimestampMap.at(rcurrent_event_counter);
+      ts_frag = fTimestampMap.at(current_event_counter);
       fTimestampMap.erase(current_event_counter);
     }
     // if no timestamp is found (weird..)
@@ -1397,7 +1397,7 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
     // look for gaps in the sequence_id
     if( sequence_id_gap > 1u )
     {
-      TLOG (TLVL_WARNING) << "Missing data; current fragment sequenceID=" << current_sequence_id;
+      TLOG (TLVL_WARNING) << "Missing data; current fragment sequenceID=" << current_sequence_id
          << ", previous fragment sequenceID / gap  = " << last_sent_seqid << " / " << sequence_id_gap;
       metricMan->sendMetric("Missing Fragments", uint64_t{sequence_id_gap}, "frags", 11, artdaq::MetricMode::Accumulate);
     }

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -42,12 +42,10 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   CAEN_DGTZ_ErrorCode retcode;
 
   fail_GetNext=false;
-
   fNChannels = fCAEN.nChannels;
-  fBoardID = fCAEN.boardId;
 
   TLOG(TCONFIG) << ": Using FragID=" << fCAEN.fragmentId 
-    << " BoardID=" << fBoardID 
+    << " BoardID=" << fCAEN.boardId 
     << " with NChannels=" << fNChannels;
 
   // opening the connection to the digitizer
@@ -176,21 +174,19 @@ void sbndaq::CAENV1730Readout::Configure()
   // Configuration is carried out in different functions
   // - CAENDecoder::checkError is applied every time: if writing fails, exception is thrown
   // - CheckReadback() is called when possible 
-
   ConfigureReadout();
   ConfigureRecordFormat();
-  ConfigureTrigger();
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "Stop Acquisition" << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SWStopAcquisition(fHandle);
-  sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fBoardID);
-  
+  ConfigureTrigger();  
   ConfigureAcquisition();
   ConfigureInterrupts();
 
-  if (fCAEN.calibrateOnConfig)     { RunADCCalibration();  }
+  // if requested, run ADC self-calibration
+  if (fCAEN.calibrateOnConfig){ 
+    RunADCCalibration();  
+  }
 
-  // Does lock bit clear on V1730 reset?   If not, always call this routine
+  // if requested, lock temperature calibration
+  // avoids recalibrating mid-run and causing baseline jumps
   if (fCAEN.lockTempCalibration )  
   { 
     for ( uint32_t ch=0; ch<fNChannels; ch++)
@@ -199,24 +195,423 @@ void sbndaq::CAENV1730Readout::Configure()
     }
   }
 
-  // Calibration added by Animesh
-  uint8_t fCalParams;
-  if (fCAEN.writeCalibration)  
-    { 
-      
-      for ( uint32_t ch=0; ch<fNChannels; ch++)
-	{
-	  TLOG(TINFO)<<"Chnumber is " <<ch<<TLOG_ENDL;
-	  Read_ADC_CalParams_V1730(fHandle, ch,&fCalParams);
-	  //  Write_ADC_CalParams_V1730(fHandle, ch,&fCalParams);
-	}
-      
-    }
-  
   TLOG_ARB(TCONFIG,TRACE_NAME) << "Configure() done." << TLOG_ENDL;
 }
 
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
+void sbndaq::CAENV1730Readout::ConfigureReadout()
+{
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureReadout()" << TLOG_ENDL;
+
+  CAEN_DGTZ_ErrorCode retcode;
+  uint32_t readback;
+  uint32_t addr,mask;
+  
+  // sets run synchronization mode
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetRunSyncMode " << (CAEN_DGTZ_RunSyncMode_t)(fCAEN.runSyncMode) << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SetRunSynchronizationMode(fHandle,(CAEN_DGTZ_RunSyncMode_t)(fCAEN.runSyncMode));
+  sbndaq::CAENDecoder::checkError(retcode,"SetRunSynchronizationMode",fCAEN.fragmentId);
+  retcode = CAEN_DGTZ_GetRunSynchronizationMode(fHandle,(CAEN_DGTZ_RunSyncMode_t*)&readback);
+  CheckReadback("SetRunSynchronizationMode",fCAEN.fragmentId,fCAEN.runSyncMode,readback);
+  
+ // test pattern Enable (default value is 0).
+ // this bit enables a triangular (0<– >3FFF) test wave 
+ // to be provided at the ADCs input for debug purposes
+  mask = ( 1 << TEST_PATTERN_t::TEST_PATTERN_S );
+  addr = (fCAEN.testPattern)
+    ? BOARD_CONFIG_SET    // writing a 1 to a bit sets that bit
+    : BOARD_CONFIG_CLEAR; // writing a 1 to a bit clears that bit
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetTestPattern addr=" << addr << ", mask=" << mask << TLOG_ENDL;
+  retcode = CAEN_DGTZ_WriteRegister(fHandle,addr,mask);
+  sbndaq::CAENDecoder::checkError(retcode,"SetTestPattern",fCAEN.fragmentId);
+
+  // sets dynamic range control
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetDynamicRange " << fCAEN.dynamicRange << TLOG_ENDL;
+  mask = (uint32_t)(fCAEN.dynamicRange);
+  retcode = CAEN_DGTZ_WriteRegister(fHandle,DYNAMIC_RANGE,mask);
+  sbndaq::CAENDecoder::checkError(retcode,"SetDynamicRange",fCAEN.fragmentId);
+
+  // sets bits in the acquisition control register
+  // later call to SetAcquisitionMode can override mode
+  // 0x28 --> bit[3] = 1, bit[5] = 1 else if default
+  // bit[3]=trigger counting mode selection; 1=all triggers are counted
+  // bit[5]=memory full mode selection; 1=one buffer free (full if N-1 are full)
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetTriggerMode (addr=" << std::hex << ACQ_CONTROL << ")" << std::hex << uint32_t{0x28} << std::dec; 
+  retcode = CAEN_DGTZ_WriteRegister(fHandle,ACQ_CONTROL,uint32_t{0x28});
+  sbndaq::CAENDecoder::checkError(retcode,"SetTriggerMode",fCAEN.fragmentId);
+  retcode = CAEN_DGTZ_ReadRegister(fHandle,ACQ_CONTROL,&readback);
+  sbndaq::CAENDecoder::checkError(retcode,"GetTriggerMode",fCAEN.fragmentId);
+  CheckReadback("SetTriggerMode",fCAEN.fragmentId,uint32_t{0x28},readback);
+
+  // sets channel DC offeset/pedestal
+  for(uint32_t ch=0; ch<fNChannels; ++ch){
+    TLOG_ARB(TCONFIG,TRACE_NAME) << "Set channel " << ch << " DC offset to " << fCAEN.pedestal[ch] << TLOG_ENDL;
+    retcode = CAEN_DGTZ_SetChannelDCOffset(fHandle,ch,fCAEN.pedestal[ch]);
+    sbndaq::CAENDecoder::checkError(retcode,"SetChannelDCOffset",fCAEN.fragmentId);
+    retcode = CAEN_DGTZ_GetChannelDCOffset(fHandle,ch,&readback);
+    CheckReadback("SetChannelDCOffset",fCAEN.fragmentId,fCAEN.pedestal[ch],readback,ch);
+  }
+
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureReadout() done." << TLOG_ENDL;
+}
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
+void sbndaq::CAENV1730Readout::ConfigureRecordFormat()
+{
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureRecordFormat()" << TLOG_ENDL;
+
+  CAEN_DGTZ_ErrorCode retcode;
+  uint32_t readback;
+
+  // channel masks for readout(?)
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetChannelEnableMask " << fCAEN.channelEnableMask << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SetChannelEnableMask(fHandle,fCAEN.channelEnableMask);
+  sbndaq::CAENDecoder::checkError(retcode,"SetChannelEnableMask",fCAEN.fragmentId);
+  retcode = CAEN_DGTZ_GetChannelEnableMask(fHandle,&readback);
+  sbndaq::CAENDecoder::checkError(retcode,"GetChannelEnableMask",fCAEN.fragmentId);
+  CheckReadback("CHANNEL_ENABLE_MASK", fCAEN.fragmentId, fCAEN.channelEnableMask, readback);
+
+  // record length (number of sample)
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetRecordLength " << fCAEN.recordLength << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SetRecordLength(fHandle,fCAEN.recordLength);
+  sbndaq::CAENDecoder::checkError(retcode,"SetRecordLength",fCAEN.fragmentId);
+  retcode = CAEN_DGTZ_GetRecordLength(fHandle,&readback);
+  sbndaq::CAENDecoder::checkError(retcode,"GetRecordLength",fCAEN.fragmentId);
+  CheckReadback("RECORD_LENGTH", fCAEN.fragmentId, fCAEN.recordLength, readback);
+
+  // post trigger size
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetPostTriggerSize " << (unsigned int)(fCAEN.postPercent) << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SetPostTriggerSize(fHandle,(unsigned int)(fCAEN.postPercent));
+  sbndaq::CAENDecoder::checkError(retcode,"SetPostTriggerSize",fCAEN.fragmentId);
+  retcode = CAEN_DGTZ_GetPostTriggerSize(fHandle,&readback);
+  sbndaq::CAENDecoder::checkError(retcode,"GetPostTriggerSize",fCAEN.fragmentId);
+  CheckReadback("POST_TRIGGER_SIZE", fCAEN.fragmentId, fCAEN.postPercent, readback);
+
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureRecordFormat() done." << TLOG_ENDL;
+}
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
+void sbndaq::CAENV1730Readout::ConfigureTrigger()
+{
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureTrigger()" << TLOG_ENDL;
+
+  CAEN_DGTZ_ErrorCode retcode;
+  uint32_t readback;
+  uint32_t addr;
+
+  // set the software trigger mode
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetSWTriggerMode" << fCAEN.swTrgMode << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SetSWTriggerMode(fHandle,(CAEN_DGTZ_TriggerMode_t)(fCAEN.swTrgMode));
+  sbndaq::CAENDecoder::checkError(retcode,"SetSWTriggerMode",fCAEN.fragmentId);
+  retcode = CAEN_DGTZ_GetSWTriggerMode(fHandle,(CAEN_DGTZ_TriggerMode_t *)&readback);
+  CheckReadback("SetSWTriggerMode", fCAEN.fragmentId,fCAEN.swTrgMode,readback);
+
+  // set the external trigger mode
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetExtTriggerMode" << fCAEN.extTrgMode << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SetExtTriggerInputMode(fHandle,(CAEN_DGTZ_TriggerMode_t)(fCAEN.extTrgMode));
+  sbndaq::CAENDecoder::checkError(retcode,"SetExtTriggerInputMode",fCAEN.fragmentId);
+  retcode = CAEN_DGTZ_GetExtTriggerInputMode(fHandle,(CAEN_DGTZ_TriggerMode_t *)&readback);
+  CheckReadback("SetExtTriggerInputMode",fCAEN.fragmentId,fCAEN.extTrgMode,readback);
+
+  for(uint32_t ch=0; ch<fNChannels; ++ch)
+  {
+    TLOG_ARB(TCONFIG,TRACE_NAME) << "Set channel " << ch 
+          << " trigger threshold to " << fCAEN.triggerThresholds[ch] << TLOG_ENDL;
+    retcode = CAEN_DGTZ_SetChannelTriggerThreshold(fHandle,ch,fCAEN.triggerThresholds[ch]);
+    sbndaq::CAENDecoder::checkError(retcode,"SetChannelTriggerThreshold",fCAEN.fragmentId);
+    retcode = CAEN_DGTZ_GetChannelTriggerThreshold(fHandle,ch,&readback);
+    CheckReadback("SetChannelTriggerThreshold",fCAEN.fragmentId,fCAEN.triggerThresholds[ch],readback,ch);
+
+    // GVS: the following configuration parameters are for SBND.
+    // fCAEN.modeLVDS must be 0
+    if(fCAEN.modeLVDS==0)
+    {
+      TLOG_ARB(TCONFIG,TRACE_NAME) << "Set Trigger Polarity " << fCAEN.triggerPolarity << " to channel: " << ch << TLOG_ENDL;
+      retcode = CAEN_DGTZ_SetTriggerPolarity(fHandle, ch,(CAEN_DGTZ_TriggerPolarity_t)(fCAEN.triggerPolarity));
+      sbndaq::CAENDecoder::checkError(retcode,"SetTriggerPolarity",fCAEN.fragmentId);
+      retcode = CAEN_DGTZ_GetTriggerPolarity(fHandle, ch,(CAEN_DGTZ_TriggerPolarity_t *)&readback);
+      CheckReadback("SetTriggerPolarity",fCAEN.fragmentId,fCAEN.triggerPolarity,readback, ch);
+
+      // GVS: pulse width must be set per channel, not per pair of channel. 
+      // This contradicts what manual says!
+      TLOG_ARB(TCONFIG,TRACE_NAME) << "Set channels " << ch << " trigger pulse width to " << fCAEN.triggerPulseWidth << TLOG_ENDL;
+      retcode = CAEN_DGTZ_WriteRegister(fHandle,TRG_OUT_WIDTH_CH+(ch<<8),fCAEN.triggerPulseWidth);
+      sbndaq::CAENDecoder::checkError(retcode,"SetChannelTriggerPulseWidth",fCAEN.fragmentId);
+      retcode = CAEN_DGTZ_ReadRegister(fHandle,TRG_OUT_WIDTH_CH+(ch<<8),&readback);
+      CheckReadback("SetChannelTriggerPulseWidth",fCAEN.fragmentId,fCAEN.triggerPulseWidth,readback, ch);
+    }
+  }
+
+  // LVDS configuration for ICARUS
+  // LVDS mode must be > 0
+  if(fCAEN.modeLVDS!=0)
+  { 
+    ConfigureLVDS();
+  }
+
+  // for clock synchronization studies
+  if( fCAEN.outputClk || fCAEN.outputClkPhase )
+  { 
+    ConfigureClkToTrgOut(); 
+  } 
+
+  // Self trigger configuration
+  // also LVDS config for SBND
+  ConfigureSelfTriggerMode();
+ 
+  // enable the trigger overlap (merging of trigger events)
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetTriggerOverlap" << fCAEN.allowTriggerOverlap << TLOG_ENDL;
+  addr = (fCAEN.allowTriggerOverlap)
+    ? BOARD_CONFIG_SET    // writing a 1 to a bit sets that bit
+    : BOARD_CONFIG_CLEAR; // writing a 1 to a bit clears that bit
+  retcode = CAEN_DGTZ_WriteRegister(fHandle, addr, TRIGGER_OVERLAP_MASK);
+  sbndaq::CAENDecoder::checkError(retcode,"SetTriggerOverlap",fCAEN.fragmentId);
+
+  // I/O level: TTL=1, NIM=0
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetIOLevel " << (CAEN_DGTZ_IOLevel_t)(fCAEN.ioLevel) << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SetIOLevel(fHandle,(CAEN_DGTZ_IOLevel_t)(fCAEN.ioLevel));
+  sbndaq::CAENDecoder::checkError(retcode,"SetIOLevel",fCAEN.fragmentId);
+  retcode = CAEN_DGTZ_GetIOLevel(fHandle,(CAEN_DGTZ_IOLevel_t *)&readback);
+  CheckReadback("SetIOLevel",fCAEN.fragmentId,fCAEN.ioLevel,readback);
+
+}
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
+void sbndaq::CAENV1730Readout::ConfigureLVDS()
+{
+  CAEN_DGTZ_ErrorCode retcod = CAEN_DGTZ_Success;
+  uint32_t data,readBack,ioMode;
+
+  // Construct mode mask: repeat chosen modeLVDS 4 times
+  // FP_LVDS_CONTROL groups multiple LVDS pins into separate 4-bit fields
+  data = fCAEN.modeLVDS | (fCAEN.modeLVDS << 4) | (fCAEN.modeLVDS << 8) | (fCAEN.modeLVDS << 12);
+  TLOG(TINFO) << "ModeLVDS: 0x" << std::hex << data << std::dec;
+  
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_CONTROL, data);
+  sbndaq::CAENDecoder::checkError(retcod,"WriteLVDSOutputConfig",fCAEN.fragmentId);
+  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_CONTROL, &readBack);
+  sbndaq::CAENDecoder::checkError(retcod,"ReadLVDSOutputConfig",fCAEN.fragmentId);
+  CheckReadback("LVDSOutputConfig", fCAEN.fragmentId, data, readBack);
+
+  // reads the FP_IO_CONTROL register (front-panel I/O configuration) into ioMode
+  // this is the base configuration -- it will be modified and written back
+  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_IO_CONTROL, &ioMode);
+  sbndaq::CAENDecoder::checkError(retcod,"ReadFPOutputConfig",fCAEN.fragmentId);
+
+  // If TRIGGER mode, send them out TRG-OUT NIM
+  if ( fCAEN.modeLVDS == LVDS_TRIGGER )
+  {
+    // Put LVDS into OUTPUT mode and send to TRG-OUT
+    ioMode |= (LVDS_IO | ENABLE_NEW_LVDS);
+    ioMode &= ~DISABLE_TRG_OUT_LEMO ;
+  }
+  else
+  {
+    // Put LVDS into INPUT mode
+    ioMode &= ~(LVDS_IO | DISABLE_TRG_OUT_LEMO);
+  }
+
+  // sets TRG-IN to level or edge
+  if ( fCAEN.trigInLevel )
+  {
+    ioMode |= TRG_IN_LEVEL;
+  }
+  else
+  {
+    ioMode &= ~(TRG_IN_LEVEL);
+  }
+
+  // finally write back to FP_IO_CONTROL the update value
+  // this should be the final configuration for this register
+  TLOG(TINFO) << "FPOutputConfig: 0x" << std::hex << ioMode << std::dec;
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_IO_CONTROL, ioMode);
+  sbndaq::CAENDecoder::checkError(retcod,"WriteFPOutputConfig",fCAEN.fragmentId);
+  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_IO_CONTROL, &readBack);
+  sbndaq::CAENDecoder::checkError(retcod,"ReadFPOutputConfig",fCAEN.fragmentId);
+  CheckReadback("FPOutputConfig", fCAEN.fragmentId, ioMode, readBack);
+
+  // set/read registers for LVDS logic values setting
+  // values are set in pairs (8 groups)
+  for (int gr = 0; gr < fNChannels/2; ++gr) 
+  {
+    // 0x1n84 with n = 0,2,4,6,..,E
+    uint32_t regAddr = SLF_TRG_LG_CH + (gr * 0x200); 
+    TLOG_ARB(TCONFIG,TRACE_NAME) << "LVDS logic value for G" << gr+1 
+      << " (0x" << std::hex << regAddr << ") : "
+      << std::dec << fCAEN.LVDSLogicValue[gr] << TLOG_ENDL;
+
+    retcod = CAEN_DGTZ_WriteRegister(fHandle, regAddr, fCAEN.LVDSLogicValue[gr]);
+    sbndaq::CAENDecoder::checkError(retcod, "WriteLVDSLogicValue", fCAEN.fragmentId);
+    retcod = CAEN_DGTZ_ReadRegister(fHandle, regAddr, &readBack);
+    sbndaq::CAENDecoder::checkError(retcod,"ReadLVDSLogicValue", fCAEN.fragID);
+    CheckReadback("LVDSLogicValue", fCAEN.fragmentId, fCAEN.LVDSLogicValue[gr], readBack, gr);
+  }
+
+  // set/read registers for LVDS output width values setting
+  // values are set per channel
+  for (int ch = 0; ch < fNChannels; ++ch) 
+  {
+    // 0x1n70 with n = 0,1,2,3,..,F
+    uint32_t regAddr = TRG_OUT_WIDTH_CH + (ch * 0x100); 
+    TLOG_ARB(TCONFIG,TRACE_NAME) << "LVDS logic value for Ch" << ch 
+      << " (0x" << std::hex << regAddr << ") : " 
+      << std::dec << fCAEN.LVDSOutWidth[ch] << TLOG_ENDL;
+
+    retcod = CAEN_DGTZ_WriteRegister(fHandle, regAddr, fCAEN.LVDSOutWidth[ch]);
+    sbndaq::CAENDecoder::checkError(retcod, "WriteLVDSOutWidth", fCAEN.fragmentId);
+    retcod = CAEN_DGTZ_ReadRegister(fHandle, regAddr, &readBack);
+    sbndaq::CAENDecoder::checkError(retcod,"ReadLVDSOutWidth", fCAEN.fragID);
+    CheckReadback("LVDSOutWidth", fCAEN.fragmentId, CAEN.LVDSOutWidth[ch], readBack, ch);
+  }
+
+  // set self-trigger polarity
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetSelfTrigBit" << fCAEN.selfTrgBit << TLOG_ENDL;
+  uint32_t addr = (fCAEN.selfTrgBit)
+    ? BOARD_CONFIG_SET    // writing a 1 to a bit sets that bit
+    : BOARD_CONFIG_CLEAR; // writing a 1 to a bit clears that bit
+  retcode = CAEN_DGTZ_WriteRegister(fHandle, addr, SLF_TRG_BIT_MASK);
+  sbndaq::CAENDecoder::checkError(retcod, "WriteSelfTrigBit", fCAEN.fragmentId);
+}
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
+void sbndaq::CAENV1730Readout::ConfigureClkToTrgOut()
+{
+  /* Check to output ONLY CLK OR CLK PHASE */
+  if ( fCAEN.outputClk && fCAEN.outputClkPhase ){
+    TLOG(TLVL_ERROR) << "Error configuring output clock: Cannot output clock and its phase at the same time." << TLOG_ENDL;
+    abort();
+  } 
+
+  CAEN_DGTZ_ErrorCode retcod = CAEN_DGTZ_Success;
+  uint32_t data;
+
+  /* Check the output of the 0x811C */
+  retcod = CAEN_DGTZ_ReadRegister(fHandle,FP_IO_CONTROL, &data);
+  sbndaq::CAENDecoder::checkError(retcod,"ClkToTrgOutCheckError",fCAEN.fragmentId);
+
+  uint32_t value16 = 0x1; 
+  uint32_t value18 = 0x0;
+  if (fCAEN.outputClk) value18 = 0x1;
+  if (fCAEN.outputClkPhase) value18 = 0x2;
+  data |= ((value16 & 0x3)<<16) + ((value18 &0x3)<<18);
+
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_IO_CONTROL, data);
+  sbndaq::CAENDecoder::checkError(retcod,"ClkToTrgOutCheckError",fCAEN.fragmentId);
+
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "Front Panel IO Control address 0x811C, new value: 0x" << std::hex << data << std::dec;
+  TLOG(TINFO) << "Front Panel IO Control address 0x811C, new value: 0x" << std::hex << data << std::dec;
+}
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
+// GVS: new ConfigureSelfTriggerMode() function
+void sbndaq::CAENV1730Readout::ConfigureSelfTriggerMode()
+{
+  CAEN_DGTZ_ErrorCode retcod = CAEN_DGTZ_Success;
+
+  // sets the channel self-trigger mode
+  retcod = CAEN_DGTZ_SetChannelSelfTrigger(fHandle,
+					   (CAEN_DGTZ_TriggerMode_t)fCAEN.selfTrgMode,
+					   fCAEN.selfTrgMask);
+  sbndaq::CAENDecoder::checkError(retcod,"SetChannelSelfTriggerMode",fCAEN.fragmentID);
+  
+  // GVS: the following configuration parameters are for SBND. 
+  // fCAEN.modeLVDS must be 0
+  if(fCAEN.modeLVDS==0)
+  { 
+    uint32_t data, data2, bitpair, readBack, aux, aux2;
+  
+    // GVS: verify the SelfTrigger values set in each channel.
+    for(uint32_t chn=0; chn<fNChannels; ++chn)
+    {
+      retcod = CAEN_DGTZ_GetChannelSelfTrigger(fHandle, chn, (CAEN_DGTZ_TriggerMode_t *)&readBack);
+      sbndaq::CAENDecoder::checkError(retcod,"GetChannelSelfTriggerMode",fCAEN.fragmentID);
+      CheckReadback("ChannelSelfTriggerMode", fCAEN.fragmentID, fCAEN.selfTrgMode, readBack, chn);
+
+      // GVS: inserted triggerLogic for each PAIR of channels.
+      if(chn%2==0)
+      {
+        retcod = CAEN_DGTZ_ReadRegister(fHandle,SLF_TRG_LG_CH+(chn<<8),&aux);
+        TLOG_ARB(TCONFIG,TRACE_NAME) << "Self-trigger logic to channel " << chn << " old value " << std::hex << aux << std::dec;
+
+        TLOG_ARB(TCONFIG,TRACE_NAME) << "Set channels " << chn << "/" << chn+1 << " self trigger logic to " << fCAEN.triggerLogic
+				/* << " self trigger pulse type to " << fCAEN.ovthValue*/ << TLOG_ENDL;
+        retcod = CAEN_DGTZ_WriteRegister(fHandle,SLF_TRG_LG_CH+(chn<<8),
+                 (fCAEN.triggerLogic & 0x3)/* + ((fCAEN.ovthValue & 0x1) <<2)*/);
+
+        sbndaq::CAENDecoder::checkError(retcod,"SelfTriggerPulseType",fCAEN.fragmentID);
+        retcod = CAEN_DGTZ_ReadRegister(fHandle,SLF_TRG_LG_CH+(chn<<8),&aux2);
+      
+        TLOG_ARB(TCONFIG,TRACE_NAME) << "Self-trigger logic to channel " << chn << " new value " << std::hex << aux2 << std::dec;
+        CheckReadback("SelfTriggerPulseType", fCAEN.fragmentID, aux2, (fCAEN.triggerLogic & 0x3) /*+ ((fCAEN.ovthValue & 0x1) <<2)*/,chn);
+      }
+    }
+  
+    // GVS: read TRG_OUT register to monitor enabled/disabled pair of channels.
+    retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_TRG_OUT_CONTROL, &bitpair);
+    TLOG_ARB(TCONFIG,TRACE_NAME) << "Front Panel TRG-OUT address 0x8110, value: 0x" << std::hex << bitpair << std::dec;
+				    
+    /* Set Majority Mode and Majority Coincidence Window */
+    retcod = CAEN_DGTZ_ReadRegister(fHandle, GLB_TRG_MASK, &data);
+    TLOG_ARB(TCONFIG,TRACE_NAME) << "Global Trigger Mask address 0x810C, old value: 0x" << std::hex << data << std::dec;
+  
+    TLOG_ARB(TCONFIG,TRACE_NAME)  << " Set Majority Level to " << fCAEN.majorityLevel << TLOG_ENDL;
+    TLOG_ARB(TCONFIG,TRACE_NAME)  << " Set Maj Coincidence Window to " << fCAEN.majorityCoincidenceWindow << TLOG_ENDL;
+				   
+    data |= ((fCAEN.majorityLevel & 0x7)<<24) + ((fCAEN.majorityCoincidenceWindow & 0xF) <<20);
+				   
+    retcod = CAEN_DGTZ_WriteRegister(fHandle,GLB_TRG_MASK, data);
+
+    sbndaq::CAENDecoder::checkError(retcod,"SetMajCoincWindow",fCAEN.fragmentID);
+    retcod = CAEN_DGTZ_ReadRegister(fHandle,GLB_TRG_MASK,&data2);
+      
+    TLOG_ARB(TCONFIG,TRACE_NAME) << "Global Trigger Mask address 0x810C, new value: 0x" << std::hex << data2 << std::dec;
+    CheckReadback("SetMajCoincWindow", fCAEN.fragmentID, data, data2);
+  }
+}
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
+oid sbndaq::CAENV1730Readout::ConfigureAcquisition()
+{
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureAcquisition()" << TLOG_ENDL;
+
+  CAEN_DGTZ_ErrorCode retcode;
+  uint32_t readback;
+
+  // sets the acquisition mode
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetAcqMode " << (CAEN_DGTZ_AcqMode_t)(fCAEN.acqMode) << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SetAcquisitionMode(fHandle,(CAEN_DGTZ_AcqMode_t)(fCAEN.acqMode));
+  sbndaq::CAENDecoder::checkError(retcode,"SetAcquisitionMode",fCAEN.fragmentId);
+  retcode = CAEN_DGTZ_GetAcquisitionMode(fHandle,(CAEN_DGTZ_AcqMode_t*)&readback);
+  CheckReadback("SetAcquisitionMode",fCAEN.fragmentId,fCAEN.acqMode,readback);
+
+  // sets analog monitor output mode
+  // GetAnalogMonOutput function does not work for V1730s -- still true?
+  // use register access instead 
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetAnalogMonOutputMode " << (CAEN_DGTZ_AnalogMonitorOutputMode_t)(fCAEN.analogMode) << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SetAnalogMonOutput(fHandle,(CAEN_DGTZ_AnalogMonitorOutputMode_t)(fCAEN.analogMode));
+  sbndaq::CAENDecoder::checkError(retcode,"SetAnalogMonOutputMode",fCAEN.fragmentId);
+  retcode = CAEN_DGTZ_ReadRegister(fHandle,ANALOG_MON_MOD,&readback);
+  CheckReadback("SetAnalogMonOutputMode",fCAEN.fragmentId,fCAEN.analogMode,readback);
+
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureAcquisition() done." << TLOG_ENDL;
+}
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
 void sbndaq::CAENV1730Readout::ConfigureInterrupts() 
 {
@@ -232,37 +627,22 @@ void sbndaq::CAENV1730Readout::ConfigureInterrupts()
   mode            = CAEN_DGTZ_IRQ_MODE_RORA; // For CONET, only RORA = Release on Register Access
   eventNumber     = fCAEN.interruptEventNumber; // Number of recorded events to generate interrupts
 
-  if(fCAEN.interruptEnable>0) // Enable interrupts
-  {
-    state           = CAEN_DGTZ_ENABLE;
-  }
-  else // Disable interrupts
-  {
-    state           = CAEN_DGTZ_DISABLE;
-  }
+  state = (fCAEN.interruptEnable>0)
+    ? CAEN_DGTZ_ENABLE    // Enable interrupts
+    : CAEN_DGTZ_DISABLE;; // Disable interrupts
 
   TLOG(TINFO) << "Configuring Interrupts state=" << uint32_t{state} << " ("
 	      << sbndaq::CAENDecoder::EnaDisMode((CAEN_DGTZ_EnaDis_t)state) << ")"
-              << ", mode=" << uint32_t{mode} << " (" << sbndaq::CAENDecoder::IRQMode((CAEN_DGTZ_IRQMode_t)mode) << ")" 
-              << ", interruptLevel=" << uint32_t{interruptLevel} 
-              << ", statusId=" << uint32_t{statusId}
-              << ", eventNumber="<< uint16_t{eventNumber};
+        << ", mode=" << uint32_t{mode} << " (" << sbndaq::CAENDecoder::IRQMode((CAEN_DGTZ_IRQMode_t)mode) << ")" 
+        << ", interruptLevel=" << uint32_t{interruptLevel} 
+        << ", statusId=" << uint32_t{statusId}
+        << ", eventNumber="<< uint16_t{eventNumber};
 
-  retcode = CAEN_DGTZ_SetInterruptConfig(fHandle,
-					 state,
-					 interruptLevel,
-					 statusId,
-					 eventNumber,
-					 mode);
-  CAENDecoder::checkError(retcode,"SetInterruptConfig",fBoardID);
+  retcode = CAEN_DGTZ_SetInterruptConfig(fHandle,state,interruptLevel,statusId,eventNumber,mode);
+  CAENDecoder::checkError(retcode,"SetInterruptConfig",fCAEN.fragmentId);
 
-  retcode = CAEN_DGTZ_GetInterruptConfig(fHandle, 
-					  &stateOut, 
-					  &interruptLevelOut, 
-					  &statusIdOut, 
-					  &eventNumberOut, 
-					  &modeOut);
-  CAENDecoder::checkError(retcode,"GetInterruptConfig",fBoardID);
+  retcode = CAEN_DGTZ_GetInterruptConfig(fHandle,&stateOut,&interruptLevelOut,&statusIdOut,&eventNumberOut,&modeOut);
+  CAENDecoder::checkError(retcode,"GetInterruptConfig",fCAEN.fragmentId);
 
   // check returned value for inconsistencies
   // skip statusId, interruptLevel, mode: these are meaningless for optical links
@@ -280,12 +660,18 @@ void sbndaq::CAENV1730Readout::ConfigureInterrupts()
   }              
 }
 
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
 void sbndaq::CAENV1730Readout::RunADCCalibration()
 {
   TLOG_ARB(TINFO,TRACE_NAME) << "Running calibration..." << TLOG_ENDL;
   auto retcode = CAEN_DGTZ_Calibrate(fHandle);
-  sbndaq::CAENDecoder::checkError(retcode,"Calibrate",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcode,"Calibrate",fCAEN.fragmentId);
 }
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
 // Following SPI code is from CAEN
 CAEN_DGTZ_ErrorCode CAENV1730Readout::ReadSPIRegister(int handle, uint32_t ch, uint32_t address, uint8_t *value)
@@ -303,7 +689,6 @@ CAEN_DGTZ_ErrorCode CAENV1730Readout::ReadSPIRegister(int handle, uint32_t ch, u
     {
       return CAEN_DGTZ_CommError;
     }
-
     SPIBusy = (SPIBusy>>2)&0x1;
     if (!SPIBusy) 
     {
@@ -323,7 +708,6 @@ CAEN_DGTZ_ErrorCode CAENV1730Readout::WriteSPIRegister(int handle, uint32_t ch, 
 {
   uint32_t SPIBusy = 1;
   CAEN_DGTZ_ErrorCode retcod = CAEN_DGTZ_Success;
-    
   uint32_t SPIBusyAddr        = 0x1088 + (ch<<8);
   uint32_t addressingRegAddr  = 0x80B4;
   uint32_t valueRegAddr       = 0x10B8 + (ch<<8);
@@ -334,7 +718,6 @@ CAEN_DGTZ_ErrorCode CAENV1730Readout::WriteSPIRegister(int handle, uint32_t ch, 
     {
       return CAEN_DGTZ_CommError;
     }
-
     SPIBusy = (SPIBusy>>2)&0x1;
     if (!SPIBusy) 
     {
@@ -348,6 +731,8 @@ CAEN_DGTZ_ErrorCode CAENV1730Readout::WriteSPIRegister(int handle, uint32_t ch, 
   return CAEN_DGTZ_Success;
 }
 
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
 void sbndaq::CAENV1730Readout::SetLockTempCalibration(bool onOff, uint32_t ch)
 {
@@ -358,464 +743,37 @@ void sbndaq::CAENV1730Readout::SetLockTempCalibration(bool onOff, uint32_t ch)
   // Following code comes from CAEN
   // enter engineering functions
   retcod = WriteSPIRegister(fHandle, ch, (uint32_t)0x7A, (uint8_t)0x59);
-  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fBoardID);
-
+  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fCAEN.fragmentId);
   retcod = WriteSPIRegister(fHandle, ch, (uint32_t)0x7A, (uint8_t)0x1A);
-  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fBoardID);
-
+  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fCAEN.fragmentId);
   retcod = WriteSPIRegister(fHandle, ch, (uint32_t)0x7A, (uint8_t)0x11);
-  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fBoardID);
-
+  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fCAEN.fragmentId);
   retcod = WriteSPIRegister(fHandle, ch, (uint32_t)0x7A, (uint8_t)0xAC);
-  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fCAEN.fragmentId);
   
   // read lock value
   retcod = ReadSPIRegister (fHandle, ch, (uint32_t)0xA7, &lock);
-  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fCAEN.fragmentId);
 
   // write lock value
   retcod = WriteSPIRegister(fHandle, ch, (uint32_t)0xA5, lock);
-  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fCAEN.fragmentId);
 
   // enable lock
   retcod = ReadSPIRegister (fHandle, ch, (uint32_t)0xA4, &ctrl);
-  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fCAEN.fragmentId);
 
   if (onOff) { ctrl |= 0x4;}  // set bit 2
   else       { ctrl &= ~0x4;}
   retcod = WriteSPIRegister(fHandle, ch, (uint32_t)0xA4, ctrl);
-  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fCAEN.fragmentId);
 
   retcod = ReadSPIRegister (fHandle, ch, (uint32_t)0xA4, &ctrl);
-  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcod,"LockTempCalibration",fCAEN.fragmentId);
 }
 
-// Animesh added here for Calibration
-
-// ---------------------------------------------------------------------------------------------------------
-// Description: Read ADC calibration from ADC chip (via SPI)
-// Inputs: handle = board handle
-// ch = channel
-// Return: 0=OK, negative number = error code
-// ---------------------------------------------------------------------------------------------------------
-
-void sbndaq::CAENV1730Readout::Read_ADC_CalParams_V1730(int handle, int ch, uint8_t *CalParams)
-{
- //int retcod = 0;
-  CAEN_DGTZ_ErrorCode retcod;
- // read offset
- retcod = ReadSPIRegister(handle, ch, 0x20, &CalParams[0]);
- TLOG(TINFO)<<"Read_ADC-CalParams_ch"<<ch<< ": Params[0]=" << (int)CalParams[0];
- sbndaq::CAENDecoder::checkError(retcod,"Read_ADC_CalParams_0x20",handle);
- retcod = ReadSPIRegister(handle, ch, 0x21, &CalParams[1]);
- TLOG(TINFO)<<"Read_ADC-CalParams_ch"<<ch<< ": Params[1]=" << (int)CalParams[1];
- sbndaq::CAENDecoder::checkError(retcod,"Read_ADC_CalParams_0x21",handle);
- retcod = ReadSPIRegister(handle, ch, 0x26, &CalParams[2]);
-  TLOG(TINFO)<<"Read_ADC-CalParams_ch"<<ch<< ": Params[2]=" << (int)CalParams[2];
- sbndaq::CAENDecoder::checkError(retcod,"Read_ADC_CalParams_0x26",handle);
- retcod = ReadSPIRegister(handle, ch, 0x27, &CalParams[3]);
- TLOG(TINFO)<<"Read_ADC-CalParams_ch"<<ch<< ": Params[3]=" << (int)CalParams[3];
- sbndaq::CAENDecoder::checkError(retcod,"Read_ADC_CalParams_0x27",handle);
- 
-// read gain
- retcod = ReadSPIRegister(handle, ch, 0x22, &CalParams[4]);
- TLOG(TINFO)<<"Read_ADC-CalParams_"<< ": Params[4]=" << (int)CalParams[4];
- sbndaq::CAENDecoder::checkError(retcod,"Read_ADC_CalParams_0x22",handle);
- retcod = ReadSPIRegister(handle, ch, 0x23, &CalParams[5]);
- TLOG(TINFO)<<"Read_ADC-CalParams_"<< ": Params[5]=" << (int)CalParams[5];
- sbndaq::CAENDecoder::checkError(retcod,"Read_ADC_CalParams_0x23",handle);
- retcod = ReadSPIRegister(handle, ch, 0x24, &CalParams[6]);
- TLOG(TINFO)<<"Read_ADC-CalParams_"<< ": Params[6]=" << (int)CalParams[6];
- sbndaq::CAENDecoder::checkError(retcod,"Read_ADC_CalParams_0x24",handle);
- retcod = ReadSPIRegister(handle, ch, 0x28, &CalParams[7]);
- TLOG(TINFO)<<"Read_ADC-CalParams_"<< ": Params[7]=" << (int)CalParams[7];
- sbndaq::CAENDecoder::checkError(retcod,"Read_ADC_CalParams_0x28",handle);
- retcod = ReadSPIRegister(handle, ch, 0x29, &CalParams[8]);
- TLOG(TINFO)<<"Read_ADC-CalParams_"<< ": Params[8]=" << (int)CalParams[8];
- sbndaq::CAENDecoder::checkError(retcod,"Read_ADC_CalParams_0x29",handle);
- retcod = ReadSPIRegister(handle, ch, 0x2A, &CalParams[9]);
- TLOG(TINFO)<<"Read_ADC-CalParams_"<< ": Params[9]=" << (int)CalParams[9];
- sbndaq::CAENDecoder::checkError(retcod,"Read_ADC_CalParams_0x2A",handle);
- // read skew
- retcod = ReadSPIRegister(handle, ch, 0x70, &CalParams[10]);
- TLOG(TINFO)<<"Read_ADC-CalParams_"<< ": Params[10]=" << (int)CalParams[10];
- sbndaq::CAENDecoder::checkError(retcod,"Read_ADC_CalParams_0x70",handle);
- //return CAEN_DGTZ_Success;
-}
-
-// ---------------------------------------------------------------------------------------------------------
-// Description: Write ADC calibration to ADC chip (via SPI)
-// Inputs: handle = board handle
-// ch = channel
-// Return: 0=OK, negative number = error code
-// ---------------------------------------------------------------------------------------------------------
-
-void sbndaq::CAENV1730Readout::Write_ADC_CalParams_V1730(int handle, int ch, uint8_t *CalParams)
-{
-  //int retcod = 0;
-  CAEN_DGTZ_ErrorCode retcod;
-  // Keep parameters frozen
-  retcod = WriteSPIRegister(handle, ch, 0xFE, 0x00);
-  TLOG(TINFO)<<"Write_ADC-CalParams_ch"<<ch<< ": Params[0]=" << (int)CalParams[0];
-  sbndaq::CAENDecoder::checkError(retcod,"Write_ADC_CalParams_0x20",handle);
-
-  // write offset
-  retcod = WriteSPIRegister(handle, ch, 0x20, CalParams[0]);
-  retcod = WriteSPIRegister(handle, ch, 0x21, CalParams[1]);
-  retcod = WriteSPIRegister(handle, ch, 0x26, CalParams[2]);
-  retcod = WriteSPIRegister(handle, ch, 0x27, CalParams[3]);
-  
-  // write gain
-  retcod = WriteSPIRegister(handle, ch, 0x22, CalParams[4]);
-  retcod = WriteSPIRegister(handle, ch, 0x23, CalParams[5]);
-  retcod = WriteSPIRegister(handle, ch, 0x24, CalParams[6]);
-  retcod = WriteSPIRegister(handle, ch, 0x28, CalParams[7]);
-  retcod = WriteSPIRegister(handle, ch, 0x29, CalParams[8]);
-  retcod = WriteSPIRegister(handle, ch, 0x2A, CalParams[9]);
-  
-  // write skew
-  retcod = WriteSPIRegister(handle, ch, 0x70, CalParams[10]);
-  
-  // Update parameters
-  retcod = WriteSPIRegister(handle, ch, 0xFE, 0x01);
-  retcod = WriteSPIRegister(handle, ch, 0xFE, 0x00);
-  
-}
-
-// Animesh add ends
-
-// GVS: new ConfigureSelfTriggerMode() function
- void sbndaq::CAENV1730Readout::ConfigureSelfTriggerMode()
-{
-  CAEN_DGTZ_ErrorCode retcod = CAEN_DGTZ_Success;
-
-  retcod = CAEN_DGTZ_SetChannelSelfTrigger(fHandle,
-					   (CAEN_DGTZ_TriggerMode_t)fCAEN.selfTrgMode,
-					   fCAEN.selfTrgMask);
-  sbndaq::CAENDecoder::checkError(retcod,"SetChannelSelfTriggerMode",fBoardID);
-  
-
-  // GVS: the following configuration parameters are for SBND. fCAEN.modeLVDS must be
-  if(fCAEN.modeLVDS==0){ 
-  
-     uint32_t data, data2, bitpair, readBack, aux, aux2;
-  
-     // GVS: verify the SelfTrigger values set in each channel.
-     for(uint32_t chn=0; chn<fNChannels; ++chn){
-         retcod = CAEN_DGTZ_GetChannelSelfTrigger(fHandle, chn, (CAEN_DGTZ_TriggerMode_t *)&readBack);
-         sbndaq::CAENDecoder::checkError(retcod,"GetChannelSelfTriggerMode",fBoardID);
-         CheckReadback("ChannelSelfTriggerMode", fBoardID, fCAEN.selfTrgMode, readBack, chn);
-
-    
-        // GVS: inserted triggerLogic for each PAIR of channels.
-        if(chn%2==0){
-      
-           retcod = CAEN_DGTZ_ReadRegister(fHandle,SLF_TRG_LG_CH+(chn<<8),&aux);
-           TLOG_ARB(TCONFIG,TRACE_NAME) << "Self-trigger logic to channel " << chn << " old value " << std::hex << aux << std::dec;
-
-           TLOG_ARB(TCONFIG,TRACE_NAME) << "Set channels " << chn << "/" << chn+1 << " self trigger logic to " << fCAEN.triggerLogic
-				       /* << " self trigger pulse type to " << fCAEN.ovthValue*/ << TLOG_ENDL;
-           retcod = CAEN_DGTZ_WriteRegister(fHandle,SLF_TRG_LG_CH+(chn<<8),
-					(fCAEN.triggerLogic & 0x3)/* + ((fCAEN.ovthValue & 0x1) <<2)*/);
-
-           sbndaq::CAENDecoder::checkError(retcod,"SelfTriggerPulseType",fBoardID);
-           retcod = CAEN_DGTZ_ReadRegister(fHandle,SLF_TRG_LG_CH+(chn<<8),&aux2);
-      
-           TLOG_ARB(TCONFIG,TRACE_NAME) << "Self-trigger logic to channel " << chn << " new value " << std::hex << aux2 << std::dec;
-           CheckReadback("SelfTriggerPulseType", fBoardID, aux2, (fCAEN.triggerLogic & 0x3) /*+ ((fCAEN.ovthValue & 0x1) <<2)*/,chn);
-        }
-     }
-  
-   
-     // GVS: read TRG_OUT register to monitor enabled/disabled pair of channels.
-     retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_TRG_OUT_CONTROL, &bitpair);
-     TLOG_ARB(TCONFIG,TRACE_NAME) << "Front Panel TRG-OUT address 0x8110, value: 0x" << std::hex << bitpair << std::dec;
-				    
-
-
-     /* Set Majority Mode and Majority Coincidence Window */
-     retcod = CAEN_DGTZ_ReadRegister(fHandle, GLB_TRG_MASK, &data);
-     TLOG_ARB(TCONFIG,TRACE_NAME) << "Global Trigger Mask address 0x810C, old value: 0x" << std::hex << data << std::dec;
-  
-     TLOG_ARB(TCONFIG,TRACE_NAME)  << " Set Majority Level to " << fCAEN.majorityLevel << TLOG_ENDL;
-     TLOG_ARB(TCONFIG,TRACE_NAME)  << " Set Maj Coincidence Window to " << fCAEN.majorityCoincidenceWindow << TLOG_ENDL;
-				   
-     data |= ((fCAEN.majorityLevel & 0x7)<<24) + ((fCAEN.majorityCoincidenceWindow & 0xF) <<20);
-				   
-     retcod = CAEN_DGTZ_WriteRegister(fHandle,GLB_TRG_MASK, data);
-
-     sbndaq::CAENDecoder::checkError(retcod,"SetMajCoincWindow",fBoardID);
-     retcod = CAEN_DGTZ_ReadRegister(fHandle,GLB_TRG_MASK,&data2);
-      
-     TLOG_ARB(TCONFIG,TRACE_NAME) << "Global Trigger Mask address 0x810C, new value: 0x" << std::hex << data2 << std::dec;
-     CheckReadback("SetMajCoincWindow", fBoardID, data, data2);
-  }
-}
-
-void sbndaq::CAENV1730Readout::ConfigureClkToTrgOut()
-{
-  /* Check to output ONLY CLK OR CLK PHASE */
-  if ( fCAEN.outputClk && fCAEN.outputClkPhase ){
-    TLOG(TLVL_ERROR) << "Error configuring output clock: Cannot output clock and its phase at the same time." << std::endl;
-    abort();
-  } 
-
-  CAEN_DGTZ_ErrorCode retcod = CAEN_DGTZ_Success;
-  uint32_t data;
-
-  /* Check the output of the 0x811C */
-  retcod = CAEN_DGTZ_ReadRegister(fHandle,FP_IO_CONTROL, &data);
-  sbndaq::CAENDecoder::checkError(retcod,"ClkToTrgOutCheckError",fBoardID);
-
-  uint32_t value16 = 0x1; 
-  uint32_t value18 = 0x0;
-  if (fCAEN.outputClk) value18 = 0x1;
-  if (fCAEN.outputClkPhase) value18 = 0x2;
-  data |= ((value16 & 0x3)<<16) + ((value18 &0x3)<<18);
-
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_IO_CONTROL, data);
-  sbndaq::CAENDecoder::checkError(retcod,"ClkToTrgOutCheckError",fBoardID);
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "Front Panel IO Control address 0x811C, new value: 0x" << std::hex << data << std::dec;
-  TLOG(TINFO) << "Front Panel IO Control address 0x811C, new value: 0x" << std::hex << data << std::dec;
-}
-
-void sbndaq::CAENV1730Readout::ConfigureLVDS()
-{
-  CAEN_DGTZ_ErrorCode retcod = CAEN_DGTZ_Success;
-  uint32_t data,readBack,ioMode;
-
-  // Always set output to "New LVDS features"
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_IO_CONTROL, &ioMode);
-  sbndaq::CAENDecoder::checkError(retcod,"ReadFPOutputConfig",fBoardID);
-
-  // Construct mode mask
-  data = fCAEN.modeLVDS | (fCAEN.modeLVDS << 4) | (fCAEN.modeLVDS << 8) | (fCAEN.modeLVDS << 12);
-  TLOG(TINFO) << "ModelLVDS: 0x" << 
-      std::hex << data << std::dec;
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_CONTROL, data);
-  sbndaq::CAENDecoder::checkError(retcod,"WriteLVDSOutputConfig",fBoardID);
-
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_CONTROL, &readBack);
-  sbndaq::CAENDecoder::checkError(retcod,"ReadLVDSOutputConfig",fBoardID);
-
-  CheckReadback("LVDSOutputConfig", fBoardID, data, readBack);
-
-  // If TRIGGER mode, send them out TRG-OUT NIM
-  if ( fCAEN.modeLVDS == LVDS_TRIGGER )
-  {
-    retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_TRG_OUT_CONTROL, &data);
-    sbndaq::CAENDecoder::checkError(retcod,"ReadTRGOutputConfig",fBoardID);
-
-    //    data |= ( ENABLE_LVDS_TRIGGER | ENABLE_TRG_OUT );
-    // wes and bill commenting out 10/14/2020 to get DaisyChain to work
-    //data |= ( ENABLE_TRG_OUT );
-    //data &= ~ TRIGGER_LOGIC ; // Choose OR Logic
-
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_TRG_OUT_CONTROL, data);
-    sbndaq::CAENDecoder::checkError(retcod,"WriteTRGOutputConfig",fBoardID);
-
-    retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_TRG_OUT_CONTROL, &readBack);
-    sbndaq::CAENDecoder::checkError(retcod,"ReadTRGOutputConfig",fBoardID);
-    
-    TLOG(TINFO) << "TrgOutputConfig: 0x" << 
-      std::hex << data << std::dec;
-    CheckReadback("TRGOutputConfig", fBoardID, data, readBack);
-
-    // Put LVDS into OUTPUT mode and send to TRG-OUT
-    ioMode |= (LVDS_IO | ENABLE_NEW_LVDS);
-    ioMode &= ~DISABLE_TRG_OUT_LEMO ;
-  }
-  else
-  {
-    // Put LVDS into INPUT mode
-    ioMode &= ~(LVDS_IO | DISABLE_TRG_OUT_LEMO);
-  }
-
-  if ( fCAEN.trigInLevel )
-  {
-    ioMode |= TRG_IN_LEVEL;
-  }
-  else
-  {
-    ioMode &= ~(TRG_IN_LEVEL);
-  }
-
-  TLOG(TINFO) << "FPOutputConfig: 0x" << 
-    std::hex << ioMode << std::dec;
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_IO_CONTROL, ioMode);
-  sbndaq::CAENDecoder::checkError(retcod,"WriteFPOutputConfig",fBoardID);
-
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_IO_CONTROL, &readBack);
-  sbndaq::CAENDecoder::checkError(retcod,"ReadFPOutputConfig",fBoardID);
-
-  CheckReadback("FPOutputConfig", fBoardID, ioMode, readBack);
-
-  //Animesh & Aiwu add - to set/read registers for LVDS logic values setting
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G1, fCAEN.LVDSLogicValue[0]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G2, fCAEN.LVDSLogicValue[1]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G3, fCAEN.LVDSLogicValue[2]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G4, fCAEN.LVDSLogicValue[3]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G5, fCAEN.LVDSLogicValue[4]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G6, fCAEN.LVDSLogicValue[5]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G7, fCAEN.LVDSLogicValue[6]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G8, fCAEN.LVDSLogicValue[7]);
-
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G1, &readBack);
-  TLOG(TINFO) << "LVDS Logic for G1: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G2, &readBack);
-  TLOG(TINFO) << "LVDS  Logic for G2: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G3, &readBack);
-  TLOG(TINFO) << "LVDS  Logic for G3: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G4, &readBack);
-  TLOG(TINFO) << "LVDS  Logic for G4: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G5, &readBack);
-  TLOG(TINFO) << "LVDS  Logic for G5: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G6, &readBack);
-  TLOG(TINFO) << "LVDS  Logic for G6: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G7, &readBack);
-  TLOG(TINFO) << "LVDS  Logic for G7: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G8, &readBack);
-  TLOG(TINFO) << "LVDS  Logic for G8: 0x" << std::hex << readBack << std::dec;
-  //Animesh & Aiwu add ends
-
-  //Animesh & Aiwu add - to set/read registers for LVDS output width values setting
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch1, fCAEN.LVDSOutWidth[0]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch2, fCAEN.LVDSOutWidth[1]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch3, fCAEN.LVDSOutWidth[2]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch4, fCAEN.LVDSOutWidth[3]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch5, fCAEN.LVDSOutWidth[4]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch6, fCAEN.LVDSOutWidth[5]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch7, fCAEN.LVDSOutWidth[6]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch8, fCAEN.LVDSOutWidth[7]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch9, fCAEN.LVDSOutWidth[8]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch10, fCAEN.LVDSOutWidth[9]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch11, fCAEN.LVDSOutWidth[10]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch12, fCAEN.LVDSOutWidth[11]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch13, fCAEN.LVDSOutWidth[12]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch14, fCAEN.LVDSOutWidth[13]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch15, fCAEN.LVDSOutWidth[14]);
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_OutWidth_Ch16, fCAEN.LVDSOutWidth[15]);
-  
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch1, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch1: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch2, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch2: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch3, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch3: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch4, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch4: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch5, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch5: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch6, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch6: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch7, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch7: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch8, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch8: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch9, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch9: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch10, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch10: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch11, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch11: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch12, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch12: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch13, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch13: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch14, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch14: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch15, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch15: 0x" << std::hex << readBack << std::dec;
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_OutWidth_Ch16, &readBack);
-  TLOG(TINFO) << "LVDS  Logic output width for Ch16: 0x" << std::hex << readBack << std::dec;
-  //Animesh & Aiwu add ends
-
-  //Animesh & Aiwu add - test self trigger polarity
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, BOARD_CONFIG_READ, fCAEN.selfTrgBit);
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, BOARD_CONFIG_READ, &readBack);
-  TLOG(TINFO) << "Address 0x8000, values inside: 0x" << std::hex << readBack << std::dec;
-  //Animesh & Aiwu end
-}
-
-void sbndaq::CAENV1730Readout::ConfigureRecordFormat()
-{
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureRecordFormat()" << TLOG_ENDL;
-  CAEN_DGTZ_ErrorCode retcode;
-  uint32_t readback;
-
-  //channel masks for readout(?)
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetChannelEnableMask " << fCAEN.channelEnableMask << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SetChannelEnableMask(fHandle,fCAEN.channelEnableMask);
-  sbndaq::CAENDecoder::checkError(retcode,"SetChannelEnableMask",fBoardID);
-  retcode = CAEN_DGTZ_GetChannelEnableMask(fHandle,&readback);
-  sbndaq::CAENDecoder::checkError(retcode,"GetChannelEnableMask",fBoardID);
-  CheckReadback("CHANNEL_ENABLE_MASK", fBoardID, fCAEN.channelEnableMask, readback);
-
-  //record length
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetRecordLength " << fCAEN.recordLength << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SetRecordLength(fHandle,fCAEN.recordLength);
-  sbndaq::CAENDecoder::checkError(retcode,"SetRecordLength",fBoardID);
-  retcode = CAEN_DGTZ_GetRecordLength(fHandle,&readback);
-  sbndaq::CAENDecoder::checkError(retcode,"GetRecordLength",fBoardID);
-  CheckReadback("RECORD_LENGTH", fBoardID, fCAEN.recordLength, readback);
-
-  //post trigger size
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetPostTriggerSize " << (unsigned int)(fCAEN.postPercent) << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SetPostTriggerSize(fHandle,(unsigned int)(fCAEN.postPercent));
-  sbndaq::CAENDecoder::checkError(retcode,"SetPostTriggerSize",fBoardID);
-  retcode = CAEN_DGTZ_GetPostTriggerSize(fHandle,&readback);
-  sbndaq::CAENDecoder::checkError(retcode,"GetPostTriggerSize",fBoardID);
-  CheckReadback("POST_TRIGGER_SIZE", fBoardID, fCAEN.postPercent, readback);
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureRecordFormat() done." << TLOG_ENDL;
-}
-
-//Taken from wavedump
-//  handle : Digitizer handle
-//  address: register address
-//  data   : value to write to register
-//  bitmask: bitmask to override only the bits that need to change while leaving the rest unchanged
-CAEN_DGTZ_ErrorCode sbndaq::CAENV1730Readout::WriteRegisterBitmask(int32_t handle, uint32_t address, 
-								   uint32_t data, uint32_t bitmask) 
-{
-  //int32_t ret = CAEN_DGTZ_Success;
-  CAEN_DGTZ_ErrorCode  ret = CAEN_DGTZ_Success;
-  uint32_t d32 = 0xFFFFFFFF;
-  uint32_t d32Out;
-
-  ret = CAEN_DGTZ_ReadRegister(handle, address, &d32);
-  if(ret != CAEN_DGTZ_Success){
-    TLOG(TLVL_ERROR) << "Failed reading a register; address=0x" << std::hex << address;
-    abort();
-  }
-
-  data &= bitmask;
-  d32 &= ~bitmask;
-  d32 |= data;
-  ret = CAEN_DGTZ_WriteRegister(handle, address, d32);
-
-  if(ret != CAEN_DGTZ_Success) {
-    TLOG(TLVL_ERROR) << "Failed writing a register; address=0x" << std::hex << address;
-    abort();
-  }
-
-  ret = CAEN_DGTZ_ReadRegister(handle, address, &d32Out);
-  if(ret != CAEN_DGTZ_Success){
-    TLOG(TLVL_ERROR) << "Failed reading a register; address=0x" << std::hex << address
-                     << ", value=" << std::bitset<32>(d32) << ", bitmask=" << std::bitset<32>(bitmask);
-    abort();
-  }
-
-  if( d32 != d32Out ) {
-    TLOG(TLVL_ERROR) << "Read and write values disagree; address=0x" << std::hex << address
-                     <<", read value=" << std::bitset<32>(d32Out) << ", write value="<< std::bitset<32>(d32)
-                     << ", bitmask="<< std::bitset<32>(bitmask);
-    abort();
-  }
-
-  return ret;
-}
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
 void sbndaq::CAENV1730Readout::ConfigureDataBuffer()
 {
@@ -823,193 +781,33 @@ void sbndaq::CAENV1730Readout::ConfigureDataBuffer()
 
   CAEN_DGTZ_ErrorCode retcode;
 
+  // sets maximum number of events to be transferred
   retcode = CAEN_DGTZ_SetMaxNumEventsBLT(fHandle,fCAEN.maxEventsPerTransfer);
-  sbndaq::CAENDecoder::checkError(retcode,"SetMaxNumEventsBLT",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcode,"SetMaxNumEventsBLT",fCAEN.fragmentId);
 
-  //we do this shenanigans so we can get the BufferSize. We then allocate our own...
+  // we do this shenanigans so we can get the BufferSize. We then allocate our own...
+  // first, calls CAEN API to allocate a temporary readout buffer
   char* myBuffer=NULL;
   retcode = CAEN_DGTZ_MallocReadoutBuffer(fHandle,&myBuffer,&fBufferSize);
-  sbndaq::CAENDecoder::checkError(retcode,"MallocReadoutBuffer",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcode,"MallocReadoutBuffer",fCAEN.fragmentId);
   
+  // now we got its buffer size, allocate our own
   fBuffer.reset(new uint16_t[fBufferSize/sizeof(uint16_t)]);
+  TLOG_ARB(TSTART,TRACE_NAME) << "Created Buffer of size " << fBufferSize << TLOG_ENDL;  
 
-  TLOG_ARB(TSTART,TRACE_NAME) << "Created Buffer of size " << fBufferSize << std::endl << TLOG_ENDL;  
-
+  // free the temporary buffer allocated by CAEN
   retcode = CAEN_DGTZ_FreeReadoutBuffer(&myBuffer);
-  sbndaq::CAENDecoder::checkError(retcode,"FreeReadoutBuffer",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcode,"FreeReadoutBuffer",fCAEN.fragmentId);
 
-  TLOG_ARB(TSTART,TRACE_NAME) << "Configuring Circular Buffer of size " << fCAEN.poolBufferSize << TLOG_ENDL;
+  // now we prepare the pool buffer on the boardreader side
+  // single block size is CAEN buffer size
+  TLOG_ARB(TSTART,TRACE_NAME) << "Configuring PoolBuffer of size " << fCAEN.poolBufferSize << TLOG_ENDL;
   fPoolBuffer.allocate(fBufferSize,fCAEN.poolBufferSize,true);
   fPoolBuffer.debugInfo();
 
+  // lock a mutex protecting fTimestampMap and clear it
   std::lock_guard<std::mutex> lock(fTimestampMapMutex);
   fTimestampMap.clear();
-}
-
-void sbndaq::CAENV1730Readout::ConfigureTrigger()
-{
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureTrigger()" << TLOG_ENDL;
-
-  CAEN_DGTZ_ErrorCode retcode;
-  uint32_t readback;
-  uint32_t addr;
-
-  //set the trigger configurations
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetSWTriggerMode" << fCAEN.swTrgMode << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SetSWTriggerMode(fHandle,(CAEN_DGTZ_TriggerMode_t)(fCAEN.swTrgMode));
-  sbndaq::CAENDecoder::checkError(retcode,"SetSWTriggerMode",fBoardID);
-  retcode = CAEN_DGTZ_GetSWTriggerMode(fHandle,(CAEN_DGTZ_TriggerMode_t *)&readback);
-  CheckReadback("SetSWTriggerMode", fBoardID,fCAEN.swTrgMode,readback);
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetExtTriggerMode" << fCAEN.extTrgMode << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SetExtTriggerInputMode(fHandle,(CAEN_DGTZ_TriggerMode_t)(fCAEN.extTrgMode));
-  sbndaq::CAENDecoder::checkError(retcode,"SetExtTriggerInputMode",fBoardID);
-  retcode = CAEN_DGTZ_GetExtTriggerInputMode(fHandle,(CAEN_DGTZ_TriggerMode_t *)&readback);
-  CheckReadback("SetExtTriggerInputMode", fBoardID,fCAEN.extTrgMode,readback);
-
-  for(uint32_t ch=0; ch<fNChannels; ++ch)
-  {
-
-    TLOG_ARB(TCONFIG,TRACE_NAME) << "Set channel " << ch
-				 << " trigger threshold to " << fCAEN.triggerThresholds[ch] << TLOG_ENDL;
-    retcode = CAEN_DGTZ_SetChannelTriggerThreshold(fHandle,ch,fCAEN.triggerThresholds[ch]); //0x8000
-    sbndaq::CAENDecoder::checkError(retcode,"SetChannelTriggerThreshold",fBoardID);
-    retcode = CAEN_DGTZ_GetChannelTriggerThreshold(fHandle,ch,&readback);
-    CheckReadback("SetChannelTriggerThreshold",fBoardID,fCAEN.triggerThresholds[ch],readback);
-
-    //GVS: the following configuration parameters are for SBND. fCAEN.modeLVDS must be 0
-      if(fCAEN.modeLVDS==0){
-      TLOG_ARB(TCONFIG,TRACE_NAME) << "Set Trigger Polarity " << fCAEN.triggerPolarity << " to channel: " << ch << TLOG_ENDL;
-      retcode = CAEN_DGTZ_SetTriggerPolarity(fHandle, ch,(CAEN_DGTZ_TriggerPolarity_t)(fCAEN.triggerPolarity));
-      sbndaq::CAENDecoder::checkError(retcode,"SetTriggerPolarity",fBoardID);
-      retcode = CAEN_DGTZ_GetTriggerPolarity(fHandle, ch,(CAEN_DGTZ_TriggerPolarity_t *)&readback);
-      CheckReadback("SetTriggerPolarity", fBoardID,fCAEN.triggerPolarity,readback, ch);
-
-    
-      //GVS: pulse width must be set per channel, not per pair of channel. This contradicts what manual says!
-      TLOG_ARB(TCONFIG,TRACE_NAME) << "Set channels " << ch << " trigger pulse width to " << fCAEN.triggerPulseWidth << TLOG_ENDL;
-      retcode = CAEN_DGTZ_WriteRegister(fHandle,TRG_OUT_WIDTH_CH+(ch<<8),fCAEN.triggerPulseWidth);
-      sbndaq::CAENDecoder::checkError(retcode,"SetChannelTriggerPulseWidth",fBoardID);
-      retcode = CAEN_DGTZ_ReadRegister(fHandle,TRG_OUT_WIDTH_CH+(ch<<8),&readback);
-      CheckReadback("SetChannelTriggerPulseWidth",fBoardID,fCAEN.triggerPulseWidth,readback, ch);
-
-      //pulse width only set in pairs, but doesn't hurt to do it for all channels I guess
-      /* TLOG_ARB(TCONFIG,TRACE_NAME) << "Set channels " << ch << "/" << ch+1 
-				   << " trigger pulse width to " << (int)(fCAEN.triggerPulseWidth) << TLOG_ENDL;
-      retcode = CAEN_DGTZ_WriteRegister(fHandle,0x1070+(ch<<8),fCAEN.triggerPulseWidth);
-      sbndaq::CAENDecoder::checkError(retcode,"SetChannelTriggerPulseWidth",fBoardID);
-      retcode = CAEN_DGTZ_ReadRegister(fHandle,0x1070+(ch<<8),&readback);
-      CheckReadback("SetChannelTriggerPulseWidth",fBoardID,fCAEN.triggerPulseWidth,readback); */
-    }
-  }
-
-  // for ICARUS
-  if(fCAEN.modeLVDS!=0){ ConfigureLVDS();  }
-	
-  // for clock synchronization studies
-  if( fCAEN.outputClk || fCAEN.outputClkPhase ){ ConfigureClkToTrgOut(); } 
-
-  ConfigureSelfTriggerMode();
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetTriggerMode" << fCAEN.extTrgMode << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SetExtTriggerInputMode(fHandle,(CAEN_DGTZ_TriggerMode_t)(fCAEN.extTrgMode));
-  sbndaq::CAENDecoder::checkError(retcode,"SetExtTriggerInputMode",fBoardID);
-  retcode = CAEN_DGTZ_GetExtTriggerInputMode(fHandle,(CAEN_DGTZ_TriggerMode_t *)&readback);
-  CheckReadback("SetExtTriggerInputMode", fBoardID,fCAEN.extTrgMode,readback);  
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetTriggerOverlap" << fCAEN.allowTriggerOverlap << TLOG_ENDL;
-  if ( fCAEN.allowTriggerOverlap )
-  {
-    addr = BOARD_CONFIG_SET;
-  }
-  else
-  {
-    addr = BOARD_CONFIG_CLEAR;
-  }
-  retcode = CAEN_DGTZ_WriteRegister(fHandle, addr, TRIGGER_OVERLAP_MASK);
-  sbndaq::CAENDecoder::checkError(retcode,"SetTriggerOverlap",fBoardID);
-
-  //level=1 for TTL, =0 for NIM
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetIOLevel " << (CAEN_DGTZ_IOLevel_t)(fCAEN.ioLevel) << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SetIOLevel(fHandle,(CAEN_DGTZ_IOLevel_t)(fCAEN.ioLevel));
-  sbndaq::CAENDecoder::checkError(retcode,"SetIOLevel",fBoardID);
-  retcode = CAEN_DGTZ_GetIOLevel(fHandle,(CAEN_DGTZ_IOLevel_t *)&readback);
-  CheckReadback("SetIOLevel", fBoardID,fCAEN.ioLevel,readback);
-
-}
-
-void sbndaq::CAENV1730Readout::ConfigureReadout()
-{
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureReadout()" << TLOG_ENDL;
-
-  CAEN_DGTZ_ErrorCode retcode;
-  uint32_t readback;
-  uint32_t addr,mask;
-  uint32_t value=0;
-  
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetRunSyncMode " << (CAEN_DGTZ_RunSyncMode_t)(fCAEN.runSyncMode) << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SetRunSynchronizationMode(fHandle,
-						(CAEN_DGTZ_RunSyncMode_t)(fCAEN.runSyncMode));
-  sbndaq::CAENDecoder::checkError(retcode,"SetRunSynchronizationMode",fBoardID);
-  retcode = CAEN_DGTZ_GetRunSynchronizationMode(fHandle,(CAEN_DGTZ_RunSyncMode_t*)&readback);
-  CheckReadback("SetRunSynchronizationMode",fBoardID,fCAEN.runSyncMode,readback);
-  
-  mask = ( 1 << TEST_PATTERN_t::TEST_PATTERN_S );
-  addr = (fCAEN.testPattern)
-    ? CAEN_DGTZ_BROAD_CH_CONFIGBIT_SET_ADD
-    : CAEN_DGTZ_BROAD_CH_CLEAR_CTRL_ADD;
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetTestPattern addr=" << addr << ", mask=" << mask << TLOG_ENDL;
-  retcode = CAEN_DGTZ_WriteRegister(fHandle,addr,mask);
-  sbndaq::CAENDecoder::checkError(retcode,"SetTestPattern",fBoardID);
-
-  //Global Registers
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetDyanmicRange " << fCAEN.dynamicRange << TLOG_ENDL;
-  mask = (uint32_t)(fCAEN.dynamicRange);
-  addr = DYNAMIC_RANGE;
-  retcode = CAEN_DGTZ_WriteRegister(fHandle,addr,mask);
-  sbndaq::CAENDecoder::checkError(retcode,"SetDynamicRange",fBoardID);
-
-  addr = ACQ_CONTROL;
-  retcode = CAEN_DGTZ_WriteRegister(fHandle,addr,uint32_t{0x28});
-  sbndaq::CAENDecoder::checkError(retcode,"SetTriggerMode",fBoardID);
-  retcode = CAEN_DGTZ_ReadRegister(fHandle,addr,&value);
-  sbndaq::CAENDecoder::checkError(retcode,"GetTriggerMode",fBoardID);
-
-  TLOG(TCONFIG) << "CAEN_DGTZ_ReadRegister addr=" << std::hex << addr << ", returned value=" << std::bitset<32>(value) ; 
-
-  for(uint32_t ch=0; ch<fNChannels; ++ch){
-    TLOG_ARB(TCONFIG,TRACE_NAME) << "Set channel " << ch << " DC offset to " << fCAEN.pedestal[ch] << TLOG_ENDL;
-    retcode = CAEN_DGTZ_SetChannelDCOffset(fHandle,ch,fCAEN.pedestal[ch]);
-    sbndaq::CAENDecoder::checkError(retcode,"SetChannelDCOffset",fBoardID);
-    retcode = CAEN_DGTZ_GetChannelDCOffset(fHandle,ch,&readback);
-    CheckReadback("SetChannelDCOffset",fBoardID,fCAEN.pedestal[ch],readback,ch);
-  }
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureReadout() done." << TLOG_ENDL;
-}
-
-void sbndaq::CAENV1730Readout::ConfigureAcquisition()
-{
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureAcquisition()" << TLOG_ENDL;
-
-  CAEN_DGTZ_ErrorCode retcode;
-  uint32_t readback;
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetAcqMode " << (CAEN_DGTZ_AcqMode_t)(fCAEN.acqMode) << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SetAcquisitionMode(fHandle,(CAEN_DGTZ_AcqMode_t)(fCAEN.acqMode));
-  sbndaq::CAENDecoder::checkError(retcode,"SetAcquisitionMode",fBoardID);
-  retcode = CAEN_DGTZ_GetAcquisitionMode(fHandle,(CAEN_DGTZ_AcqMode_t*)&readback);
-  CheckReadback("SetAcquisitionMode",fBoardID,fCAEN.acqMode,readback);
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "SetAnalogMonOutputMode " << (CAEN_DGTZ_AnalogMonitorOutputMode_t)(fCAEN.analogMode) << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SetAnalogMonOutput(fHandle,(CAEN_DGTZ_AnalogMonitorOutputMode_t)(fCAEN.analogMode));
-  sbndaq::CAENDecoder::checkError(retcode,"SetAnalogMonOutputMode",fBoardID);
-  
-  // GetAnalogMonOutput function does not work for V1730s, use register access instead
-  retcode = CAEN_DGTZ_ReadRegister(fHandle,CAEN_DGTZ_MON_MODE_ADD,&readback);
-  CheckReadback("SetAnalogMonOutputMode",fBoardID,fCAEN.analogMode,readback);
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureAcquisition() done." << TLOG_ENDL;
 }
 
 // ------------------------------------------------------------------------
@@ -1040,122 +838,66 @@ void sbndaq::CAENV1730Readout::CheckReadback(std::string label,
 
 void sbndaq::CAENV1730Readout::start()
 {
-
   TLOG_INFO("CAENV1730Readout") << "start()" << TLOG_ENDL;
   
+  // configure pool buffer 
   ConfigureDataBuffer();
-  last_sent_seqid = 0;
   
   if((CAEN_DGTZ_AcqMode_t)(fCAEN.acqMode)==CAEN_DGTZ_AcqMode_t::CAEN_DGTZ_SW_CONTROLLED)
-    {
-      CAEN_DGTZ_ErrorCode retcode;
-      TLOG_ARB(TSTART,TRACE_NAME) << "SWStartAcquisition" << TLOG_ENDL;
-      retcode = CAEN_DGTZ_SWStartAcquisition(fHandle);
-      sbndaq::CAENDecoder::checkError(retcode,"SWStartAcquisition",fBoardID);
-    }
+  {
+    CAEN_DGTZ_ErrorCode retcode;
+    TLOG_ARB(TSTART,TRACE_NAME) << "SWStartAcquisition" << TLOG_ENDL;
+    retcode = CAEN_DGTZ_SWStartAcquisition(fHandle);
+    sbndaq::CAENDecoder::checkError(retcode,"SWStartAcquisition",fCAEN.fragmentId);
+  }
   
+  last_sent_seqid = 0;
   fEvCounter=0;
   fOverflowCounter=0;
-  CAEN_DGTZ_ErrorCode retcod;
 
-  // Animesh add ADC registers here
-
+  // Manual calibration added by Animesh - DELETE?
+  // "its origin and purpose is still a total mistery"
+  // this overwrites ADC calibration parameters
   if (fCAEN.writeCalibration)  
-    { 
-      for ( uint32_t ch=0; ch<fNChannels; ++ch)
-        {
-          retcod = WriteSPIRegister(fHandle, ch, 0xFE, 0x00);
-          // TLOG(TINFO)<<"Write_ADC-CalParams_ch"<<ch<< ": Params[0]=" << CalParams[0]; 
-          // sbndaq::CAENDecoder::checkError(retcod,"Write_ADC_CalParams_0x20",handle);
-      
-          // write offset
-          retcod = WriteSPIRegister(fHandle, ch, 0x20, 114);
-          retcod = WriteSPIRegister(fHandle, ch, 0x21, 107);
-          retcod = WriteSPIRegister(fHandle, ch, 0x26, 122);
-          retcod = WriteSPIRegister(fHandle, ch, 0x27, 76);
-      
-          // write gain
-          retcod = WriteSPIRegister(fHandle, ch, 0x22, 14);
-          retcod = WriteSPIRegister(fHandle, ch, 0x23, 128);
-          retcod = WriteSPIRegister(fHandle, ch, 0x24, 127);
-          retcod = WriteSPIRegister(fHandle, ch, 0x28, 14);
-          retcod = WriteSPIRegister(fHandle, ch, 0x29, 135);
-          retcod = WriteSPIRegister(fHandle, ch, 0x2A, 125);
-      
-          // write skew
-          retcod = WriteSPIRegister(fHandle, ch, 0x70, 129);
-      
-          // Update parameters
-          retcod = WriteSPIRegister(fHandle, ch, 0xFE, 0x01);
-          retcod = WriteSPIRegister(fHandle, ch, 0xFE, 0x00);
-        }
-  }
-  //  Animesh ends
-  
-  uint32_t readBack;
-  
-  // Animesh Check trigger threshold here
-  
-  for(uint32_t ch=0; ch<fNChannels; ++ch)
+  { 
+    CAEN_DGTZ_ErrorCode retcod;
+    for ( uint32_t ch=0; ch<fNChannels; ++ch)
     {
-      retcod = CAEN_DGTZ_GetChannelTriggerThreshold(fHandle,ch,&readBack);
-      TLOG(TINFO) << "Trigger threshold before run start for ch " << ch << " is " << readBack << TLOG_ENDL;    
+      retcod = WriteSPIRegister(fHandle, ch, 0xFE, 0x00);      
+      // write offset
+      retcod = WriteSPIRegister(fHandle, ch, 0x20, 114);
+      retcod = WriteSPIRegister(fHandle, ch, 0x21, 107);
+      retcod = WriteSPIRegister(fHandle, ch, 0x26, 122);
+      retcod = WriteSPIRegister(fHandle, ch, 0x27, 76);
+      // write gain
+      retcod = WriteSPIRegister(fHandle, ch, 0x22, 14);
+      retcod = WriteSPIRegister(fHandle, ch, 0x23, 128);
+      retcod = WriteSPIRegister(fHandle, ch, 0x24, 127);
+      retcod = WriteSPIRegister(fHandle, ch, 0x28, 14);
+      retcod = WriteSPIRegister(fHandle, ch, 0x29, 135);
+      retcod = WriteSPIRegister(fHandle, ch, 0x2A, 125);
+      // write skew
+      retcod = WriteSPIRegister(fHandle, ch, 0x70, 129);    
+      // Update parameters
+      retcod = WriteSPIRegister(fHandle, ch, 0xFE, 0x01);
+      retcod = WriteSPIRegister(fHandle, ch, 0xFE, 0x00);
     }
-  
-  
-  // Animesh end 
-  
-  //  uint32_t readBack;
-  //Animesh & Aiwu add - to set/read registers for LVDS logic values setting
-
-  if(fCAEN.modeLVDS!=0){
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G1, fCAEN.LVDSLogicValue[0]);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G2, fCAEN.LVDSLogicValue[1]);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G3, fCAEN.LVDSLogicValue[2]);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G4, fCAEN.LVDSLogicValue[3]);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G5, fCAEN.LVDSLogicValue[4]);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G6, fCAEN.LVDSLogicValue[5]);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G7, fCAEN.LVDSLogicValue[6]);
-    retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_Logic_G8, fCAEN.LVDSLogicValue[7]);
-    
-    
-    retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G1, &readBack);
-    TLOG(TINFO) << "After Start Register for G1: 0x" <<retcod<< std::hex << readBack << std::dec;
-    retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G2, &readBack);
-    TLOG(TINFO) << " After Start Register for G2: 0x" << std::hex << readBack << std::dec;
-    retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G3, &readBack);
-    TLOG(TINFO) << " After Start Register for G3: 0x" << std::hex << readBack << std::dec;
-    retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G4, &readBack);
-    TLOG(TINFO) << " After Start Register for G4: 0x" << std::hex << readBack << std::dec;
-    retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G5, &readBack);
-    TLOG(TINFO) << " After Start Register for G5: 0x" << std::hex << readBack << std::dec;
-    retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G6, &readBack);
-    TLOG(TINFO) << " After Start Register for G6: 0x" << std::hex << readBack << std::dec;
-    retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G7, &readBack);
-    TLOG(TINFO) << "After Start Register for G7: 0x" << std::hex << readBack << std::dec;
-    retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_LVDS_Logic_G8, &readBack);
-    TLOG(TINFO) << "After Start Register for G8: 0x" << std::hex << readBack << std::dec;
   }
-
-
+    
   fTimePollBegin = boost::posix_time::microsec_clock::universal_time();
   GetData_thread_->start();
   
-  // Check the baseline values
-  for(uint32_t i_ch=0; i_ch<fNChannels; ++i_ch)
-  {
-    retcod = CAEN_DGTZ_GetChannelDCOffset(fHandle,i_ch,&readBack);
-    TLOG(TINFO)<<"DC offset or baseline before run start for Ch " << i_ch << " is " << readBack << TLOG_ENDL;    
-  }   
-
   TLOG_ARB(TSTART,TRACE_NAME) << "start() done." << TLOG_ENDL;
 }
 
 // ------------------------------------------------------------------------
 // ------------------------------------------------------------------------
 
-bool sbndaq::CAENV1730Readout::GetData() {
+// this is really the DAQ part where the server reads data from 
+// the card and stores in its internal pool buffer
 
+bool sbndaq::CAENV1730Readout::GetData()
+{
   TLOG(TGETDATA)<< "Begin of GetData()";
 
   CAEN_DGTZ_ErrorCode retcod;
@@ -1170,8 +912,7 @@ bool sbndaq::CAENV1730Readout::GetData() {
 
   // read the data from the buffer of the card
   return readWindowDataBlocks();
-
-}// CAENV1730Readout::GetData()
+}
 
 bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 
@@ -1412,8 +1153,6 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 // ------------------------------------------------------------------------
 // ------------------------------------------------------------------------
 
-// this is really the DAQ part where the server reads data from 
-// the card and stores them
 bool sbndaq::CAENV1730Readout::getNext_(artdaq::FragmentPtrs & fragments){
   if(fail_GetNext) throw std::runtime_error("Critical error; stopping boardreader process...." ) ;
   return readSingleWindowFragments(fragments);
@@ -1657,7 +1396,7 @@ void sbndaq::CAENV1730Readout::stop()
   CAEN_DGTZ_ErrorCode retcode;
   TLOG_ARB(TSTOP,TRACE_NAME) << "SWStopAcquisition" << TLOG_ENDL;
   retcode = CAEN_DGTZ_SWStopAcquisition(fHandle);
-  sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fCAEN.fragmentId);
 
   if(fBuffer != NULL){
     fBuffer.reset();

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -254,21 +254,6 @@ void sbndaq::CAENV1730Readout::RunADCCalibration()
   sbndaq::CAENDecoder::checkError(retcode,"Calibrate",fBoardID);
 }
 
-
-void CAENV1730Readout::ReadChannelBusyStatus(int handle, uint32_t ch, uint32_t& status)
-{
-
-  status = 0xdeadbeef;
-  uint32_t SPIBusyAddr = 0x1088 + (ch<<8);
-
-  auto ret = CAEN_DGTZ_ReadRegister(handle, SPIBusyAddr, &status);
-  
-  if(ret!=CAEN_DGTZ_Success)
-    TLOG(TLVL_WARNING) << "Failed reading busy status for channel " << ch;
-     
-}
-
-
 // Following SPI code is from CAEN
 CAEN_DGTZ_ErrorCode CAENV1730Readout::ReadSPIRegister(int handle, uint32_t ch, uint32_t address, uint8_t *value)
 {
@@ -1161,99 +1146,6 @@ void sbndaq::CAENV1730Readout::stop()
   TLOG_ARB(TSTOP,TRACE_NAME) << "stop() done." << TLOG_ENDL;
 }
 
-// This function is called internally by the art framework and should not be called in the boardreader itself
-// The two relevant fcl parameters are: "poll_hardware_status" (true/false) and "hardware_poll_interval_us" (period in us)
-bool sbndaq::CAENV1730Readout::checkHWStatus_(){
-
-  for(size_t ch=0; ch<CAENConfiguration::MAX_CHANNELS; ++ch)
-  {
-    std::ostringstream tempStream;
-    tempStream << "CAENV1730.Card" << fBoardID
-		  << ".Channel" << ch << ".Temp"; 
-    std::ostringstream statStream;
-    statStream << "CAENV1730.Card" << fBoardID
-		  << ".Channel" << ch << ".Status"; 
-    std::ostringstream memfullStream;
-    memfullStream << "CAENV1730.Card" << fBoardID
-		  << ".Channel" << ch << ".MemoryFull"; 
-   
-    CAEN_DGTZ_ErrorCode retcod;
-
-    if ( fCAEN.temperatureCheckMask & ( 1 << ch ) ) // Channels temperature readout enabled?
-    {
-      retcod = CAEN_DGTZ_ReadTemperature(fHandle, ch, &(ch_temps[ch]));
-      TLOG_ARB(TTEMP,TRACE_NAME) << tempStream.str()
-				 << ": " << ch_temps[ch] << "  C"
-				 << TLOG_ENDL;
-      
-      metricMan->sendMetric(tempStream.str(), int(ch_temps[ch]), "C", 11,
-			    artdaq::MetricMode::Average);
-
-      //Need 3 requirements to shut down for high temperature: 
-      // 1. Can successfully read temperature: return code = 0 since S/N 164 can fail to read temperature during acquisition
-      // 2. Temperature < non_physical temperature, 200C since S/N 164 can produce non-physical temperature
-      // 3. Temperature > Requirement , 70C for V1730 and 85C for V1730S
-      if ( retcod == CAEN_DGTZ_Success && ch_temps[ch] < V1730_UNPHYSICAL_TEMPERATURE )
-      {  
-	if ( ch_temps[ch] > fCAEN.maxTemp ) 
-	{
-	   // V1730(S) shuts down at 70(85) celsius, give a warning ahead of that
-	   TLOG(TLVL_ERROR) << "SHUTTING DOWN CAENV1730 BoardID " << fBoardID << " : "
-			     << " Channel " << ch
-			     << " temperature " << ch_temps[ch]
-			     << " > " << fCAEN.maxTemp << " degrees Celsius."
-			     << " ReadTemperature Return Code = " << retcod
-			     << TLOG_ENDL;
-	}
-      }
-      else
-      {
-	    // Ignore unphysical temperatures/bad return codes from S/N 164.  CAEN advises not to read temperatures 
-	    //   while the readout is running, but we cannot do that.  Only one sensors on one 
-	    //   V1730 has ever malfunctioned.
-	    // S/N 164 sometimes returns a non-physical temperature, ignore it and move on
-	    TLOG(TLVL_WARNING) << "CAENV1730 BoardID " << fBoardID << " : "
-			       << " Channel " << ch
-			       << " unphysical temperature " << ch_temps[ch] << " degrees Celsius."
-			       << " ReadTemperature Return Code = " << retcod
-			       << TLOG_ENDL;
-       }
-    }
-
-    ReadChannelBusyStatus(fHandle,ch,ch_status[ch]);
-    TLOG_ARB(TTEMP,TRACE_NAME) << statStream.str()
-			       << std::hex
-                               << ": 0x" << ch_status[ch]
-			       << std::dec << TLOG_ENDL;
-
-
-    if(ch_status[ch]==0xdeadbeef){
-      TLOG(TLVL_WARNING) << "Failed reading busy status for channel " << ch;
-    }
-    else{
-      metricMan->sendMetric(statStream.str(), int(ch_status[ch]), "", 11,
-			    artdaq::MetricMode::LastPoint);
-
-      metricMan->sendMetric(memfullStream.str(), int((ch_status[ch] & 0x1)), "", 11,
-			    artdaq::MetricMode::LastPoint);
-
-      /*
-      metricMan->sendMetric("MemoryEmpty", int((ch_status[ch] & 0x2)>>1), "", 1,
-			    artdaq::MetricMode::LastPoint,tempStream.str());
-
-      metricMan->sendMetric("DACBusy", int((ch_status[ch] & 0x4)>>2), "", 1,
-			    artdaq::MetricMode::LastPoint,tempStream.str());
-
-      metricMan->sendMetric("ADCPowerDown", int((ch_status[ch] & 0x100)>>8), "", 1,
-			    artdaq::MetricMode::LastPoint,tempStream.str());
-      */
-    }
-
-
-  }
-
-  return true;
-}
 
 bool sbndaq::CAENV1730Readout::GetData() {
 
@@ -1770,6 +1662,112 @@ void sbndaq::CAENV1730Readout::CheckReadback(std::string label,
   
 }
 
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
+// Checks the hardware status and sends corresponding metrics to Grafana
+// This function is called internally by the framework, no need to call it manually
+// Relevant fcl parameters are: 
+// - "poll_hardware_status" (true/false)
+// - "hardware_poll_interval_us" (interval in us)
+bool sbndaq::CAENV1730Readout::checkHWStatus_(){
+
+  // first, check the acqusition status register: CAEN_DGTZ_ACQ_STATUS_ADD
+  // this provides overall status of the board
+  uint32_t data;
+  auto ret = CAEN_DGTZ_ReadRegister(fHandle,CAEN_DGTZ_ACQ_STATUS_ADD,&data);
+  if ( ret == CAEN_DGTZ_Success ){
+    // unpacking only "interesting" values
+    bool run  = data & 0x0004; // is running?
+    bool full = data & 0x0010; // is busy?
+    bool shut = data & 0x80000; // is shutting down? 
+
+    metricMan->sendMetric("Running", int(run), "", 11, artdaq::MetricMode::LastPoint);
+    metricMan->sendMetric("Busy", int(full), "", 11, artdaq::MetricMode::LastPoint);
+    metricMan->sendMetric("Shutdown", int(shut), "", 11, artdaq::MetricMode::LastPoint);
+
+  } else {
+    TLOG(TLVL_WARNING) << "(FragID=" << fCAEN.fragmentId << ") "
+                       << "Failed reading CAEN_DGTZ_ACQ_STATUS_ADD register!";
+  } 
+
+  // second, check individual channel status
+  // this provides temperature reading + channel memory full
+  for(size_t ch=0; ch<CAENConfiguration::MAX_CHANNELS; ++ch)
+  {
+    std::ostringstream tempStream; 
+    tempStream << "Channel" << ch << ".Temp"; 
+    
+    std::ostringstream memfullStream;
+    memfullStream << "Channel" << ch << ".MemoryFull"; 
+   
+    CAEN_DGTZ_ErrorCode retcod;
+
+    // temperature readout enabled for this channel?
+    if ( fCAEN.temperatureCheckMask & ( 1 << ch ) ) 
+    {
+      retcod = CAEN_DGTZ_ReadTemperature(fHandle, ch, &(ch_temps[ch]));
+      TLOG_ARB(TTEMP,TRACE_NAME) << "(fragID=" << fCAEN.fragmentId << ")"
+         << tempStream.str() << ": " 
+         << ch_temps[ch] << "  C"
+				 << TLOG_ENDL;
+      
+      metricMan->sendMetric(tempStream.str(), int(ch_temps[ch]), "C", 11, artdaq::MetricMode::Average);
+
+      // Need 2 requirements for measurement to be meaningfull 
+      // 1. Can successfully read temperature: return code = 0 since S/N 164 can fail to read temperature during acquisition
+      // 2. Temperature < non_physical temperature, 200C since S/N 164 can produce non-physical temperature
+      if ( retcod == CAEN_DGTZ_Success && ch_temps[ch] < V1730_UNPHYSICAL_TEMPERATURE )
+      {
+        // V1730(S) shuts down at 70(85) celsius, give a error ahead of that
+        // threshold temperature is set via fhicl parameter
+        if ( ch_temps[ch] > fCAEN.maxTemp ) {
+          TLOG(TLVL_ERROR) << "SHUTTING DOWN CAENV1730 fragID=" << fCAEN.fragmentId << " : "
+			     << " Channel " << ch
+			     << " temperature " << ch_temps[ch]
+			     << " > " << fCAEN.maxTemp << " degrees Celsius."
+			     << " ReadTemperature Return Code = " << retcod
+			     << TLOG_ENDL;
+          } 
+      } else {
+        // Ignore unphysical temperatures/bad return codes from S/N 164.
+        // CAEN advises not to read temperatures while the readout is running, but we cannot do that.
+        // Only one sensors on one V1730 has ever malfunctioned.
+        // S/N 164 sometimes returns a non-physical temperature, ignore it and move on
+        TLOG(TLVL_WARNING) << "CAENV1730 fragID=" << fCAEN.fragmentId << " : "
+			   << " Channel " << ch
+			   << " unphysical temperature " << ch_temps[ch] << " degrees Celsius."
+			   << " ReadTemperature Return Code = " << retcod
+			   << TLOG_ENDL;
+      }
+    }
+
+    // now check if channel memory is full
+    uint32_t CHANNEL_STATUS_ADD = 0x1088 + (ch<<8);
+    retcod = CAEN_DGTZ_ReadRegister(handle, CHANNEL_STATUS_ADD, &(ch_status[ch]));
+
+    if(retcod == CAEN_DGTZ_Success){
+      // unpack only memory full status
+      bool full = ch_status[ch] & 0x1;
+
+      TLOG_ARB(TTEMP,TRACE_NAME) << "(fragID=" << fCAEN.fragmentId << ")"
+         << memfullStream.str() << ": " 
+         << int(full) << TLOG_ENDL;
+
+      metricMan->sendMetric(memfullStream.str(), int(full), "", 11, artdaq::MetricMode::LastPoint);
+    } else {
+      TLOG(TLVL_WARNING) << "(FragID=" << fCAEN.fragmentId << ") "
+                         << "Failed reading CHANNEL_STATUS register for channel " << ch;
+    }
+  } //end channel loop
+  return true;
+}
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
+// this function queries software and board information
+// board S/N + firmware, CAEN libraries versions, VME bridge firmware/driver
 void sbndaq::CAENV1730Readout::GetSWInfo(){
 
   int retcod=0;
@@ -1832,5 +1830,8 @@ void sbndaq::CAENV1730Readout::GetSWInfo(){
     CAENVME_End(BHandle);
   }
 }
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
 DEFINE_ARTDAQ_COMMANDABLE_GENERATOR(sbndaq::CAENV1730Readout)

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -21,15 +21,16 @@
 
 using namespace sbndaq;
 
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
 // Constructor of the CAENV1730Readout.
 // All configuration parameters are loaded and stored in CAENConfiguration.
 // Connection is opened, board is reset and Configure() is called.
-
 sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   CommandableFragmentGenerator(ps),
   fCAEN(ps)
 {
-
   TLOG_ARB(TCONFIG,TRACE_NAME) << "CAENV1730Readout()" << TLOG_ENDL;
 
   // print-out all configuration parameters
@@ -45,55 +46,77 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   fNChannels = fCAEN.nChannels;
   fBoardID = fCAEN.boardId;
 
-  TLOG(TCONFIG) << ": Using BoardID=" << fBoardID << " with NChannels=" 
-		<< fNChannels;
+  TLOG(TCONFIG) << ": Using FragID=" << fCAEN.fragmentId 
+    << " BoardID=" << fBoardID 
+    << " with NChannels=" << fNChannels;
 
+  // opening the connection to the digitizer
   retcode = CAEN_DGTZ_OpenDigitizer(CAEN_DGTZ_OpticalLink, fCAEN.link, 
 				    fCAEN.boardChainNumber, 0, &fHandle);
 
-  fOK=true;
-
   if(retcode != CAEN_DGTZ_Success)
   {
-    sbndaq::CAENDecoder::checkError(retcode,"OpenDigitizer",fBoardID);
+    sbndaq::CAENDecoder::checkError(retcode,"OpenDigitizer",fCAEN.fragmentId);
 		CAEN_DGTZ_CloseDigitizer(fHandle);
     fHandle = -1;
-    fOK = false;
-    TLOG(TLVL_ERROR) << ": Fatal error configuring CAEN board at " << 
-      fCAEN.link << ", " << fCAEN.boardChainNumber;
-    TLOG(TLVL_ERROR) << "Terminating process";
+    TLOG(TLVL_ERROR) << "(fragID=" << fCAEN.fragmentId 
+      << ") Fatal error configuring CAEN board at link=" << fCAEN.link
+      << ", boardChainNumber=" << fCAEN.boardChainNumber 
+      << ". Terminating process...";
     abort();
   }
  
-  // check current firmware/software versions
+  // prints current firmware/software versions
+  // prints VME bridge firmware and driver 
   GetSWInfo();
   
+  // software reset signal: clears all registers and buffers
+  // should clear any running or busy state
   retcode = CAEN_DGTZ_Reset(fHandle);
-  sbndaq::CAENDecoder::checkError(retcode,"Reset",fBoardID);
+  sbndaq::CAENDecoder::checkError(retcode,"Reset",fCAEN.fragmentId);
   
+  // initiate board configuration
   sleep(1);
   Configure();
 
+  // after configuration is over, read and print registers
+  // this is a summary snapshot of the board config
   uint32_t data;
+
+  // board configuration register
+  retcode = CAEN_DGTZ_ReadRegister(fHandle,BOARD_CONFIG_READ,&data);
+  TLOG(TLVL_INFO) << "BOARD_CONFIG_ADDR Reg:0x" << std::hex << BOARD_CONFIG_READ << 
+    "=0x" << data;
+  
+  // front panel TRG-OUT contol register
   retcode = CAEN_DGTZ_ReadRegister(fHandle,FP_TRG_OUT_CONTROL,&data);
   TLOG(TLVL_INFO) << "FP_TRG_OUT_CONTROL Reg:0x" << std::hex << FP_TRG_OUT_CONTROL << 
     "=0x" << data;
 
+  // front panel I/O control register
   retcode = CAEN_DGTZ_ReadRegister(fHandle,FP_IO_CONTROL,&data);
   TLOG(TLVL_INFO) << "FP_IO_CONTROL Reg:0x" << std::hex << FP_IO_CONTROL << "=0x" << data;
 
+  // front panel LVDS I/O control register
   retcode = CAEN_DGTZ_ReadRegister(fHandle,FP_LVDS_CONTROL,&data);
   TLOG(TLVL_INFO) << "FP_LVDS_CONTROL Reg:0x" << std::hex << FP_LVDS_CONTROL << "=0x" << 
     data << std::dec;
 
-  if(!fOK)
-  {
-    CAEN_DGTZ_CloseDigitizer(fHandle);
-    TLOG(TLVL_ERROR) << ": Fatal error configuring CAEN board at " << 
-      fCAEN.link << ", " << fCAEN.boardChainNumber;
-    TLOG(TLVL_ERROR) << "Terminating process";
-    abort();
-  }
+  // acquisition control register
+  retcode = CAEN_DGTZ_ReadRegister(fHandle,ACQ_CONTROL,&data);
+  TLOG(TLVL_INFO) << "ACQ_CONTROL Reg:0x" << std::hex << ACQ_CONTROL << "=0x" << data;
+
+  // readout control register (interrupts)
+  retcode = CAEN_DGTZ_ReadRegister(fHandle,READOUT_CONTROL,&data);
+  TLOG(TLVL_INFO) << "READOUT_CONTROL Reg:0x" << std::hex << READOUT_CONTROL << "=0x" << data;
+  
+  // global trigger mask
+  retcode = CAEN_DGTZ_ReadRegister(fHandle,GLB_TRG_MASK,&data);
+  TLOG(TLVL_INFO) << "GLB_TRG_MASK Reg:0x" << std::hex << GLB_TRG_MASK << "=0x" << data;
+
+  // channel enable mask
+  retcode = CAEN_DGTZ_ReadRegister(fHandle,CH_ENABLE_MASK,&data);
+  TLOG(TLVL_INFO) << "CH_ENABLE_MASK Reg:0x" << std::hex << CH_ENABLE_MASK << "=0x" << data;
 
   // Set up worker getdata thread.
   share::ThreadFunctor functor = std::bind(&CAENV1730Readout::GetData,this);
@@ -102,12 +125,14 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   GetData_thread_.swap(GetData_worker);
   TLOG_ARB(TCONFIG,TRACE_NAME) << "GetData worker thread setup." << TLOG_ENDL;
 
-  TLOG(TCONFIG) << "Configuration complete with OK=" << fOK << TLOG_ENDL;
-
+  TLOG(TCONFIG) << "Configuration complete!" << TLOG_ENDL;
 
   //epoch time
   fTimeEpoch = boost::posix_time::ptime(boost::gregorian::date(1970,1,1));
 }
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
 sbndaq::CAENV1730Readout::~CAENV1730Readout()
 {
@@ -119,6 +144,79 @@ sbndaq::CAENV1730Readout::~CAENV1730Readout()
 
   TLOG_ARB(TCONFIG,TRACE_NAME) << "~CAENV1730Readout() done." << TLOG_ENDL;
 }
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
+void sbndaq::CAENV1730Readout::Configure()
+{
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "Configure()" << TLOG_ENDL;
+
+  CAEN_DGTZ_ErrorCode retcode;
+  uint32_t readback;
+
+  // Make sure DAQ run is off first
+  // This should be garantueed by the previous reset, but still
+  // Set software control acquistion, then stop
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "Set Acquisition Mode to SW" << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SetAcquisitionMode(fHandle,CAEN_DGTZ_SW_CONTROLLED);
+  sbndaq::CAENDecoder::checkError(retcode,"SetAcquisitionMode",fCAEN.fragmentId);
+
+  retcode = CAEN_DGTZ_GetAcquisitionMode(fHandle,(CAEN_DGTZ_AcqMode_t *)&readback);
+  CheckReadback("SetAcquisitionMode",fCAEN.fragmentId,(uint32_t)CAEN_DGTZ_SW_CONTROLLED ,readback);
+
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "Stop Acquisition" << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SWStopAcquisition(fHandle);
+  sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fCAEN.fragmentId);
+
+  // reset again to clear acquisition mode
+  retcode = CAEN_DGTZ_Reset(fHandle);
+  sleep(2);
+
+  // Configuration is carried out in different functions
+  // - CAENDecoder::checkError is applied every time: if writing fails, exception is thrown
+  // - CheckReadback() is called when possible 
+
+  ConfigureReadout();
+  ConfigureRecordFormat();
+  ConfigureTrigger();
+
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "Stop Acquisition" << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SWStopAcquisition(fHandle);
+  sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fBoardID);
+  
+  ConfigureAcquisition();
+  ConfigureInterrupts();
+
+  if (fCAEN.calibrateOnConfig)     { RunADCCalibration();  }
+
+  // Does lock bit clear on V1730 reset?   If not, always call this routine
+  if (fCAEN.lockTempCalibration )  
+  { 
+    for ( uint32_t ch=0; ch<fNChannels; ch++)
+    {
+      SetLockTempCalibration(true,ch);
+    }
+  }
+
+  // Calibration added by Animesh
+  uint8_t fCalParams;
+  if (fCAEN.writeCalibration)  
+    { 
+      
+      for ( uint32_t ch=0; ch<fNChannels; ch++)
+	{
+	  TLOG(TINFO)<<"Chnumber is " <<ch<<TLOG_ENDL;
+	  Read_ADC_CalParams_V1730(fHandle, ch,&fCalParams);
+	  //  Write_ADC_CalParams_V1730(fHandle, ch,&fCalParams);
+	}
+      
+    }
+  
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "Configure() done." << TLOG_ENDL;
+}
+
+
 
 void sbndaq::CAENV1730Readout::ConfigureInterrupts() 
 {
@@ -179,83 +277,7 @@ void sbndaq::CAENV1730Readout::ConfigureInterrupts()
   {
     TLOG_WARNING("CAENV1730Readout") << "Interrupt eventNumber was not setup properly, eventNumber write/read="
                                      << uint32_t{eventNumber} << "/" << uint32_t{eventNumberOut};
-  }
-
-  // Checking READOUT_CONTROL register after interrupts config
-  // this is the actual check to make sure they were configured correctly
-  // expected value is 0x18 or 0b11000
-  uint32_t addr = READOUT_CONTROL;
-  uint32_t value = 0;
-  retcode = CAEN_DGTZ_ReadRegister(fHandle,addr,&value);
-  sbndaq::CAENDecoder::checkError(retcode,"READOUT_CONTROL",fBoardID);
-  TLOG(TINFO) << "Checking READOUT_CONTROL register addr=0x" << std::hex << addr 
-              << " returns value=0x" << std::hex << value 
-              << " (0b" << std::bitset<10>(value) << ")"; 
-              
-}
-
-void sbndaq::CAENV1730Readout::Configure()
-{
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "Configure()" << TLOG_ENDL;
-
-  CAEN_DGTZ_ErrorCode retcode;
-  uint32_t readback;
-
-  //Make sure DAQ is off first
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "Set Acquisition Mode to SW" << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SetAcquisitionMode(fHandle,CAEN_DGTZ_SW_CONTROLLED);
-  sbndaq::CAENDecoder::checkError(retcode,"SetAcquisitionMode",fBoardID);
-  retcode = CAEN_DGTZ_GetAcquisitionMode(fHandle,(CAEN_DGTZ_AcqMode_t *)&readback);
-  CheckReadback("SetAcquisitionMode", fBoardID,(uint32_t)CAEN_DGTZ_SW_CONTROLLED ,readback);
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "Stop Acquisition" << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SWStopAcquisition(fHandle);
-  sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fBoardID);
-
-  //get info, make sure board is in good communicative state
-  retcode = CAEN_DGTZ_GetInfo(fHandle,&fBoardInfo);
-  fOK = (retcode==CAEN_DGTZ_Success);
-
-  retcode = CAEN_DGTZ_Reset(fHandle);
-  sleep(2);
-
-  ConfigureReadout();
-  ConfigureRecordFormat();
-  ConfigureTrigger();
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "Stop Acquisition" << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SWStopAcquisition(fHandle);
-  sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fBoardID);
-  
-  ConfigureAcquisition();
-  ConfigureInterrupts();
-
-  if (fCAEN.calibrateOnConfig)     { RunADCCalibration();  }
-
-  // Does lock bit clear on V1730 reset?   If not, always call this routine
-  if (fCAEN.lockTempCalibration )  
-  { 
-    for ( uint32_t ch=0; ch<fNChannels; ch++)
-    {
-      SetLockTempCalibration(true,ch);
-    }
-  }
-
-  // Calibration added by Animesh
-  uint8_t fCalParams;
-  if (fCAEN.writeCalibration)  
-    { 
-      
-      for ( uint32_t ch=0; ch<fNChannels; ch++)
-	{
-	  TLOG(TINFO)<<"Chnumber is " <<ch<<TLOG_ENDL;
-	  Read_ADC_CalParams_V1730(fHandle, ch,&fCalParams);
-	  //  Write_ADC_CalParams_V1730(fHandle, ch,&fCalParams);
-	}
-      
-    }
-  
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "Configure() done." << TLOG_ENDL;
+  }              
 }
 
 void sbndaq::CAENV1730Readout::RunADCCalibration()
@@ -710,8 +732,8 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
   //Animesh & Aiwu add ends
 
   //Animesh & Aiwu add - test self trigger polarity
-  retcod = CAEN_DGTZ_WriteRegister(fHandle, CONFIG_READ_ADDR, fCAEN.selfTrgBit);
-  retcod = CAEN_DGTZ_ReadRegister(fHandle, CONFIG_READ_ADDR, &readBack);
+  retcod = CAEN_DGTZ_WriteRegister(fHandle, BOARD_CONFIG_READ, fCAEN.selfTrgBit);
+  retcod = CAEN_DGTZ_ReadRegister(fHandle, BOARD_CONFIG_READ, &readBack);
   TLOG(TINFO) << "Address 0x8000, values inside: 0x" << std::hex << readBack << std::dec;
   //Animesh & Aiwu end
 }
@@ -898,11 +920,11 @@ void sbndaq::CAENV1730Readout::ConfigureTrigger()
   TLOG_ARB(TCONFIG,TRACE_NAME) << "SetTriggerOverlap" << fCAEN.allowTriggerOverlap << TLOG_ENDL;
   if ( fCAEN.allowTriggerOverlap )
   {
-    addr = CONFIG_SET_ADDR;
+    addr = BOARD_CONFIG_SET;
   }
   else
   {
-    addr = CONFIG_CLEAR_ADDR;
+    addr = BOARD_CONFIG_CLEAR;
   }
   retcode = CAEN_DGTZ_WriteRegister(fHandle, addr, TRIGGER_OVERLAP_MASK);
   sbndaq::CAENDecoder::checkError(retcode,"SetTriggerOverlap",fBoardID);
@@ -990,8 +1012,11 @@ void sbndaq::CAENV1730Readout::ConfigureAcquisition()
   TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureAcquisition() done." << TLOG_ENDL;
 }
 
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
+
 void sbndaq::CAENV1730Readout::CheckReadback(std::string label,
-					      int boardID,
+					      int fragID,
 					      uint32_t wrote,
 					      uint32_t readback,
 					      int channelID)
@@ -1000,20 +1025,18 @@ void sbndaq::CAENV1730Readout::CheckReadback(std::string label,
 
     std::stringstream channelLabel(" ");
     if (channelID >= 0)
-      channelLabel << " Ch/Grp " << channelID;
+      channelLabel << " Channel/Group " << channelID;
     
     std::stringstream text;
-    text << " " << label << 
-      " ReadBack error BoardId " << boardID << channelLabel.str() 
-	 << " wrote " << wrote << " read " << readback;
-    TLOG(TLVL_ERROR ) << "" << text.str();
+    text << " " << label << " ReadBack error fragID=" << fragID 
+      << channelLabel.str() << " wrote " << wrote << " read " << readback;
 
-    //sbndaq::CAENException e(CAEN_DGTZ_DigitizerNotReady,
-    //			     text.str(), boardId);
-    //throw(e);
+    TLOG(TLVL_ERROR ) << "" << text.str();
   }
-  
 }
+
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
 void sbndaq::CAENV1730Readout::start()
 {

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -604,7 +604,7 @@ void sbndaq::CAENV1730Readout::ConfigureAcquisition()
   TLOG_ARB(TCONFIG,TRACE_NAME) << "SetAnalogMonOutputMode " << (CAEN_DGTZ_AnalogMonitorOutputMode_t)(fCAEN.analogMode) << TLOG_ENDL;
   retcode = CAEN_DGTZ_SetAnalogMonOutput(fHandle,(CAEN_DGTZ_AnalogMonitorOutputMode_t)(fCAEN.analogMode));
   sbndaq::CAENDecoder::checkError(retcode,"SetAnalogMonOutputMode",fCAEN.fragmentId);
-  retcode = CAEN_DGTZ_ReadRegister(fHandle,ANALOG_MON_MOD,&readback);
+  retcode = CAEN_DGTZ_ReadRegister(fHandle,ANALOG_MON_MODE,&readback);
   CheckReadback("SetAnalogMonOutputMode",fCAEN.fragmentId,fCAEN.analogMode,readback);
 
   TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureAcquisition() done." << TLOG_ENDL;

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -893,8 +893,11 @@ void sbndaq::CAENV1730Readout::start()
 // ------------------------------------------------------------------------
 // ------------------------------------------------------------------------
 
-// this is really the DAQ part where the server reads data from 
+// This is really the DAQ part where the boardreader reads data from 
 // the card and stores in its internal pool buffer
+// - this is executed through the GetData worker thread
+// - at this stage, data is identified by the CAEN event number in the header
+// - timestamp map (key=CAEN event num) is used to later package the timestamp
 
 bool sbndaq::CAENV1730Readout::GetData()
 {
@@ -926,6 +929,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
   TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")" << "Begin.";
 
   // (re)-arm interrupt before waiting for one
+  // this is required for links through a5818 cards
   CAEN_DGTZ_ErrorCode retcode = CAEN_DGTZ_RearmInterrupt(fHandle);
   if(retcode < 0){
     TLOG(TLVL_WARNING) << "(FragID=" << fCAEN.fragmentId << ")"
@@ -965,8 +969,8 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
   TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		 << "Start while loop read. " << read_data_size; 
 
-  while(read_data_size!=0){
-
+  while(read_data_size!=0)
+  {
     TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		   << "Last read data size was " << read_data_size; 
 
@@ -1124,7 +1128,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     //if the run is long, it can overflow --> do not throw errors in that case
     auto readoutwindow_trigger_counter_gap= uint32_t{header->eventCounter} - last_rcvd_rwcounter;
     if( readoutwindow_trigger_counter_gap > 1u && last_rcvd_rwcounter < max_rwcounter ){
-      TLOG (TLVL_DEBUG) << "(FragID=" << fCAEN.fragmentId << ")"
+      TLOG (TLVL_WARNING) << "(FragID=" << fCAEN.fragmentId << ")"
 			<< "Missing triggers; previous trigger eventCounter / gap  = " << last_rcvd_rwcounter << " / "
 			<< readoutwindow_trigger_counter_gap <<", freeBlockCount=" <<fPoolBuffer.freeBlockCount() 
 			<< ", activeBlockCount=" <<fPoolBuffer.activeBlockCount() << ", fullyDrainedCount=" << fPoolBuffer.fullyDrainedCount();
@@ -1153,24 +1157,41 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 // ------------------------------------------------------------------------
 // ------------------------------------------------------------------------
 
-bool sbndaq::CAENV1730Readout::getNext_(artdaq::FragmentPtrs & fragments){
-  if(fail_GetNext) throw std::runtime_error("Critical error; stopping boardreader process...." ) ;
+// This is the part of the boardared that packages the fragments
+// - getNext_ is called internally by the artdaq framework
+// - available data in the pool buffers are packaged into fragments
+// - fragment timestamp is assigned through the timestamp map
+
+bool sbndaq::CAENV1730Readout::getNext_(artdaq::FragmentPtrs & fragments)
+{
+  if(fail_GetNext){
+    throw std::runtime_error("Critical error; stopping boardreader process...." );
+  }
   return readSingleWindowFragments(fragments);
 }
 
-bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & fragments){
+bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & fragments)
+{
   TLOG(TGETNEXT) << "Begin of readSingleWindowFragments()" ;
 
+  // this value would persist across function calls (static)
+  // but we update it manually at the end of each read cycle
   static auto start= std::chrono::steady_clock::now();
 
+  // measure the time delta between the end of previous fragment creation
+  // this tells how "laggy" getNext is in creating fragments
+  // threshold is configurable -> find a better name?
   std::chrono::duration<double> delta = std::chrono::steady_clock::now()-start;
+  if (delta.count() > 0.005*fCAEN.getNextFragmentBunchSize)
+  {
+    metricMan->sendMetric("Laggy getNext",1,"count",11,artdaq::MetricMode::Accumulate);
+    TLOG (TLVL_DEBUG) << "Time spent outside of getNext_() " << delta.count()*1000 << " ms. Last seen fragment sequenceID=" << last_sent_seqid;
+  }
 
-  if (delta.count() >0.005*fCAEN.getNextFragmentBunchSize) {
-     metricMan->sendMetric("Laggy getNext",1,"count",11,artdaq::MetricMode::Accumulate);
-     TLOG (TLVL_DEBUG) << "Time spent outside of getNext_() " << delta.count()*1000 << " ms. Last seen fragment sequenceID=" << last_sent_seqid;
-   }
-
-  if(fPoolBuffer.activeBlockCount() == 0){
+  // check if there are any active blocks inside the pool buffer
+  // if not, wait a bit and retry
+  if(fPoolBuffer.activeBlockCount() == 0)
+  {
     TLOG(TGETNEXT) << "PoolBuffer has no data.  Laast last seen fragment sequenceID=" << last_sent_seqid
                    << "; Sleep for " << fCAEN.getNextSleep << " us and return.";
     ::usleep(fCAEN.getNextSleep);
@@ -1181,26 +1202,34 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
   double max_fragment_create_time = 0.0;
   double min_fragment_create_time = 10000.0;
   struct timespec now;
-  clock_gettime(CLOCK_REALTIME,&now);
+  clock_gettime(CLOCK_REALTIME,&now); // get current server time
+
+  // prepare V1730 fragment metadata structure
   const auto metadata = CAENV1730FragmentMetadata(fNChannels,fCAEN.recordLength,now.tv_sec,now.tv_nsec,ch_temps);
   const auto fragment_datasize_bytes = metadata.ExpectedDataSize();
   TLOG(TMAKEFRAG)<< "Created CAENV1730FragmentMetadata with expected data size of "
                  << fragment_datasize_bytes << " bytes.";
 
-  //auto fragment_count=fGetNextFragmentBunchSize;
-
   //just get anything that's there...
-  while(fPoolBuffer.activeBlockCount()){
-
+  while(fPoolBuffer.activeBlockCount())
+  {
     start= std::chrono::steady_clock::now();
+
+    // create an artdaq::Fragment buffer to receive the data
+    // set some identifiers as required 
     auto fragment_uptr=artdaq::Fragment::FragmentBytes(fragment_datasize_bytes,fEvCounter,fCAEN.fragmentId,sbndaq::detail::FragmentType::CAENV1730,metadata);
 
-
+    // create a data range that points into the fragment
+    // now poolbuffer "knows" where it needs to write the payload
     using sbndaq::PoolBuffer;
     PoolBuffer::DataRange<decltype(artdaq::Fragment())> range{fragment_uptr->dataBegin(),fragment_uptr->dataEnd()};
 
+    // copy next block from the pool buffer into the fragment
+    // if it fails, no more usable data so break out of the loop
     if(!fPoolBuffer.read(range)) break;
 
+    // initial part of the fragmet is casted to the V1730 event header
+    // this is so we can read values off of it
     const auto header = reinterpret_cast<CAENV1730EventHeader const *>(fragment_uptr->dataBeginBytes());
    
     // get eventCounter, which is the key to get the correct timestamp from the map
@@ -1208,28 +1237,34 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
     // build sequence id keeping track of overflows (avoids repeated seqIDs in the same run)
     const auto readoutwindow_event_counter = uint32_t {header->eventCounter};
     uint64_t readoutwindow_sequence_id = uint64_t{readoutwindow_event_counter + fOverflowCounter*(max_rwcounter+1u)};
+    
+    // sets this new event counter as sequence_id for the fragment
     fragment_uptr->setSequenceID(readoutwindow_sequence_id);
 
-    size_t ts_count;
+    // now look up the timestamp from the map
+    size_t ts_count=0;
     {
       std::lock_guard<std::mutex> lock(fTimestampMapMutex);
       ts_count = fTimestampMap.count(readoutwindow_event_counter);
     }
-    int ts_loop=0;
 
-    while(ts_loop<3 && ts_count==0){
+    // if no timestamp is found, retry 3 times -- sleeping in between 
+    int ts_loop=0;
+    while(ts_loop<3 && ts_count==0)
+    {
       TLOG(TLVL_WARNING) << " TIMESTAMP FOR SEQID " << readoutwindow_sequence_id << " EVCOUNTER " << readoutwindow_event_counter << " not found in fTimestampMap!"
 			 << " Will sleep for 200 ms and try again. Times tried = " << ts_loop;
       ::usleep(200000);
       ts_loop++;
       {
-	std::lock_guard<std::mutex> lock(fTimestampMapMutex);
-	ts_count = fTimestampMap.count(readoutwindow_event_counter);
+	      std::lock_guard<std::mutex> lock(fTimestampMapMutex);
+	      ts_count = fTimestampMap.count(readoutwindow_event_counter);
       }
     }
 
-    //check where we are now in time
-    artdaq::Fragment::timestamp_t ts_frag,ts_now;
+    // check where we are now in time
+    // this is taking the current server clock
+    artdaq::Fragment::timestamp_t ts_frag, ts_now;
     {
       using namespace boost::gregorian;
       using namespace boost::posix_time;
@@ -1241,69 +1276,78 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
       ts_now = diff.total_nanoseconds();
     }
 
-    ts_count=0;
+    // if the map contains a timestamp entry
+    // fetch it and erase it from the map
+    if(ts_count>0)
     {
-      std::lock_guard<std::mutex> lock(fTimestampMapMutex);
-      ts_count = fTimestampMap.count(readoutwindow_event_counter);
-    }
-
-    if(ts_count>0){
       std::lock_guard<std::mutex> lock(fTimestampMapMutex);      
       ts_frag = fTimestampMap.at(readoutwindow_event_counter);
       fTimestampMap.erase(readoutwindow_event_counter);
     }
-    else{
+    // if no timestamp is found (weird..)
+    // generate a new timestamp based on the current time
+    // use similar procedure to getData, just different "now"
+    // no "polling" correction being applied here
+    else
+    {
       TLOG(TLVL_ERROR) << " TIMESTAMP FOR SEQID " << readoutwindow_sequence_id << " EVCOUNTER " << readoutwindow_event_counter << " not found in fTimestampMap!"
 		       << " Will generate new one now...";
 
-      if(fCAEN.useTimeTagForTimeStamp){
-	const auto TTT = uint32_t {header->triggerTimeTag};
+      if(fCAEN.useTimeTagForTimeStamp)
+      {
+	      const auto TTT = uint32_t {header->triggerTimeTag};
 	
-	using namespace boost::gregorian;
-	using namespace boost::posix_time;
+        using namespace boost::gregorian;
+        using namespace boost::posix_time;
 	
-	ptime t_now(second_clock::universal_time());
-	ptime time_t_epoch(date(1970,1,1));
-	time_duration diff = t_now - time_t_epoch;
-	uint32_t t_offset_s = diff.total_seconds();
-	uint64_t t_offset_ticks = diff.total_seconds()*125000000; //in 8ns ticks
-	uint64_t t_truetriggertime = t_offset_ticks + TTT;
-	TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
-	
-	ts_frag = (t_truetriggertime*8); //in 1ns ticks
-      }
-      else if(fCAEN.useTimeTagShiftForTimeStamp){
-	const auto TTT = uint32_t {header->triggerTimeTag};
-	
-	using namespace boost::gregorian;
-	using namespace boost::posix_time;
-	
-	ptime t_now(second_clock::universal_time());
-	ptime time_t_epoch(date(1970,1,1));
-	time_duration diff = t_now - time_t_epoch;
-	uint32_t t_offset_s = diff.total_seconds();
-	uint64_t t_offset_ticks = diff.total_seconds()*125000000; //in 8ns ticks
-	uint64_t t_truetriggertime = t_offset_ticks + TTT;
-	TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
+        ptime t_now(second_clock::universal_time());
+        ptime time_t_epoch(date(1970,1,1));
+        time_duration diff = t_now - time_t_epoch;
+        uint32_t t_offset_s = diff.total_seconds();
+        uint64_t t_offset_ticks = diff.total_seconds()*125000000; //in 8ns ticks
+        uint64_t t_truetriggertime = t_offset_ticks + TTT;
 
-	// TTT is 8 ticks/ns, record length is 2 ticks/ns. See CAEN V1730 manuals for details
-	ts_frag = (t_truetriggertime*8.0) - (((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0)); //in 1ns ticks
+        TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch" << TLOG_ENDL;
+        ts_frag = (t_truetriggertime*8); //in 1ns ticks
       }
-      else{
-	using namespace boost::gregorian;
-	using namespace boost::posix_time;
+      else if(fCAEN.useTimeTagShiftForTimeStamp)
+      {
+	      const auto TTT = uint32_t {header->triggerTimeTag};
 	
-	ptime t_now(microsec_clock::universal_time());
-	ptime time_t_epoch(date(1970,1,1));
-	time_duration diff = t_now - time_t_epoch;
+        using namespace boost::gregorian;
+        using namespace boost::posix_time;
 	
-	ts_frag = diff.total_nanoseconds() - fCAEN.timeOffsetNanoSec;
+        ptime t_now(second_clock::universal_time());
+        ptime time_t_epoch(date(1970,1,1));
+        time_duration diff = t_now - time_t_epoch;
+        uint32_t t_offset_s = diff.total_seconds();
+        uint64_t t_offset_ticks = diff.total_seconds()*125000000; //in 8ns ticks
+        uint64_t t_truetriggertime = t_offset_ticks + TTT;
+        TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "time offset = " << t_offset_ticks << " ns since the epoch"<< TLOG_ENDL;
+
+        // TTT is 8 ticks/ns, record length is 2 ticks/ns. See CAEN V1730 manuals for details
+        ts_frag = (t_truetriggertime*8.0) - (((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0)); //in 1ns ticks
+      }
+      else
+      {
+        using namespace boost::gregorian;
+        using namespace boost::posix_time;
+        
+        ptime t_now(microsec_clock::universal_time());
+        ptime time_t_epoch(date(1970,1,1));
+        time_duration diff = t_now - time_t_epoch;
+        
+        ts_frag = diff.total_nanoseconds() - fCAEN.timeOffsetNanoSec;
       }
     }
 
-    TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "fragment timestamp in 1ns ticks = " << ts_frag << TLOG_ENDL;
+    TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "Fragment timestamp in 1ns ticks = " << ts_frag << TLOG_ENDL;
     TLOG_ARB(TMAKEFRAG,TRACE_NAME) << "Difference to now in ns is = " << (ts_now - ts_frag) << TLOG_ENDL;
 
+    // assumng ts_frag was read from the timestamp map
+    // we can check ordering is correct and how much time it took
+    // note: ts_frag is a mix of server time + CAEN TTT
+    // bad values in TTT (board not getting PPS reset properly) might trigger a problem here
     if( ts_frag>ts_now )
       TLOG(TLVL_WARNING) << "Fragment assigned timestamp is after timestamp from fragment creation! Causality problem!!"
 			 << "ts_frag - ts_now = " << ts_frag - ts_now << " ns!"
@@ -1319,39 +1363,42 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 			 << "ts_now - ts_frag = " << ts_now-ts_frag << " ns!"
 			 << TLOG_ENDL;
     }
+
     metricMan->sendMetric("FragmentCreationGapMax", (ts_now-ts_frag), "ns", 12, artdaq::MetricMode::Maximum);
     metricMan->sendMetric("FragmentCreationGapAvg", (ts_now-ts_frag), "ns", 12, artdaq::MetricMode::Average);
 
-
+    // finally, set the timestamp to the fragment 
     fragment_uptr->setTimestamp( ts_frag );
 
     // check for possible gaps in the sequence IDs: compare current one with last sent
     // throw errors if gap > 1 or order is not correct
     auto readoutwindow_sequence_id_gap= readoutwindow_sequence_id - last_sent_seqid;
 
-    TLOG(TMAKEFRAG)<<"Created fragment " << fCAEN.fragmentId << " sequenceID " << readoutwindow_sequence_id << " for event " << readoutwindow_event_counter
-                   << " triggerTimeTag " << header->triggerTimeTag << " ts=" << ts_frag;
+    TLOG(TMAKEFRAG) << "Created fragment " << fCAEN.fragmentId << " sequenceID " << readoutwindow_sequence_id << " for event " << readoutwindow_event_counter
+                    << " triggerTimeTag " << header->triggerTimeTag << " ts=" << ts_frag;
     
-    if( readoutwindow_sequence_id_gap > 1u ){
+    // look for gaps in the sequence_id
+    if( readoutwindow_sequence_id_gap > 1u )
+    {
       if ( last_sent_seqid > 0 )
       {
-	TLOG (TLVL_DEBUG) << "Missing data; previous fragment sequenceID / gap  = " << last_sent_seqid << " / "
-                        << readoutwindow_sequence_id_gap;
-	metricMan->sendMetric("Missing Fragments", uint64_t{readoutwindow_sequence_id_gap}, "frags", 11, artdaq::MetricMode::Accumulate);
+	      TLOG (TLVL_DEBUG) << "Missing data; previous fragment sequenceID / gap  = " << last_sent_seqid << " / " << readoutwindow_sequence_id_gap;
+	      metricMan->sendMetric("Missing Fragments", uint64_t{readoutwindow_sequence_id_gap}, "frags", 11, artdaq::MetricMode::Accumulate);
       }
     }
 
+    // look for bad ordering
     if( readoutwindow_sequence_id < last_sent_seqid )
-      {
-	TLOG(TLVL_ERROR) << "SequenceIDs processed out of order!! "
-			 << readoutwindow_sequence_id << " < " << last_sent_seqid << TLOG_ENDL;
-      }
+    {
+	    TLOG(TLVL_ERROR) << "SequenceIDs processed out of order!! " << readoutwindow_sequence_id << " < " << last_sent_seqid << TLOG_ENDL;
+    }
     if( last_sent_ts > ts_frag)
-      {
-	TLOG(TLVL_ERROR) << "Timestamps out of order!! Last event later than current one."
-			 << ts_frag << " < " << last_sent_ts << TLOG_ENDL;
-      }
+    {
+	    TLOG(TLVL_ERROR) << "Timestamps out of order!! Last event later than current one." << ts_frag << " < " << last_sent_ts << TLOG_ENDL;
+    }
 
+    // finally push the fragments to the eventbuilders
+    // clear and them move in the fragments vector
     fragments.emplace_back(nullptr);
     std::swap(fragments.back(),fragment_uptr);
    
@@ -1362,25 +1409,28 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
 
     last_sent_seqid = readoutwindow_sequence_id;
     last_sent_ts = ts_frag;
-    delta = std::chrono::steady_clock::now()-start;
 
+    // keep track of how much time it took
+    // also update min/max time of each loop call
+    delta = std::chrono::steady_clock::now()-start;
     min_fragment_create_time=std::min(delta.count(),min_fragment_create_time);
     max_fragment_create_time=std::max(delta.count(),max_fragment_create_time);
 
-    if (delta.count() >0.0005 ) {
+    if (delta.count() >0.0005) 
+    {
       metricMan->sendMetric("Laggy Fragments",1,"frags",11,artdaq::MetricMode::Maximum);
-      TLOG (TLVL_DEBUG+1) << "Creating a fragment with setSequenceID=" << last_sent_seqid <<  " took " << delta.count()*1000 << " ms";
-//TRACE_CNTL("modeM", 0);
+      TLOG (TLVL_DEBUG+1) << "Creating a fragment with setSequenceID=" << last_sent_seqid << " took " << delta.count()*1000 << " ms";
     }
+
   }
 
-  metricMan->sendMetric("Fragment Create Time  Max",max_fragment_create_time,"s",11,artdaq::MetricMode::Accumulate);
- // metricMan->sendMetric("Fragment Create Time  Min" ,min_fragment_create_time,"s",1,artdaq::MetricMode::Accumulate);
+  metricMan->sendMetric("Fragment Create Time Max",max_fragment_create_time,"s",11,artdaq::MetricMode::Accumulate);
+  //metricMan->sendMetric("Fragment Create Time  Min" ,min_fragment_create_time,"s",1,artdaq::MetricMode::Accumulate);
 
   TLOG(TGETNEXT) << "End of readSingleWindowFragments(); returning " << fragments.size() << " fragments.";
 
+  // reset the start time
   start= std::chrono::steady_clock::now();
-
   return true;
 }
 

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1744,7 +1744,7 @@ bool sbndaq::CAENV1730Readout::checkHWStatus_(){
 
     // now check if channel memory is full
     uint32_t CHANNEL_STATUS_ADD = 0x1088 + (ch<<8);
-    retcod = CAEN_DGTZ_ReadRegister(handle, CHANNEL_STATUS_ADD, &(ch_status[ch]));
+    retcod = CAEN_DGTZ_ReadRegister(fHandle, CHANNEL_STATUS_ADD, &(ch_status[ch]));
 
     if(retcod == CAEN_DGTZ_Success){
       // unpack only memory full status

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1256,10 +1256,12 @@ bool sbndaq::CAENV1730Readout::checkHWStatus_(){
 }
 
 bool sbndaq::CAENV1730Readout::GetData() {
+
   TLOG(TGETDATA)<< "Begin of GetData()";
 
   CAEN_DGTZ_ErrorCode retcod;
 
+  // if the software trigger is on, send one
   if(fCAEN.swTrigger) {
     usleep(fCAEN.getNextSleep);
     TLOG(TGETDATA) << "Sending SW trigger..." << TLOG_ENDL;
@@ -1268,8 +1270,6 @@ bool sbndaq::CAENV1730Readout::GetData() {
   }
 
   // read the data from the buffer of the card
-  // this_data_size is the size of the acq window
-
   return readWindowDataBlocks();
 
 }// CAENV1730Readout::GetData()
@@ -1278,13 +1278,12 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 
   if(fail_GetNext) {
     TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
-		     << "Not calling CAEN_DGTZ_ReadData due a previous critical error...";
+                     << "Not calling CAEN_DGTZ_ReadData due a previous critical error...";
     ::usleep(50000);
     return false;
   }
 
-  TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"    
-		 << "Begin.";
+  TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")" << "Begin.";
 
   // (re)-arm interrupt before waiting for one
   CAEN_DGTZ_ErrorCode retcode = CAEN_DGTZ_RearmInterrupt(fHandle);
@@ -1325,6 +1324,7 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 
   TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		 << "Start while loop read. " << read_data_size; 
+
   while(read_data_size!=0){
 
     TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
@@ -1335,77 +1335,87 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 
     //get a block of data from the PoolBuffer. Hopefully doesn't take very long.
     auto block =  fPoolBuffer.takeFreeBlock();
+
     if(!block) {
       TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
-		       << "PoolBuffer is empty; last received trigger eventCounter=" <<last_rcvd_rwcounter;
+                       << "PoolBuffer is empty; last received trigger eventCounter=" <<last_rcvd_rwcounter;
       TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
-		       << "PoolBuffer status: freeBlockCount=" << fPoolBuffer.freeBlockCount()
+                       << "PoolBuffer status: freeBlockCount=" << fPoolBuffer.freeBlockCount()
                        << "(FragID=" << fCAEN.fragmentId << ")"
-		       <<", activeBlockCount=" << fPoolBuffer.activeBlockCount();
+                       << ", activeBlockCount=" << fPoolBuffer.activeBlockCount();
       TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
-		       << "Critical error; aborting boardreader process....";				
-
+                       << "Critical error; aborting boardreader process....";				
       fail_GetNext = true;
-
       std::this_thread::yield();
       return false;
     }
-    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
-		   << "Got a free DataBlock from PoolBuffer";
 
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
+                   << "Got a free DataBlock from PoolBuffer";
 
     //call ReadData
     TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
-		   << "Calling ReadData(fHandle="<<fHandle<< ",bufp=" << (void*)block->begin
+                   << "Calling ReadData(fHandle="<<fHandle<< ",bufp=" << (void*)block->begin
                    << ",&block.size="<<(void*)&(block->size) << ")";
 
     retcode = CAEN_DGTZ_ReadData(fHandle,CAEN_DGTZ_SLAVE_TERMINATED_READOUT_MBLT,
                                 (char*)block->begin,&read_data_size);
 
-    if(read_data_size==0) { 
-      fPoolBuffer.returnFreeBlock(block);
-      break;
-    }
-
-    ++n_reads;
-    
-    block->verify_redzone();
-    block->data_size= read_data_size;
-
-    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
-		   << "This read data size was " << read_data_size; 
-
-    //check to make sure no errors on readout.
-    if (retcode !=CAEN_DGTZ_Success) {
+    // 1) check to make sure no errors on readout
+    if (retcode != CAEN_DGTZ_Success) {
       TLOG(TLVL_ERROR) << "CAEN_DGTZ_ReadData returned non zero return code; return code=" << int{retcode};
       fPoolBuffer.returnFreeBlock(block);
       std::this_thread::yield();
       return false;
     }
 
+    // 2) check for no data 
+    if(read_data_size==0) { 
+      fPoolBuffer.returnFreeBlock(block);
+      break;
+    }
+    
+    // 3) check if data is within buffer boundaries
+    if(read_data_size > block->size){
+      LOG(TLVL_ERROR) << "CAENReadData tried to write " << read_data_size
+                      << " bytes into a " << block->size << "-byte buffer; dropping.";
+      fPoolBuffer.returnFreeBlock(block);
+      break;
+    }
+
+    TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
+		   << "This read data size was " << read_data_size; 
+    ++n_reads;
+
+    // 4) update data size in block and verify_redzone
+    block->data_size= read_data_size;
+    block->verify_redzone();
+
     fTimePollEnd = boost::posix_time::microsec_clock::universal_time();
+    
     TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		   << "CAEN_DGTZ_ReadData complete with returned data size " << block->data_size
                    << " retcod=" << int{retcode};
 
-
+    // now time to read off what we got in the header
     const auto header = reinterpret_cast<CAENV1730EventHeader const *>(block->begin);
     
     TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
-		   
 		   << ": PMT_EVENT_COUNTER=" << header->eventCounter
 		   << ", PMT_EVENT_SIZE=" << header->eventSize
 		   << ", PMT_TIME_TAG=" << header->triggerTimeTag;
 
     const size_t header_event_size = sizeof(uint32_t)* header->eventSize; 
+
+    // does the size reported in the header much the actual size?
     if(block->data_size != header_event_size ) {
       TLOG(TLVL_ERROR) << "(FragID=" << fCAEN.fragmentId << ")"
-		       <<"Wrong event size; returned="
-                       << block->data_size << ", header=" << header_event_size
-		       << ". PMT_EVENT_COUNTER=" << header->eventCounter
-		       << ", PMT_EVENT_SIZE=" << header->eventSize
-		       << ", PMT_TIME_TAG=" << header->triggerTimeTag 
-		       << ". DROPPING THIS FRAGMENT.";
+                       << " Wrong event size; returned=" << block->data_size 
+                       << ", header=" << header_event_size
+                       << ". PMT_EVENT_COUNTER=" << header->eventCounter
+                       << ", PMT_EVENT_SIZE=" << header->eventSize
+                       << ", PMT_TIME_TAG=" << header->triggerTimeTag 
+                       << ". DROPPING THIS FRAGMENT.";
       fPoolBuffer.returnFreeBlock(block);
       break;
     }
@@ -1422,29 +1432,31 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     fTTT_ns = -1;
 
     if(fCAEN.useTimeTagForTimeStamp){
-      fTTT = uint32_t{header->triggerTimeTag}; // 
-      fTTT_ns = fTTT*8;
-      
+
+      fTTT = uint32_t{header->triggerTimeTag}; 
+      fTTT_ns = fTTT*8;      
+
       // Scheme borrowed from what Antoni developed for CRT.
       // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783
       fTS = fMeanPollTime - fMeanPollTimeNS + fTTT_ns
-	+ (fTTT_ns - (long)fMeanPollTimeNS < -500000000) * 1000000000
-	- (fTTT_ns - (long)fMeanPollTimeNS >  500000000) * 1000000000
-	- fCAEN.timeOffsetNanoSec;
-    }
-    else if(fCAEN.useTimeTagShiftForTimeStamp){
+          + (fTTT_ns - (long)fMeanPollTimeNS < -500000000) * 1000000000
+          - (fTTT_ns - (long)fMeanPollTimeNS >  500000000) * 1000000000
+          - fCAEN.timeOffsetNanoSec;
+
+    } else if(fCAEN.useTimeTagShiftForTimeStamp){
+
       fTTT = uint32_t{header->triggerTimeTag}; // 
       // TTT is 8 ticks/ns, record length is 2 ticks/ns. See CAEN V1730 manuals for details
       fTTT_ns = (fTTT*8.0) - (((double)fCAEN.recordLength * 2.0) * ((double)fCAEN.postPercent / 100.0)); //in 1 ns
-      
+
       // Scheme borrowed from what Antoni developed for CRT.
       // See https://sbn-docdb.fnal.gov/cgi-bin/private/DisplayMeeting?sessionid=7783
       fTS = fMeanPollTime - fMeanPollTimeNS + fTTT_ns
-	+ (fTTT_ns - (long)fMeanPollTimeNS < -500000000) * 1000000000
-	- (fTTT_ns - (long)fMeanPollTimeNS >  500000000) * 1000000000
-	- fCAEN.timeOffsetNanoSec;
-    }
-    else{
+          + (fTTT_ns - (long)fMeanPollTimeNS < -500000000) * 1000000000
+          - (fTTT_ns - (long)fMeanPollTimeNS >  500000000) * 1000000000
+          - fCAEN.timeOffsetNanoSec;
+
+    } else{
       fTS = fTimeDiffPollEnd.total_nanoseconds() - fCAEN.timeOffsetNanoSec;
     }
 
@@ -1467,7 +1479,6 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     TLOG(TGETDATA) << "(FragID=" << fCAEN.fragmentId << ")"
 		   << "TIMESTAMP " << fCAEN.fragmentId 
 		   << ": Timestamp for event " << header->eventCounter << " = " << fTS;
-
 
     //check trigger event counter gaps: this is a 24-bit counter in the CAEN board
     //if the run is long, it can overflow --> do not throw errors in that case

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -109,6 +109,17 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   fTimeEpoch = boost::posix_time::ptime(boost::gregorian::date(1970,1,1));
 }
 
+sbndaq::CAENV1730Readout::~CAENV1730Readout()
+{
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "~CAENV1730Readout()" << TLOG_ENDL;
+
+  if(fBuffer != NULL){
+    fBuffer.reset();
+  }
+
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "~CAENV1730Readout() done." << TLOG_ENDL;
+}
+
 void sbndaq::CAENV1730Readout::ConfigureInterrupts() 
 {
   CAEN_DGTZ_EnaDis_t  state, stateOut;
@@ -224,7 +235,7 @@ void sbndaq::CAENV1730Readout::Configure()
   // Does lock bit clear on V1730 reset?   If not, always call this routine
   if (fCAEN.lockTempCalibration )  
   { 
-    for ( uint32_t ch=0; ch<CAENConfiguration::MAX_CHANNELS; ch++)
+    for ( uint32_t ch=0; ch<fNChannels; ch++)
     {
       SetLockTempCalibration(true,ch);
     }
@@ -235,7 +246,7 @@ void sbndaq::CAENV1730Readout::Configure()
   if (fCAEN.writeCalibration)  
     { 
       
-      for ( uint32_t ch=0; ch<CAENConfiguration::MAX_CHANNELS; ch++)
+      for ( uint32_t ch=0; ch<fNChannels; ch++)
 	{
 	  TLOG(TINFO)<<"Chnumber is " <<ch<<TLOG_ENDL;
 	  Read_ADC_CalParams_V1730(fHandle, ch,&fCalParams);
@@ -738,17 +749,6 @@ void sbndaq::CAENV1730Readout::ConfigureRecordFormat()
   TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureRecordFormat() done." << TLOG_ENDL;
 }
 
-sbndaq::CAENV1730Readout::~CAENV1730Readout()
-{
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "~CAENV1730Readout()" << TLOG_ENDL;
-
-  if(fBuffer != NULL){
-    fBuffer.reset();
-  }
-
-  TLOG_ARB(TCONFIG,TRACE_NAME) << "~CAENV1730Readout() done." << TLOG_ENDL;
-}
-
 //Taken from wavedump
 //  handle : Digitizer handle
 //  address: register address
@@ -990,29 +990,29 @@ void sbndaq::CAENV1730Readout::ConfigureAcquisition()
   TLOG_ARB(TCONFIG,TRACE_NAME) << "ConfigureAcquisition() done." << TLOG_ENDL;
 }
 
-bool sbndaq::CAENV1730Readout::WaitForTrigger()
+void sbndaq::CAENV1730Readout::CheckReadback(std::string label,
+					      int boardID,
+					      uint32_t wrote,
+					      uint32_t readback,
+					      int channelID)
 {
+  if (wrote != readback){
 
-  TLOG_ARB(TSTATUS,TRACE_NAME) << "WaitForTrigger()" << TLOG_ENDL;
+    std::stringstream channelLabel(" ");
+    if (channelID >= 0)
+      channelLabel << " Ch/Grp " << channelID;
+    
+    std::stringstream text;
+    text << " " << label << 
+      " ReadBack error BoardId " << boardID << channelLabel.str() 
+	 << " wrote " << wrote << " read " << readback;
+    TLOG(TLVL_ERROR ) << "" << text.str();
 
-  CAEN_DGTZ_ErrorCode retcode;
-
-  uint32_t acqStatus;
-  retcode = CAEN_DGTZ_ReadRegister(fHandle,
-				   CAEN_DGTZ_ACQ_STATUS_ADD,
-				   &acqStatus);
-  if(retcode!=CAEN_DGTZ_Success){
-    TLOG_WARNING("CAENV1730Readout")
-      << "Trying ReadRegister ACQUISITION_STATUS again." << TLOG_ENDL;
-    retcode = CAEN_DGTZ_ReadRegister(fHandle,
-				     CAEN_DGTZ_ACQ_STATUS_ADD,
-				     &acqStatus);
+    //sbndaq::CAENException e(CAEN_DGTZ_DigitizerNotReady,
+    //			     text.str(), boardId);
+    //throw(e);
   }
-  sbndaq::CAENDecoder::checkError(retcode,"ReadRegister ACQ_STATUS",fBoardID);
-
-  TLOG_ARB(TSTATUS,TRACE_NAME) << " Acq status = " << acqStatus << TLOG_ENDL;
-  return (acqStatus & ACQ_STATUS_MASK_t::EVENT_READY);
-
+  
 }
 
 void sbndaq::CAENV1730Readout::start()
@@ -1021,7 +1021,6 @@ void sbndaq::CAENV1730Readout::start()
   TLOG_INFO("CAENV1730Readout") << "start()" << TLOG_ENDL;
   
   ConfigureDataBuffer();
-  total_data_size = 0;
   last_sent_seqid = 0;
   
   if((CAEN_DGTZ_AcqMode_t)(fCAEN.acqMode)==CAEN_DGTZ_AcqMode_t::CAEN_DGTZ_SW_CONTROLLED)
@@ -1040,7 +1039,7 @@ void sbndaq::CAENV1730Readout::start()
 
   if (fCAEN.writeCalibration)  
     { 
-      for ( uint32_t ch=0; ch<CAENConfiguration::MAX_CHANNELS; ++ch)
+      for ( uint32_t ch=0; ch<fNChannels; ++ch)
         {
           retcod = WriteSPIRegister(fHandle, ch, 0xFE, 0x00);
           // TLOG(TINFO)<<"Write_ADC-CalParams_ch"<<ch<< ": Params[0]=" << CalParams[0]; 
@@ -1129,23 +1128,8 @@ void sbndaq::CAENV1730Readout::start()
   TLOG_ARB(TSTART,TRACE_NAME) << "start() done." << TLOG_ENDL;
 }
 
-void sbndaq::CAENV1730Readout::stop()
-{
-  TLOG_INFO("CAENV1730Readout") << "stop()" << TLOG_ENDL;
-
-  GetData_thread_->stop();
-
-  CAEN_DGTZ_ErrorCode retcode;
-  TLOG_ARB(TSTOP,TRACE_NAME) << "SWStopAcquisition" << TLOG_ENDL;
-  retcode = CAEN_DGTZ_SWStopAcquisition(fHandle);
-  sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fBoardID);
-
-  if(fBuffer != NULL){
-    fBuffer.reset();
-  }
-  TLOG_ARB(TSTOP,TRACE_NAME) << "stop() done." << TLOG_ENDL;
-}
-
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
 bool sbndaq::CAENV1730Readout::GetData() {
 
@@ -1402,6 +1386,8 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
   return true;
 }
 
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
 // this is really the DAQ part where the server reads data from 
 // the card and stores them
@@ -1636,30 +1622,24 @@ bool sbndaq::CAENV1730Readout::readSingleWindowFragments(artdaq::FragmentPtrs & 
   return true;
 }
 
+// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
-void sbndaq::CAENV1730Readout::CheckReadback(std::string label,
-					      int boardID,
-					      uint32_t wrote,
-					      uint32_t readback,
-					      int channelID)
+void sbndaq::CAENV1730Readout::stop()
 {
-  if (wrote != readback){
+  TLOG_INFO("CAENV1730Readout") << "stop()" << TLOG_ENDL;
 
-    std::stringstream channelLabel(" ");
-    if (channelID >= 0)
-      channelLabel << " Ch/Grp " << channelID;
-    
-    std::stringstream text;
-    text << " " << label << 
-      " ReadBack error BoardId " << boardID << channelLabel.str() 
-	 << " wrote " << wrote << " read " << readback;
-    TLOG(TLVL_ERROR ) << "" << text.str();
+  GetData_thread_->stop();
 
-    //sbndaq::CAENException e(CAEN_DGTZ_DigitizerNotReady,
-    //			     text.str(), boardId);
-    //throw(e);
+  CAEN_DGTZ_ErrorCode retcode;
+  TLOG_ARB(TSTOP,TRACE_NAME) << "SWStopAcquisition" << TLOG_ENDL;
+  retcode = CAEN_DGTZ_SWStopAcquisition(fHandle);
+  sbndaq::CAENDecoder::checkError(retcode,"SWStopAcquisition",fBoardID);
+
+  if(fBuffer != NULL){
+    fBuffer.reset();
   }
-  
+  TLOG_ARB(TSTOP,TRACE_NAME) << "stop() done." << TLOG_ENDL;
 }
 
 // ------------------------------------------------------------------------
@@ -1693,7 +1673,7 @@ bool sbndaq::CAENV1730Readout::checkHWStatus_(){
 
   // second, check individual channel status
   // this provides temperature reading + channel memory full
-  for(size_t ch=0; ch<CAENConfiguration::MAX_CHANNELS; ++ch)
+  for(size_t ch=0; ch<fNChannels; ++ch)
   {
     std::ostringstream tempStream; 
     tempStream << "Channel" << ch << ".Temp"; 

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -1377,8 +1377,8 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
     
     // 3) check if data is within buffer boundaries
     if(read_data_size > block->size){
-      LOG(TLVL_ERROR) << "CAENReadData tried to write " << read_data_size
-                      << " bytes into a " << block->size << "-byte buffer; dropping.";
+      TLOG(TLVL_ERROR) << "CAENReadData() tried to write " << read_data_size
+                       << " bytes into a " << block->size << "-byte buffer; dropping.";
       fPoolBuffer.returnFreeBlock(block);
       break;
     }

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -80,38 +80,44 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
 
   // board configuration register
   retcode = CAEN_DGTZ_ReadRegister(fHandle,BOARD_CONFIG_READ,&data);
-  TLOG(TLVL_INFO) << "BOARD_CONFIG_ADDR Reg:0x" << std::hex << BOARD_CONFIG_READ << 
-    "=0x" << data;
+  TLOG(TLVL_INFO) << "Board configuration (BOARD_CONFIG_ADDR=0x" 
+	          << std::hex << static_cast<unsigned int>(BOARD_CONFIG_READ) << ") = 0x" << data;
   
-  // front panel TRG-OUT contol register
+  // front panel TRG-OUT control register
   retcode = CAEN_DGTZ_ReadRegister(fHandle,FP_TRG_OUT_CONTROL,&data);
-  TLOG(TLVL_INFO) << "FP_TRG_OUT_CONTROL Reg:0x" << std::hex << FP_TRG_OUT_CONTROL << 
-    "=0x" << data;
+  TLOG(TLVL_INFO) << "Front panel TRG-OUT control (FP_TRG_OUT_CONTROL=0x" 
+                  << std::hex << static_cast<unsigned int>(FP_TRG_OUT_CONTROL) << ") = 0x" << data;
 
   // front panel I/O control register
   retcode = CAEN_DGTZ_ReadRegister(fHandle,FP_IO_CONTROL,&data);
-  TLOG(TLVL_INFO) << "FP_IO_CONTROL Reg:0x" << std::hex << FP_IO_CONTROL << "=0x" << data;
+  TLOG(TLVL_INFO) << "Front panel I/O control (FP_IO_CONTROL=0x" 
+	          << std::hex << static_cast<unsigned int>(FP_IO_CONTROL) << ") = 0x" << data;
 
   // front panel LVDS I/O control register
   retcode = CAEN_DGTZ_ReadRegister(fHandle,FP_LVDS_CONTROL,&data);
-  TLOG(TLVL_INFO) << "FP_LVDS_CONTROL Reg:0x" << std::hex << FP_LVDS_CONTROL << "=0x" << 
-    data << std::dec;
+  TLOG(TLVL_INFO) << "Front panel LVDS I/O control (FP_LVDS_CONTROL=0x" 
+	          << std::hex << static_cast<unsigned int>(FP_LVDS_CONTROL) << ") = 0x" << data;
 
   // acquisition control register
   retcode = CAEN_DGTZ_ReadRegister(fHandle,ACQ_CONTROL,&data);
-  TLOG(TLVL_INFO) << "ACQ_CONTROL Reg:0x" << std::hex << ACQ_CONTROL << "=0x" << data;
+  TLOG(TLVL_INFO) << "Acquisition control (ACQ_CONTROL=0x" 
+                  << std::hex << static_cast<unsigned int>(ACQ_CONTROL) << ") = 0x" << data;
 
   // readout control register (interrupts)
   retcode = CAEN_DGTZ_ReadRegister(fHandle,READOUT_CONTROL,&data);
-  TLOG(TLVL_INFO) << "READOUT_CONTROL Reg:0x" << std::hex << READOUT_CONTROL << "=0x" << data;
+  TLOG(TLVL_INFO) << "Readout interrupts control  (READOUT_CONTROL=0x" 
+                  << std::hex << static_cast<unsigned int>(READOUT_CONTROL) << ") = 0x" << data;
   
   // global trigger mask
   retcode = CAEN_DGTZ_ReadRegister(fHandle,GLB_TRG_MASK,&data);
-  TLOG(TLVL_INFO) << "GLB_TRG_MASK Reg:0x" << std::hex << GLB_TRG_MASK << "=0x" << data;
+  TLOG(TLVL_INFO) << "Global trigger mask (GLB_TRG_MASK=0x" 
+	  	  << std::hex << static_cast<unsigned int>(GLB_TRG_MASK) << ") = 0x" << data;
 
   // channel enable mask
   retcode = CAEN_DGTZ_ReadRegister(fHandle,CH_ENABLE_MASK,&data);
-  TLOG(TLVL_INFO) << "CH_ENABLE_MASK Reg:0x" << std::hex << CH_ENABLE_MASK << "=0x" << data;
+  TLOG(TLVL_INFO) << "Channel enable mask (CH_ENABLE_MASK=0x" 
+                  << std::hex << static_cast<unsigned int>(CH_ENABLE_MASK) << ") = 0x" << data
+                  << std::dec;
 
   // Set up worker getdata thread.
   share::ThreadFunctor functor = std::bind(&CAENV1730Readout::GetData,this);
@@ -120,7 +126,7 @@ sbndaq::CAENV1730Readout::CAENV1730Readout(fhicl::ParameterSet const& ps) :
   GetData_thread_.swap(GetData_worker);
   TLOG_ARB(TCONFIG,TRACE_NAME) << "GetData worker thread setup." << TLOG_ENDL;
 
-  TLOG(TCONFIG) << "Configuration complete!" << TLOG_ENDL;
+  TLOG(TLVL_INFO) << "Configuration complete!" << TLOG_ENDL;
 
   //epoch time
   fTimeEpoch = boost::posix_time::ptime(boost::gregorian::date(1970,1,1));
@@ -186,6 +192,7 @@ void sbndaq::CAENV1730Readout::Configure()
   // avoids recalibrating mid-run and causing baseline jumps
   if (fCAEN.lockTempCalibration )  
   { 
+    TLOG_ARB(TINFO,TRACE_NAME) << "Locking mid-run temperature calibration adjustements..." << TLOG_ENDL;
     for ( uint32_t ch=0; ch<fNChannels; ch++)
     {
       SetLockTempCalibration(true,ch);
@@ -390,7 +397,7 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
   // Construct mode mask: repeat chosen modeLVDS 4 times
   // FP_LVDS_CONTROL groups multiple LVDS pins into separate 4-bit fields
   data = fCAEN.modeLVDS | (fCAEN.modeLVDS << 4) | (fCAEN.modeLVDS << 8) | (fCAEN.modeLVDS << 12);
-  TLOG(TINFO) << "ModeLVDS: 0x" << std::hex << data << std::dec;
+  TLOG(TCONFIG) << "ModeLVDS: 0x" << std::hex << data << std::dec;
   
   retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_LVDS_CONTROL, data);
   sbndaq::CAENDecoder::checkError(retcod,"WriteLVDSOutputConfig",fCAEN.fragmentId);
@@ -428,7 +435,7 @@ void sbndaq::CAENV1730Readout::ConfigureLVDS()
 
   // finally write back to FP_IO_CONTROL the update value
   // this should be the final configuration for this register
-  TLOG(TINFO) << "FPOutputConfig: 0x" << std::hex << ioMode << std::dec;
+  TLOG(TCONFIG) << "FPOutputConfig: 0x" << std::hex << ioMode << std::dec;
   retcod = CAEN_DGTZ_WriteRegister(fHandle, FP_IO_CONTROL, ioMode);
   sbndaq::CAENDecoder::checkError(retcod,"WriteFPOutputConfig",fCAEN.fragmentId);
   retcod = CAEN_DGTZ_ReadRegister(fHandle, FP_IO_CONTROL, &readBack);
@@ -735,7 +742,7 @@ void sbndaq::CAENV1730Readout::SetLockTempCalibration(bool onOff, uint32_t ch)
 {
   CAEN_DGTZ_ErrorCode retcod;
   uint8_t lock, ctrl;
-  TLOG_ARB(TINFO,TRACE_NAME) << "Locking Temperature Calibration Adjustments, channel " << ch << TLOG_ENDL;
+  TLOG_ARB(TCONFIG,TRACE_NAME) << "Locking Temperature Calibration Adjustments, channel " << ch << TLOG_ENDL;
 
   // Following code comes from CAEN
   // enter engineering functions

--- a/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
+++ b/sbndaq-artdaq/Generators/Common/CAENV1730Readout_generator.cc
@@ -936,14 +936,18 @@ bool sbndaq::CAENV1730Readout::readWindowDataBlocks() {
 
   // (re)-arm interrupt before waiting for one
   // this is required for links through a5818 cards
-  CAEN_DGTZ_ErrorCode retcode = CAEN_DGTZ_RearmInterrupt(fHandle);
-  if(retcode < 0){
-    TLOG(TLVL_WARNING) << "(FragID=" << fCAEN.fragmentId << ")"
-                       << " RearmInterrupt() failed: " << retcode;
-  } 
+  // but causes stability issues for a3818 links...
+  if(fCAEN.aX818 == 5)
+  {
+    CAEN_DGTZ_ErrorCode retcode = CAEN_DGTZ_RearmInterrupt(fHandle);
+    if(retcode < 0){
+      TLOG(TLVL_WARNING) << "(FragID=" << fCAEN.fragmentId << ")"
+                         << " RearmInterrupt() failed: " << retcode;
+    } 
+  }
 
   //wait for one event, then interrupt
-  retcode = CAEN_DGTZ_IRQWait(fHandle, fCAEN.IRQTimeoutMS);
+  CAEN_DGTZ_ErrorCode retcode = CAEN_DGTZ_IRQWait(fHandle, fCAEN.IRQTimeoutMS);
 
   //if we have a timeout condition, return
   if (retcode == CAEN_DGTZ_Timeout) {

--- a/sbndaq-artdaq/Generators/Common/PoolBuffer.hh
+++ b/sbndaq-artdaq/Generators/Common/PoolBuffer.hh
@@ -36,7 +36,11 @@ class PoolBuffer {
 
   void verify_redzone(){
     if (!std::equal(redzone_bytes.begin(), redzone_bytes.end(),end - redzone_bytes.size())){
-      TLOG(TLVL_ERROR) << __func__<<  ": Redzone was overwritten; DataBlock.index="<< index;
+      TLOG(TLVL_ERROR) << __func__<<  ": Redzone was overwritten; DataBlock.index="<< index
+                       << ", size=" << size
+                       << ", data_size=" << data_size
+                       << ", end - begin=" << (end - begin)
+                       << ", redzone size=" << redzone_bytes.size();
       throw std::overflow_error("Redzone was overwritten; DataBlock.index="s + std::to_string(index));
     }
   }

--- a/sbndaq-artdaq/Generators/Common/PoolBuffer.hh
+++ b/sbndaq-artdaq/Generators/Common/PoolBuffer.hh
@@ -339,7 +339,7 @@ inline std::size_t PoolBuffer::allocate(std::size_t block_size, std::size_t pool
 
   for (std::size_t i = 0; i<  _blockCount ;  i++) {
     _allDataBlocks.push_front(
-        std::make_shared<DataBlock>(buf + i * block_size, buf + (i + 1) * block_size, _blockSize, i, 0));
+        std::make_shared<DataBlock>(buf + i * block_size, buf + (i + 1) * block_size, _blockSize, 0, i));
     if (_enableRedzones != 0) {
       std::copy(redzone_bytes.begin(), redzone_bytes.end(),
                 _allDataBlocks.front()->begin + (block_size - redzone_bytes.size()));


### PR DESCRIPTION
### Description

This PR completes the summer review and clean-up of the CAENV1730 boardreader code started with #185 and #186 .
The code should now be more easily accessible and plenty of comments have also been added.
Unused/duplicate variables and functions have been removed or merged. 
Some logic has also been changed to make it more straighforward. 
Logging and trace levels have been sligthly adjusted to reduce verbose and rate-limited output.

#### List of non-breaking changes:

- Switch from using boardID to fragmentID for component identification in both `CAENDecoder` and `CAENException`. 
- Removed sketchy `fOk` check after configure() step -- problems during the configuration steps are caught by either `CAENDecoder` (if return code is bad) or `CheckReadback` (if value read after setting does not match).
- Add printing of all control registers after configuration for a quick and easy-to-compare overview.
- Removed duplicate "StopAcquisition" command in Configure().
- Removed `Read_ADC_CalParams_V1730()` and in `Write_ADC_CalParams_V1730()` functions.  Functionality of the latter is preserved in start() (guarded by `writeCalibration`).
- Reviewed all the ConfigureSomething() functions, added extensive comments. Functions are also no longer scattered in the file, but close together. Enforced `CAENDecoder` + `CheckReadback`checks everywhere. Enforced use of bitmasks when writing into registers directly. Printouts to `TCONFIG`.
- (ICARUS-only) In ConfigureLVDS(), LVDS output signal widths and LVDS pairs logic values are now set through a loop instead of hard-coding each register address. Header file cleaned-up accordingly.
- Removed verbose and rate-limited printing in start();
- In `readWindowDataBlocks()`, added one check on the acquired data + changed the order: 1) check return code, 2) check if data_read_size is zero, 3) check if data_read_size is bigger than buffer block (NEW), 3) verify redzone.
- Simplified logic of the event counter gap check in `readWindowDataBlocks()`.
- In `readWindowDataBlocks()`, apply `RearmInterrupt()` for A5818 links only as tests showed repeated stability issues when applied to links via A3818 cards.
- In `getNext_()`, simplified logic for assigning fragment sequenceID from event counter; better handling of 24-bit overflows. Added extensive comments.
- In `getNext_()`, remove duplicate fetching of fragment timestamp from map (it already tries once + in a loop for 3 times).
- In `PoolBuffer.hh`: fixed bug with data block index at allocation + dump more info in `verify_redzone` error code.

#### List of breaking changes:

- (ICARUS only) Configuration parameter `selfTrgBit` now writes only into `bit[6]` of register `0x8000` instead of overwriting the entire register. As a result, it should now be set to `1` (negative polarity) instead of `80`.
- Changes to the Grafana metrics in `checkHWStatus_()`. Names are simplified to remove boardID (fragmentID is already in the name) + three new metrics:
--`icarus.icaruspmt*.BoardReader.*.CAENV1730.Card*.Channel*.Status` is removed (confusing);
--The following board-level metrics are added: `icarus.icaruspmt*.BoardReader.*.Running`, `icarus.icaruspmt*.BoardReader.*.Busy`, `icarus.icaruspmt*.BoardReader.*.Shutdown`.
--`icarus.icaruspmt*.BoardReader.*.CAENV1730.Card*.Channel*.Temp` becomes `icarus.icaruspmt*.BoardReader.*.Channel*.Temp` (removing boardId);
--`icarus.icaruspmt*.BoardReader.*.CAENV1730.Card*.Channel*.MemoryFull` becomes `icarus.icaruspmt*.BoardReader.*.Channel*.MemoryFull` (removing boardId);

### Testing details
- ICARUS: tested with `Test_Calibration_a5818_pmt04_00006` (ECL#[293342](https://dbweb0.fnal.gov/ECL/sbnfd/E/show?e=293342))
- SBND: _needs testing_
